### PR TITLE
Rename package from anyllm to llm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 
 ```
 any-llm-go/
-├── anyllm.go           # Public API convenience functions
+├── llm.go           # Public API convenience functions
 ├── types.go            # Core type definitions
 ├── provider.go         # Provider interface and helpers
 ├── options.go          # Configuration options
@@ -114,7 +114,7 @@ package newprovider
 import (
     "context"
 
-    anyllm "github.com/mozilla-ai/any-llm-go"
+    github.com/mozilla-ai/any-llm-go"
 )
 
 const (
@@ -124,22 +124,22 @@ const (
 
 type Provider struct {
     client *sdk.Client
-    config *anyllm.Config
+    config *llm.Config
 }
 
 // Ensure interface compliance
 var (
-    _ anyllm.Provider           = (*Provider)(nil)
-    _ anyllm.CapabilityProvider = (*Provider)(nil)
+    _ llm.Provider           = (*Provider)(nil)
+    _ llm.CapabilityProvider = (*Provider)(nil)
 )
 
-func New(opts ...anyllm.Option) (*Provider, error) {
-    cfg := anyllm.DefaultConfig()
+func New(opts ...llm.Option) (*Provider, error) {
+    cfg := llm.DefaultConfig()
     cfg.ApplyOptions(opts...)
 
     apiKey := cfg.GetAPIKeyFromEnv(envAPIKey)
     if apiKey == "" {
-        return nil, anyllm.NewMissingAPIKeyError(providerName, envAPIKey)
+        return nil, llm.NewMissingAPIKeyError(providerName, envAPIKey)
     }
 
     // Initialize the official SDK client
@@ -155,28 +155,28 @@ func (p *Provider) Name() string {
     return providerName
 }
 
-func (p *Provider) Capabilities() anyllm.ProviderCapabilities {
-    return anyllm.ProviderCapabilities{
+func (p *Provider) Capabilities() llm.ProviderCapabilities {
+    return llm.ProviderCapabilities{
         Completion:          true,
         CompletionStreaming: true,
         // ... other capabilities
     }
 }
 
-func (p *Provider) Completion(ctx context.Context, params anyllm.CompletionParams) (*anyllm.ChatCompletion, error) {
+func (p *Provider) Completion(ctx context.Context, params llm.CompletionParams) (*llm.ChatCompletion, error) {
     // Convert params to provider format
     // Make API call
     // Convert response to anyllm format
-    // Handle errors with anyllm.ConvertError()
+    // Handle errors with llm.ConvertError()
 }
 
-func (p *Provider) CompletionStream(ctx context.Context, params anyllm.CompletionParams) (<-chan anyllm.ChatCompletionChunk, <-chan error) {
+func (p *Provider) CompletionStream(ctx context.Context, params llm.CompletionParams) (<-chan llm.ChatCompletionChunk, <-chan error) {
     // Implement streaming
 }
 
 // Register the provider
 func init() {
-    anyllm.Register(providerName, func(opts ...anyllm.Option) (anyllm.Provider, error) {
+    llm.Register(providerName, func(opts ...llm.Option) (llm.Provider, error) {
         return New(opts...)
     })
 }
@@ -193,13 +193,13 @@ import (
     "github.com/stretchr/testify/assert"
     "github.com/stretchr/testify/require"
 
-    anyllm "github.com/mozilla-ai/any-llm-go"
+    github.com/mozilla-ai/any-llm-go"
     "github.com/mozilla-ai/any-llm-go/internal/testutil"
 )
 
 func TestNew(t *testing.T) {
     t.Run("creates provider with API key", func(t *testing.T) {
-        provider, err := New(anyllm.WithAPIKey("test-key"))
+        provider, err := New(llm.WithAPIKey("test-key"))
         require.NoError(t, err)
         assert.NotNil(t, provider)
     })
@@ -237,7 +237,7 @@ func TestIntegrationCompletion(t *testing.T) {
 - [ ] Implements `Provider` interface
 - [ ] Implements `CapabilityProvider` interface
 - [ ] Normalizes responses to OpenAI format
-- [ ] Normalizes errors using `anyllm.ConvertError()`
+- [ ] Normalizes errors using `llm.ConvertError()`
 - [ ] Registers provider in `init()`
 - [ ] Has unit tests with >80% coverage
 - [ ] Has integration tests (skipped when no API key)

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ import (
     "fmt"
     "log"
 
-    anyllm "github.com/mozilla-ai/any-llm-go"
+    github.com/mozilla-ai/any-llm-go"
     _ "github.com/mozilla-ai/any-llm-go/providers/openai" // Register provider
 )
 
 func main() {
     ctx := context.Background()
 
-    response, err := anyllm.Completion(ctx, "openai:gpt-4o-mini", []anyllm.Message{
+    response, err := llm.Completion(ctx, "openai:gpt-4o-mini", []llm.Message{
         {Role: "user", Content: "Hello!"},
     })
     if err != nil {
@@ -73,7 +73,7 @@ Import the providers you need:
 
 ```go
 import (
-    anyllm "github.com/mozilla-ai/any-llm-go"
+    github.com/mozilla-ai/any-llm-go"
     _ "github.com/mozilla-ai/any-llm-go/providers/openai"    // OpenAI
     _ "github.com/mozilla-ai/any-llm-go/providers/anthropic" // Anthropic
 )
@@ -95,7 +95,7 @@ export MISTRAL_API_KEY="your-key-here"
 Alternatively, pass API keys directly in your code using options:
 
 ```go
-provider, err := openai.New(anyllm.WithAPIKey("your-key-here"))
+provider, err := openai.New(llm.WithAPIKey("your-key-here"))
 ```
 
 ## Why choose `any-llm-go`?
@@ -119,13 +119,13 @@ Use the convenience functions with `provider:model` format:
 import (
     "context"
 
-    anyllm "github.com/mozilla-ai/any-llm-go"
+    github.com/mozilla-ai/any-llm-go"
     _ "github.com/mozilla-ai/any-llm-go/providers/openai"
 )
 
 ctx := context.Background()
 
-response, err := anyllm.Completion(ctx, "openai:gpt-4o-mini", []anyllm.Message{
+response, err := llm.Completion(ctx, "openai:gpt-4o-mini", []llm.Message{
     {Role: "user", Content: "Hello!"},
 })
 if err != nil {
@@ -143,21 +143,21 @@ For applications that need to reuse providers or require more control:
 import (
     "context"
 
-    anyllm "github.com/mozilla-ai/any-llm-go"
+    github.com/mozilla-ai/any-llm-go"
     "github.com/mozilla-ai/any-llm-go/providers/openai"
 )
 
 // Create provider once, reuse for multiple requests
-provider, err := openai.New(anyllm.WithAPIKey("your-api-key"))
+provider, err := openai.New(llm.WithAPIKey("your-api-key"))
 if err != nil {
     log.Fatal(err)
 }
 
 ctx := context.Background()
 
-response, err := provider.Completion(ctx, anyllm.CompletionParams{
+response, err := provider.Completion(ctx, llm.CompletionParams{
     Model: "gpt-4o-mini",
-    Messages: []anyllm.Message{
+    Messages: []llm.Message{
         {Role: "user", Content: "Hello!"},
     },
 })
@@ -167,7 +167,7 @@ response, err := provider.Completion(ctx, anyllm.CompletionParams{
 
 | Approach | Best For | Connection Handling |
 |----------|----------|---------------------|
-| **Direct API Functions** (`anyllm.Completion`) | Scripts, quick prototypes, single requests | New client per call |
+| **Direct API Functions** (`llm.Completion`) | Scripts, quick prototypes, single requests | New client per call |
 | **Provider Instance** (`provider.Completion`) | Production apps, multiple requests | Reuses client |
 
 Both approaches support identical features: streaming, tools, reasoning, etc.
@@ -177,9 +177,9 @@ Both approaches support identical features: streaming, tools, reasoning, etc.
 Use channels for streaming responses:
 
 ```go
-chunks, errs := provider.CompletionStream(ctx, anyllm.CompletionParams{
+chunks, errs := provider.CompletionStream(ctx, llm.CompletionParams{
     Model: "gpt-4o-mini",
-    Messages: []anyllm.Message{
+    Messages: []llm.Message{
         {Role: "user", Content: "Write a short poem about Go."},
     },
     Stream: true,
@@ -199,15 +199,15 @@ if err := <-errs; err != nil {
 ### Tools / Function Calling
 
 ```go
-response, err := provider.Completion(ctx, anyllm.CompletionParams{
+response, err := provider.Completion(ctx, llm.CompletionParams{
     Model: "gpt-4o-mini",
-    Messages: []anyllm.Message{
+    Messages: []llm.Message{
         {Role: "user", Content: "What's the weather in Paris?"},
     },
-    Tools: []anyllm.Tool{
+    Tools: []llm.Tool{
         {
             Type: "function",
-            Function: anyllm.Function{
+            Function: llm.Function{
                 Name:        "get_weather",
                 Description: "Get the current weather for a location",
                 Parameters: map[string]any{
@@ -238,12 +238,12 @@ if len(response.Choices[0].Message.ToolCalls) > 0 {
 For models that support extended thinking (like Claude):
 
 ```go
-response, err := provider.Completion(ctx, anyllm.CompletionParams{
+response, err := provider.Completion(ctx, llm.CompletionParams{
     Model: "claude-sonnet-4-20250514",
-    Messages: []anyllm.Message{
+    Messages: []llm.Message{
         {Role: "user", Content: "Solve this step by step: What is 15% of 80?"},
     },
-    ReasoningEffort: anyllm.ReasoningEffortMedium,
+    ReasoningEffort: llm.ReasoningEffortMedium,
 })
 
 if response.Choices[0].Message.Reasoning != nil {
@@ -260,11 +260,11 @@ All provider errors are normalized to common error types:
 response, err := provider.Completion(ctx, params)
 if err != nil {
     switch {
-    case errors.Is(err, anyllm.ErrRateLimit):
+    case errors.Is(err, llm.ErrRateLimit):
         // Handle rate limiting - maybe retry with backoff
-    case errors.Is(err, anyllm.ErrAuthentication):
+    case errors.Is(err, llm.ErrAuthentication):
         // Handle auth errors - check API key
-    case errors.Is(err, anyllm.ErrContextLength):
+    case errors.Is(err, llm.ErrContextLength):
         // Handle context too long - reduce input
     default:
         // Handle other errors
@@ -275,7 +275,7 @@ if err != nil {
 You can also use type assertions for more details:
 
 ```go
-var rateLimitErr *anyllm.RateLimitError
+var rateLimitErr *llm.RateLimitError
 if errors.As(err, &rateLimitErr) {
     fmt.Printf("Rate limited by %s: %s\n", rateLimitErr.Provider, rateLimitErr.Message)
 }
@@ -292,7 +292,7 @@ To find available models:
 - Use the `ListModels` API (if the provider supports it):
 
 ```go
-models, err := anyllm.ListModels(ctx, "openai")
+models, err := llm.ListModels(ctx, "openai")
 for _, model := range models.Data {
     fmt.Println(model.ID)
 }

--- a/anyllm.go
+++ b/anyllm.go
@@ -17,7 +17,7 @@
 //	for chunk := range chunks {
 //	    fmt.Print(chunk.Choices[0].Delta.Content)
 //	}
-package anyllm
+package llm
 
 import (
 	"context"

--- a/docs/api/completion.md
+++ b/docs/api/completion.md
@@ -8,14 +8,14 @@ The completion API is the primary way to interact with LLM providers.
 import (
     "context"
 
-    anyllm "github.com/mozilla-ai/any-llm-go"
+    github.com/mozilla-ai/any-llm-go"
     _ "github.com/mozilla-ai/any-llm-go/providers/openai"
 )
 
 ctx := context.Background()
 
-response, err := anyllm.Completion(ctx, "openai:gpt-4o-mini", []anyllm.Message{
-    {Role: anyllm.RoleUser, Content: "Hello!"},
+response, err := llm.Completion(ctx, "openai:gpt-4o-mini", []llm.Message{
+    {Role: llm.RoleUser, Content: "Hello!"},
 })
 ```
 
@@ -47,9 +47,9 @@ Performs a chat completion request using the specified model.
 **Example:**
 
 ```go
-response, err := anyllm.Completion(ctx, "anthropic:claude-3-5-haiku-latest", []anyllm.Message{
-    {Role: anyllm.RoleSystem, Content: "You are a helpful assistant."},
-    {Role: anyllm.RoleUser, Content: "What is Go?"},
+response, err := llm.Completion(ctx, "anthropic:claude-3-5-haiku-latest", []llm.Message{
+    {Role: llm.RoleSystem, Content: "You are a helpful assistant."},
+    {Role: llm.RoleUser, Content: "What is Go?"},
 })
 if err != nil {
     log.Fatal(err)
@@ -83,9 +83,9 @@ Performs a chat completion with full parameter control.
 temp := 0.7
 maxTokens := 1000
 
-response, err := anyllm.CompletionWithParams(ctx, "openai:gpt-4o", anyllm.CompletionParams{
-    Messages: []anyllm.Message{
-        {Role: anyllm.RoleUser, Content: "Write a poem about coding."},
+response, err := llm.CompletionWithParams(ctx, "openai:gpt-4o", llm.CompletionParams{
+    Messages: []llm.Message{
+        {Role: llm.RoleUser, Content: "Write a poem about coding."},
     },
     Temperature: &temp,
     MaxTokens:   &maxTokens,
@@ -174,11 +174,11 @@ const (
 For messages with images or other content types:
 
 ```go
-message := anyllm.Message{
-    Role: anyllm.RoleUser,
-    Content: []anyllm.ContentPart{
+message := llm.Message{
+    Role: llm.RoleUser,
+    Content: []llm.ContentPart{
         {Type: "text", Text: "What's in this image?"},
-        {Type: "image_url", ImageURL: &anyllm.ImageURL{
+        {Type: "image_url", ImageURL: &llm.ImageURL{
             URL: "https://example.com/image.jpg",
         }},
     },
@@ -228,10 +228,10 @@ const (
 ### Defining Tools
 
 ```go
-tools := []anyllm.Tool{
+tools := []llm.Tool{
     {
         Type: "function",
-        Function: anyllm.Function{
+        Function: llm.Function{
             Name:        "get_weather",
             Description: "Get the current weather for a location",
             Parameters: map[string]any{
@@ -252,28 +252,28 @@ tools := []anyllm.Tool{
 ### Processing Tool Calls
 
 ```go
-response, err := provider.Completion(ctx, anyllm.CompletionParams{
+response, err := provider.Completion(ctx, llm.CompletionParams{
     Model:    "gpt-4o-mini",
     Messages: messages,
     Tools:    tools,
 })
 
-if response.Choices[0].FinishReason == anyllm.FinishReasonToolCalls {
+if response.Choices[0].FinishReason == llm.FinishReasonToolCalls {
     for _, tc := range response.Choices[0].Message.ToolCalls {
         // Process tool call
         result := executeFunction(tc.Function.Name, tc.Function.Arguments)
 
         // Add tool result to messages
         messages = append(messages, response.Choices[0].Message)
-        messages = append(messages, anyllm.Message{
-            Role:       anyllm.RoleTool,
+        messages = append(messages, llm.Message{
+            Role:       llm.RoleTool,
             Content:    result,
             ToolCallID: tc.ID,
         })
     }
 
     // Continue conversation with tool results
-    response, err = provider.Completion(ctx, anyllm.CompletionParams{
+    response, err = provider.Completion(ctx, llm.CompletionParams{
         Model:    "gpt-4o-mini",
         Messages: messages,
         Tools:    tools,
@@ -294,7 +294,7 @@ if err != nil {
 }
 
 // Use provider.Completion() directly
-response, err := provider.Completion(ctx, anyllm.CompletionParams{
+response, err := provider.Completion(ctx, llm.CompletionParams{
     Model:    "gpt-4o-mini",
     Messages: messages,
 })

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -14,23 +14,23 @@ import "errors"
 response, err := provider.Completion(ctx, params)
 if err != nil {
     switch {
-    case errors.Is(err, anyllm.ErrRateLimit):
+    case errors.Is(err, llm.ErrRateLimit):
         // Rate limit exceeded - retry with backoff
-    case errors.Is(err, anyllm.ErrAuthentication):
+    case errors.Is(err, llm.ErrAuthentication):
         // Invalid API key
-    case errors.Is(err, anyllm.ErrInvalidRequest):
+    case errors.Is(err, llm.ErrInvalidRequest):
         // Malformed request
-    case errors.Is(err, anyllm.ErrContextLength):
+    case errors.Is(err, llm.ErrContextLength):
         // Input too long
-    case errors.Is(err, anyllm.ErrContentFilter):
+    case errors.Is(err, llm.ErrContentFilter):
         // Content blocked by safety filters
-    case errors.Is(err, anyllm.ErrModelNotFound):
+    case errors.Is(err, llm.ErrModelNotFound):
         // Model doesn't exist
-    case errors.Is(err, anyllm.ErrProvider):
+    case errors.Is(err, llm.ErrProvider):
         // General provider error
-    case errors.Is(err, anyllm.ErrMissingAPIKey):
+    case errors.Is(err, llm.ErrMissingAPIKey):
         // No API key provided
-    case errors.Is(err, anyllm.ErrUnsupportedProvider):
+    case errors.Is(err, llm.ErrUnsupportedProvider):
         // Provider not registered
     default:
         // Unknown error
@@ -60,7 +60,7 @@ For more details, use `errors.As()` to access structured error types:
 ### RateLimitError
 
 ```go
-var rateLimitErr *anyllm.RateLimitError
+var rateLimitErr *llm.RateLimitError
 if errors.As(err, &rateLimitErr) {
     fmt.Printf("Provider: %s\n", rateLimitErr.Provider)
     fmt.Printf("Message: %s\n", rateLimitErr.Message)
@@ -71,7 +71,7 @@ if errors.As(err, &rateLimitErr) {
 ### AuthenticationError
 
 ```go
-var authErr *anyllm.AuthenticationError
+var authErr *llm.AuthenticationError
 if errors.As(err, &authErr) {
     fmt.Printf("Provider: %s\n", authErr.Provider)
     fmt.Printf("Message: %s\n", authErr.Message)
@@ -81,7 +81,7 @@ if errors.As(err, &authErr) {
 ### ContextLengthError
 
 ```go
-var ctxErr *anyllm.ContextLengthError
+var ctxErr *llm.ContextLengthError
 if errors.As(err, &ctxErr) {
     fmt.Printf("Provider: %s\n", ctxErr.Provider)
     fmt.Printf("Message: %s\n", ctxErr.Message)
@@ -91,7 +91,7 @@ if errors.As(err, &ctxErr) {
 ### ProviderError
 
 ```go
-var providerErr *anyllm.ProviderError
+var providerErr *llm.ProviderError
 if errors.As(err, &providerErr) {
     fmt.Printf("Provider: %s\n", providerErr.Provider)
     fmt.Printf("Status code: %d\n", providerErr.StatusCode)
@@ -102,7 +102,7 @@ if errors.As(err, &providerErr) {
 ### MissingAPIKeyError
 
 ```go
-var keyErr *anyllm.MissingAPIKeyError
+var keyErr *llm.MissingAPIKeyError
 if errors.As(err, &keyErr) {
     fmt.Printf("Provider: %s\n", keyErr.Provider)
     fmt.Printf("Expected env var: %s\n", keyErr.EnvVar)
@@ -127,7 +127,7 @@ type BaseError struct {
 All any-llm errors wrap the original provider error:
 
 ```go
-var baseErr *anyllm.BaseError
+var baseErr *llm.BaseError
 if errors.As(err, &baseErr) {
     // Access the original provider error
     originalErr := baseErr.Err
@@ -140,7 +140,7 @@ if errors.As(err, &baseErr) {
 ### Retry with Backoff
 
 ```go
-func completionWithRetry(ctx context.Context, params anyllm.CompletionParams) (*anyllm.ChatCompletion, error) {
+func completionWithRetry(ctx context.Context, params llm.CompletionParams) (*llm.ChatCompletion, error) {
     maxRetries := 3
     backoff := time.Second
 
@@ -150,9 +150,9 @@ func completionWithRetry(ctx context.Context, params anyllm.CompletionParams) (*
             return response, nil
         }
 
-        if errors.Is(err, anyllm.ErrRateLimit) {
+        if errors.Is(err, llm.ErrRateLimit) {
             // Check for retry-after hint
-            var rateLimitErr *anyllm.RateLimitError
+            var rateLimitErr *llm.RateLimitError
             if errors.As(err, &rateLimitErr) && rateLimitErr.RetryAfter > 0 {
                 backoff = time.Duration(rateLimitErr.RetryAfter) * time.Second
             }
@@ -181,8 +181,8 @@ func getResponse(ctx context.Context, prompt string) (string, error) {
     providers := []string{"openai:gpt-4o", "anthropic:claude-3-5-haiku-latest"}
 
     for _, model := range providers {
-        response, err := anyllm.Completion(ctx, model, []anyllm.Message{
-            {Role: anyllm.RoleUser, Content: prompt},
+        response, err := llm.Completion(ctx, model, []llm.Message{
+            {Role: llm.RoleUser, Content: prompt},
         })
 
         if err == nil {
@@ -193,7 +193,7 @@ func getResponse(ctx context.Context, prompt string) (string, error) {
         log.Printf("Provider %s failed: %v", model, err)
 
         // Don't failover for certain errors
-        if errors.Is(err, anyllm.ErrContentFilter) {
+        if errors.Is(err, llm.ErrContentFilter) {
             return "", err // Content issue, not provider issue
         }
     }
@@ -207,15 +207,15 @@ func getResponse(ctx context.Context, prompt string) (string, error) {
 ```go
 func userFriendlyError(err error) string {
     switch {
-    case errors.Is(err, anyllm.ErrRateLimit):
+    case errors.Is(err, llm.ErrRateLimit):
         return "Too many requests. Please try again in a moment."
-    case errors.Is(err, anyllm.ErrAuthentication):
+    case errors.Is(err, llm.ErrAuthentication):
         return "Authentication failed. Please check your API configuration."
-    case errors.Is(err, anyllm.ErrContextLength):
+    case errors.Is(err, llm.ErrContextLength):
         return "Your message is too long. Please shorten it and try again."
-    case errors.Is(err, anyllm.ErrContentFilter):
+    case errors.Is(err, llm.ErrContentFilter):
         return "Your request was blocked by content filters."
-    case errors.Is(err, anyllm.ErrModelNotFound):
+    case errors.Is(err, llm.ErrModelNotFound):
         return "The requested model is not available."
     default:
         return "An error occurred. Please try again later."

--- a/docs/api/streaming.md
+++ b/docs/api/streaming.md
@@ -5,10 +5,10 @@ Streaming allows you to receive partial responses as they're generated, enabling
 ## Quick Start
 
 ```go
-chunks, errs := provider.CompletionStream(ctx, anyllm.CompletionParams{
+chunks, errs := provider.CompletionStream(ctx, llm.CompletionParams{
     Model: "gpt-4o-mini",
-    Messages: []anyllm.Message{
-        {Role: anyllm.RoleUser, Content: "Write a short story."},
+    Messages: []llm.Message{
+        {Role: llm.RoleUser, Content: "Write a short story."},
     },
     Stream: true,
 })
@@ -153,14 +153,14 @@ fmt.Printf("Finish reason: %s\n", finishReason)
 ### Streaming with Tool Calls
 
 ```go
-chunks, errs := provider.CompletionStream(ctx, anyllm.CompletionParams{
+chunks, errs := provider.CompletionStream(ctx, llm.CompletionParams{
     Model:    "gpt-4o-mini",
     Messages: messages,
     Tools:    tools,
     Stream:   true,
 })
 
-var toolCalls []anyllm.ToolCall
+var toolCalls []llm.ToolCall
 toolCallArgs := make(map[int]strings.Builder)
 
 for chunk := range chunks {
@@ -201,10 +201,10 @@ for i, tc := range toolCalls {
 ### Streaming with Reasoning (Claude)
 
 ```go
-chunks, errs := provider.CompletionStream(ctx, anyllm.CompletionParams{
+chunks, errs := provider.CompletionStream(ctx, llm.CompletionParams{
     Model:           "claude-sonnet-4-20250514",
     Messages:        messages,
-    ReasoningEffort: anyllm.ReasoningEffortMedium,
+    ReasoningEffort: llm.ReasoningEffortMedium,
     Stream:          true,
 })
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -24,7 +24,7 @@ any-llm-go supports multiple LLM providers through a unified interface. Each pro
 
 ```go
 import (
-    anyllm "github.com/mozilla-ai/any-llm-go"
+    github.com/mozilla-ai/any-llm-go"
     "github.com/mozilla-ai/any-llm-go/providers/openai"
 )
 
@@ -32,12 +32,12 @@ import (
 provider, err := openai.New()
 
 // Or with explicit API key
-provider, err := openai.New(anyllm.WithAPIKey("sk-..."))
+provider, err := openai.New(llm.WithAPIKey("sk-..."))
 
 // Or with custom base URL (for Azure, proxies, etc.)
 provider, err := openai.New(
-    anyllm.WithAPIKey("your-key"),
-    anyllm.WithBaseURL("https://your-endpoint.openai.azure.com"),
+    llm.WithAPIKey("your-key"),
+    llm.WithBaseURL("https://your-endpoint.openai.azure.com"),
 )
 ```
 
@@ -58,7 +58,7 @@ provider, err := openai.New(
 
 ```go
 import (
-    anyllm "github.com/mozilla-ai/any-llm-go"
+    github.com/mozilla-ai/any-llm-go"
     "github.com/mozilla-ai/any-llm-go/providers/anthropic"
 )
 
@@ -66,7 +66,7 @@ import (
 provider, err := anthropic.New()
 
 // Or with explicit API key
-provider, err := anthropic.New(anyllm.WithAPIKey("sk-ant-..."))
+provider, err := anthropic.New(llm.WithAPIKey("sk-ant-..."))
 ```
 
 **Environment Variable:** `ANTHROPIC_API_KEY`
@@ -82,10 +82,10 @@ provider, err := anthropic.New(anyllm.WithAPIKey("sk-ant-..."))
 Anthropic's Claude models support extended thinking for complex reasoning tasks:
 
 ```go
-response, err := provider.Completion(ctx, anyllm.CompletionParams{
+response, err := provider.Completion(ctx, llm.CompletionParams{
     Model: "claude-sonnet-4-20250514",
     Messages: messages,
-    ReasoningEffort: anyllm.ReasoningEffortMedium, // low, medium, or high
+    ReasoningEffort: llm.ReasoningEffortMedium, // low, medium, or high
 })
 
 // Access the thinking content

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -40,15 +40,15 @@ import (
     "fmt"
     "log"
 
-    anyllm "github.com/mozilla-ai/any-llm-go"
+    github.com/mozilla-ai/any-llm-go"
     _ "github.com/mozilla-ai/any-llm-go/providers/openai" // Register the provider
 )
 
 func main() {
     ctx := context.Background()
 
-    response, err := anyllm.Completion(ctx, "openai:gpt-4o-mini", []anyllm.Message{
-        {Role: anyllm.RoleUser, Content: "Say hello in three languages!"},
+    response, err := llm.Completion(ctx, "openai:gpt-4o-mini", []llm.Message{
+        {Role: llm.RoleUser, Content: "Say hello in three languages!"},
     })
     if err != nil {
         log.Fatal(err)
@@ -72,7 +72,7 @@ import (
     "fmt"
     "log"
 
-    anyllm "github.com/mozilla-ai/any-llm-go"
+    github.com/mozilla-ai/any-llm-go"
     "github.com/mozilla-ai/any-llm-go/providers/anthropic"
 )
 
@@ -86,10 +86,10 @@ func main() {
     ctx := context.Background()
 
     // Make requests
-    response, err := provider.Completion(ctx, anyllm.CompletionParams{
+    response, err := provider.Completion(ctx, llm.CompletionParams{
         Model: "claude-3-5-haiku-latest",
-        Messages: []anyllm.Message{
-            {Role: anyllm.RoleUser, Content: "What's the capital of France?"},
+        Messages: []llm.Message{
+            {Role: llm.RoleUser, Content: "What's the capital of France?"},
         },
     })
     if err != nil {
@@ -105,14 +105,14 @@ func main() {
 If you prefer not to use environment variables:
 
 ```go
-provider, err := openai.New(anyllm.WithAPIKey("sk-your-api-key"))
+provider, err := openai.New(llm.WithAPIKey("sk-your-api-key"))
 ```
 
 Or with the convenience function:
 
 ```go
-response, err := anyllm.Completion(ctx, "openai:gpt-4o-mini", messages,
-    anyllm.WithAPIKey("sk-your-api-key"),
+response, err := llm.Completion(ctx, "openai:gpt-4o-mini", messages,
+    llm.WithAPIKey("sk-your-api-key"),
 )
 ```
 
@@ -128,7 +128,7 @@ import (
     "fmt"
     "log"
 
-    anyllm "github.com/mozilla-ai/any-llm-go"
+    github.com/mozilla-ai/any-llm-go"
     "github.com/mozilla-ai/any-llm-go/providers/openai"
 )
 
@@ -140,10 +140,10 @@ func main() {
 
     ctx := context.Background()
 
-    chunks, errs := provider.CompletionStream(ctx, anyllm.CompletionParams{
+    chunks, errs := provider.CompletionStream(ctx, llm.CompletionParams{
         Model: "gpt-4o-mini",
-        Messages: []anyllm.Message{
-            {Role: anyllm.RoleUser, Content: "Write a haiku about programming."},
+        Messages: []llm.Message{
+            {Role: llm.RoleUser, Content: "Write a haiku about programming."},
         },
         Stream: true,
     })
@@ -168,11 +168,11 @@ func main() {
 Guide the model's behavior with system messages:
 
 ```go
-response, err := provider.Completion(ctx, anyllm.CompletionParams{
+response, err := provider.Completion(ctx, llm.CompletionParams{
     Model: "gpt-4o-mini",
-    Messages: []anyllm.Message{
-        {Role: anyllm.RoleSystem, Content: "You are a helpful assistant that speaks like a pirate."},
-        {Role: anyllm.RoleUser, Content: "How do I make coffee?"},
+    Messages: []llm.Message{
+        {Role: llm.RoleSystem, Content: "You are a helpful assistant that speaks like a pirate."},
+        {Role: llm.RoleUser, Content: "How do I make coffee?"},
     },
 })
 ```
@@ -185,10 +185,10 @@ Control the model's output:
 temp := 0.7
 maxTokens := 500
 
-response, err := provider.Completion(ctx, anyllm.CompletionParams{
+response, err := provider.Completion(ctx, llm.CompletionParams{
     Model: "gpt-4o-mini",
-    Messages: []anyllm.Message{
-        {Role: anyllm.RoleUser, Content: "Write a creative story."},
+    Messages: []llm.Message{
+        {Role: llm.RoleUser, Content: "Write a creative story."},
     },
     Temperature: &temp,
     MaxTokens:   &maxTokens,
@@ -206,15 +206,15 @@ import "errors"
 response, err := provider.Completion(ctx, params)
 if err != nil {
     // Check for specific error types
-    if errors.Is(err, anyllm.ErrRateLimit) {
+    if errors.Is(err, llm.ErrRateLimit) {
         fmt.Println("Rate limited - please retry later")
         return
     }
-    if errors.Is(err, anyllm.ErrAuthentication) {
+    if errors.Is(err, llm.ErrAuthentication) {
         fmt.Println("Invalid API key")
         return
     }
-    if errors.Is(err, anyllm.ErrContextLength) {
+    if errors.Is(err, llm.ErrContextLength) {
         fmt.Println("Input too long - please reduce message size")
         return
     }
@@ -241,7 +241,7 @@ models := []string{
 }
 
 for _, model := range models {
-    response, err := anyllm.Completion(ctx, model, messages)
+    response, err := llm.Completion(ctx, model, messages)
     if err != nil {
         log.Printf("Error with %s: %v", model, err)
         continue

--- a/errors.go
+++ b/errors.go
@@ -1,4 +1,4 @@
-package anyllm
+package llm
 
 import (
 	"errors"

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -13,16 +13,16 @@ import (
 	"fmt"
 	"log"
 
-	anyllm "github.com/mozilla-ai/any-llm-go"
-	_ "github.com/mozilla-ai/any-llm-go/providers/openai" // Register provider
+	llm "github.com/mozilla-ai/any-llm-go"
+	_ "github.com/mozilla-ai/any-llm-go/providers/openai" // Register provider.
 )
 
 func main() {
 	ctx := context.Background()
 
 	// Simple completion using the convenience function
-	response, err := anyllm.Completion(ctx, "openai:gpt-4o-mini", []anyllm.Message{
-		{Role: anyllm.RoleUser, Content: "What is the capital of France? Reply in one word."},
+	response, err := llm.Completion(ctx, "openai:gpt-4o-mini", []llm.Message{
+		{Role: llm.RoleUser, Content: "What is the capital of France? Reply in one word."},
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/examples/multi-provider/main.go
+++ b/examples/multi-provider/main.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"log"
 
-	anyllm "github.com/mozilla-ai/any-llm-go"
+	llm "github.com/mozilla-ai/any-llm-go"
 	_ "github.com/mozilla-ai/any-llm-go/providers/anthropic" // Register Anthropic
 	_ "github.com/mozilla-ai/any-llm-go/providers/openai"    // Register OpenAI
 )
@@ -37,12 +37,12 @@ func main() {
 	for _, model := range models {
 		fmt.Printf("Model: %s\n", model)
 
-		response, err := anyllm.Completion(ctx, model, []anyllm.Message{
-			{Role: anyllm.RoleUser, Content: prompt},
+		response, err := llm.Completion(ctx, model, []llm.Message{
+			{Role: llm.RoleUser, Content: prompt},
 		})
 		if err != nil {
 			// Handle provider-specific errors gracefully
-			if errors.Is(err, anyllm.ErrMissingAPIKey) {
+			if errors.Is(err, llm.ErrMissingAPIKey) {
 				fmt.Printf("  Skipped: API key not configured\n\n")
 				continue
 			}

--- a/examples/streaming/main.go
+++ b/examples/streaming/main.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"log"
 
-	anyllm "github.com/mozilla-ai/any-llm-go"
+	llm "github.com/mozilla-ai/any-llm-go"
 	"github.com/mozilla-ai/any-llm-go/providers/openai"
 )
 
@@ -27,10 +27,10 @@ func main() {
 	ctx := context.Background()
 
 	// Request a streaming completion
-	chunks, errs := provider.CompletionStream(ctx, anyllm.CompletionParams{
+	chunks, errs := provider.CompletionStream(ctx, llm.CompletionParams{
 		Model: "gpt-4o-mini",
-		Messages: []anyllm.Message{
-			{Role: anyllm.RoleUser, Content: "Write a short poem about programming in Go."},
+		Messages: []llm.Message{
+			{Role: llm.RoleUser, Content: "Write a short poem about programming in Go."},
 		},
 		Stream: true,
 	})

--- a/examples/tools/main.go
+++ b/examples/tools/main.go
@@ -14,15 +14,15 @@ import (
 	"fmt"
 	"log"
 
-	anyllm "github.com/mozilla-ai/any-llm-go"
+	llm "github.com/mozilla-ai/any-llm-go"
 	"github.com/mozilla-ai/any-llm-go/providers/openai"
 )
 
 // Define tools that the model can call
-var tools = []anyllm.Tool{
+var tools = []llm.Tool{
 	{
 		Type: "function",
-		Function: anyllm.Function{
+		Function: llm.Function{
 			Name:        "get_weather",
 			Description: "Get the current weather for a location",
 			Parameters: map[string]any{
@@ -62,15 +62,15 @@ func main() {
 	ctx := context.Background()
 
 	// Initial message asking about weather
-	messages := []anyllm.Message{
-		{Role: anyllm.RoleUser, Content: "What's the weather like in Paris?"},
+	messages := []llm.Message{
+		{Role: llm.RoleUser, Content: "What's the weather like in Paris?"},
 	}
 
 	fmt.Println("User: What's the weather like in Paris?")
 	fmt.Println()
 
 	// First request - model may call the tool
-	response, err := provider.Completion(ctx, anyllm.CompletionParams{
+	response, err := provider.Completion(ctx, llm.CompletionParams{
 		Model:      "gpt-4o-mini",
 		Messages:   messages,
 		Tools:      tools,
@@ -81,7 +81,7 @@ func main() {
 	}
 
 	// Check if the model wants to call a tool
-	if response.Choices[0].FinishReason == anyllm.FinishReasonToolCalls {
+	if response.Choices[0].FinishReason == llm.FinishReasonToolCalls {
 		fmt.Println("Model is calling tools...")
 
 		// Add the assistant's message (with tool calls) to the conversation
@@ -107,15 +107,15 @@ func main() {
 			fmt.Println()
 
 			// Add the tool result to the conversation
-			messages = append(messages, anyllm.Message{
-				Role:       anyllm.RoleTool,
+			messages = append(messages, llm.Message{
+				Role:       llm.RoleTool,
 				Content:    result,
 				ToolCallID: tc.ID,
 			})
 		}
 
 		// Continue the conversation with the tool results
-		response, err = provider.Completion(ctx, anyllm.CompletionParams{
+		response, err = provider.Completion(ctx, llm.CompletionParams{
 			Model:    "gpt-4o-mini",
 			Messages: messages,
 			Tools:    tools,

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	anyllm "github.com/mozilla-ai/any-llm-go"
+	llm "github.com/mozilla-ai/any-llm-go"
 )
 
 // ProviderModelMap maps providers to small, cheap test models.
@@ -50,8 +50,8 @@ var EmbeddingProviderModelMap = map[string]string{
 }
 
 // ProviderClientConfig holds provider-specific configuration for tests.
-var ProviderClientConfig = map[string][]anyllm.Option{
-	"anthropic": {anyllm.WithTimeout(60 * time.Second)},
+var ProviderClientConfig = map[string][]llm.Option{
+	"anthropic": {llm.WithTimeout(60 * time.Second)},
 }
 
 // LocalProviders are providers that run locally and don't need API keys.
@@ -64,48 +64,48 @@ var LocalProviders = map[string]bool{
 }
 
 // SimpleMessages returns a simple test message.
-func SimpleMessages() []anyllm.Message {
-	return []anyllm.Message{
-		{Role: anyllm.RoleUser, Content: "Say 'Hello World' exactly, nothing else."},
+func SimpleMessages() []llm.Message {
+	return []llm.Message{
+		{Role: llm.RoleUser, Content: "Say 'Hello World' exactly, nothing else."},
 	}
 }
 
 // MessagesWithSystem returns messages with a system prompt.
-func MessagesWithSystem() []anyllm.Message {
-	return []anyllm.Message{
-		{Role: anyllm.RoleSystem, Content: "You are a helpful assistant that follows instructions exactly."},
-		{Role: anyllm.RoleUser, Content: "Say 'Hello World' exactly, nothing else."},
+func MessagesWithSystem() []llm.Message {
+	return []llm.Message{
+		{Role: llm.RoleSystem, Content: "You are a helpful assistant that follows instructions exactly."},
+		{Role: llm.RoleUser, Content: "Say 'Hello World' exactly, nothing else."},
 	}
 }
 
 // ConversationMessages returns a multi-turn conversation.
-func ConversationMessages() []anyllm.Message {
-	return []anyllm.Message{
-		{Role: anyllm.RoleUser, Content: "My name is Alice."},
-		{Role: anyllm.RoleAssistant, Content: "Hello Alice! Nice to meet you."},
-		{Role: anyllm.RoleUser, Content: "What is my name?"},
+func ConversationMessages() []llm.Message {
+	return []llm.Message{
+		{Role: llm.RoleUser, Content: "My name is Alice."},
+		{Role: llm.RoleAssistant, Content: "Hello Alice! Nice to meet you."},
+		{Role: llm.RoleUser, Content: "What is my name?"},
 	}
 }
 
 // ToolCallMessages returns messages for testing tool calls.
-func ToolCallMessages() []anyllm.Message {
-	return []anyllm.Message{
-		{Role: anyllm.RoleUser, Content: "What is the weather in Paris?"},
+func ToolCallMessages() []llm.Message {
+	return []llm.Message{
+		{Role: llm.RoleUser, Content: "What is the weather in Paris?"},
 	}
 }
 
 // AgentLoopMessages returns messages for testing agent loops.
-func AgentLoopMessages() []anyllm.Message {
-	return []anyllm.Message{
-		{Role: anyllm.RoleUser, Content: "What is the weather like in Salvaterra?"},
+func AgentLoopMessages() []llm.Message {
+	return []llm.Message{
+		{Role: llm.RoleUser, Content: "What is the weather like in Salvaterra?"},
 		{
-			Role:    anyllm.RoleAssistant,
+			Role:    llm.RoleAssistant,
 			Content: "",
-			ToolCalls: []anyllm.ToolCall{
+			ToolCalls: []llm.ToolCall{
 				{
 					ID:   "call_123",
 					Type: "function",
-					Function: anyllm.FunctionCall{
+					Function: llm.FunctionCall{
 						Name:      "get_weather",
 						Arguments: `{"location": "Salvaterra"}`,
 					},
@@ -113,7 +113,7 @@ func AgentLoopMessages() []anyllm.Message {
 			},
 		},
 		{
-			Role:       anyllm.RoleTool,
+			Role:       llm.RoleTool,
 			Content:    "sunny, 22°C",
 			ToolCallID: "call_123",
 		},
@@ -121,10 +121,10 @@ func AgentLoopMessages() []anyllm.Message {
 }
 
 // WeatherTool returns a weather tool definition for testing.
-func WeatherTool() anyllm.Tool {
-	return anyllm.Tool{
+func WeatherTool() llm.Tool {
+	return llm.Tool{
 		Type: "function",
-		Function: anyllm.Function{
+		Function: llm.Function{
 			Name:        "get_weather",
 			Description: "Get the current weather for a location.",
 			Parameters: map[string]any{
@@ -142,10 +142,10 @@ func WeatherTool() anyllm.Tool {
 }
 
 // DateTool returns a date tool definition for testing.
-func DateTool() anyllm.Tool {
-	return anyllm.Tool{
+func DateTool() llm.Tool {
+	return llm.Tool{
 		Type: "function",
-		Function: anyllm.Function{
+		Function: llm.Function{
 			Name:        "get_current_date",
 			Description: "Get the current date and time.",
 			Parameters: map[string]any{
@@ -162,7 +162,7 @@ func HasAPIKey(provider string) bool {
 		return true
 	}
 
-	envKey := anyllm.ProviderEnvKeyName(anyllm.LLMProvider(provider))
+	envKey := llm.ProviderEnvKeyName(llm.LLMProvider(provider))
 	if envKey == "" {
 		return false
 	}
@@ -200,7 +200,7 @@ func GetEmbeddingModel(provider string) string {
 }
 
 // GetClientOptions returns the client options for a provider.
-func GetClientOptions(provider string) []anyllm.Option {
+func GetClientOptions(provider string) []llm.Option {
 	if opts, ok := ProviderClientConfig[provider]; ok {
 		return opts
 	}

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -3,123 +3,123 @@ package testutil
 import (
 	"context"
 
-	anyllm "github.com/mozilla-ai/any-llm-go"
+	llm "github.com/mozilla-ai/any-llm-go"
 )
 
 // MockProvider is a mock implementation of the Provider interface for testing.
 type MockProvider struct {
 	NameFunc             func() string
-	CompletionFunc       func(ctx context.Context, params anyllm.CompletionParams) (*anyllm.ChatCompletion, error)
-	CompletionStreamFunc func(ctx context.Context, params anyllm.CompletionParams) (<-chan anyllm.ChatCompletionChunk, <-chan error)
-	EmbeddingFunc        func(ctx context.Context, params anyllm.EmbeddingParams) (*anyllm.EmbeddingResponse, error)
-	ListModelsFunc       func(ctx context.Context) (*anyllm.ModelsResponse, error)
-	CapabilitiesFunc     func() anyllm.ProviderCapabilities
+	CompletionFunc       func(ctx context.Context, params llm.CompletionParams) (*llm.ChatCompletion, error)
+	CompletionStreamFunc func(ctx context.Context, params llm.CompletionParams) (<-chan llm.ChatCompletionChunk, <-chan error)
+	EmbeddingFunc        func(ctx context.Context, params llm.EmbeddingParams) (*llm.EmbeddingResponse, error)
+	ListModelsFunc       func(ctx context.Context) (*llm.ModelsResponse, error)
+	CapabilitiesFunc     func() llm.ProviderCapabilities
 
 	// Track calls for assertions
-	CompletionCalls       []anyllm.CompletionParams
-	CompletionStreamCalls []anyllm.CompletionParams
-	EmbeddingCalls        []anyllm.EmbeddingParams
+	CompletionCalls       []llm.CompletionParams
+	CompletionStreamCalls []llm.CompletionParams
+	EmbeddingCalls        []llm.EmbeddingParams
 	ListModelsCalls       int
 }
 
 // Ensure MockProvider implements all interfaces.
 var (
-	_ anyllm.Provider           = (*MockProvider)(nil)
-	_ anyllm.EmbeddingProvider  = (*MockProvider)(nil)
-	_ anyllm.ModelLister        = (*MockProvider)(nil)
-	_ anyllm.CapabilityProvider = (*MockProvider)(nil)
+	_ llm.Provider           = (*MockProvider)(nil)
+	_ llm.EmbeddingProvider  = (*MockProvider)(nil)
+	_ llm.ModelLister        = (*MockProvider)(nil)
+	_ llm.CapabilityProvider = (*MockProvider)(nil)
 )
 
 // NewMockProvider creates a new MockProvider with default implementations.
 func NewMockProvider() *MockProvider {
 	return &MockProvider{
 		NameFunc: func() string { return "mock" },
-		CompletionFunc: func(ctx context.Context, params anyllm.CompletionParams) (*anyllm.ChatCompletion, error) {
-			return &anyllm.ChatCompletion{
+		CompletionFunc: func(ctx context.Context, params llm.CompletionParams) (*llm.ChatCompletion, error) {
+			return &llm.ChatCompletion{
 				ID:     "mock-completion-id",
 				Object: "chat.completion",
 				Model:  params.Model,
-				Choices: []anyllm.Choice{
+				Choices: []llm.Choice{
 					{
 						Index: 0,
-						Message: anyllm.Message{
-							Role:    anyllm.RoleAssistant,
+						Message: llm.Message{
+							Role:    llm.RoleAssistant,
 							Content: "Hello World",
 						},
-						FinishReason: anyllm.FinishReasonStop,
+						FinishReason: llm.FinishReasonStop,
 					},
 				},
-				Usage: &anyllm.Usage{
+				Usage: &llm.Usage{
 					PromptTokens:     10,
 					CompletionTokens: 5,
 					TotalTokens:      15,
 				},
 			}, nil
 		},
-		CompletionStreamFunc: func(ctx context.Context, params anyllm.CompletionParams) (<-chan anyllm.ChatCompletionChunk, <-chan error) {
-			chunks := make(chan anyllm.ChatCompletionChunk, 3)
+		CompletionStreamFunc: func(ctx context.Context, params llm.CompletionParams) (<-chan llm.ChatCompletionChunk, <-chan error) {
+			chunks := make(chan llm.ChatCompletionChunk, 3)
 			errs := make(chan error, 1)
 
 			go func() {
 				defer close(chunks)
 				defer close(errs)
 
-				chunks <- anyllm.ChatCompletionChunk{
+				chunks <- llm.ChatCompletionChunk{
 					ID:     "mock-chunk-id",
 					Object: "chat.completion.chunk",
 					Model:  params.Model,
-					Choices: []anyllm.ChunkChoice{
-						{Index: 0, Delta: anyllm.ChunkDelta{Role: anyllm.RoleAssistant}},
+					Choices: []llm.ChunkChoice{
+						{Index: 0, Delta: llm.ChunkDelta{Role: llm.RoleAssistant}},
 					},
 				}
-				chunks <- anyllm.ChatCompletionChunk{
+				chunks <- llm.ChatCompletionChunk{
 					ID:     "mock-chunk-id",
 					Object: "chat.completion.chunk",
 					Model:  params.Model,
-					Choices: []anyllm.ChunkChoice{
-						{Index: 0, Delta: anyllm.ChunkDelta{Content: "Hello World"}},
+					Choices: []llm.ChunkChoice{
+						{Index: 0, Delta: llm.ChunkDelta{Content: "Hello World"}},
 					},
 				}
-				chunks <- anyllm.ChatCompletionChunk{
+				chunks <- llm.ChatCompletionChunk{
 					ID:     "mock-chunk-id",
 					Object: "chat.completion.chunk",
 					Model:  params.Model,
-					Choices: []anyllm.ChunkChoice{
-						{Index: 0, FinishReason: anyllm.FinishReasonStop},
+					Choices: []llm.ChunkChoice{
+						{Index: 0, FinishReason: llm.FinishReasonStop},
 					},
 				}
 			}()
 
 			return chunks, errs
 		},
-		EmbeddingFunc: func(ctx context.Context, params anyllm.EmbeddingParams) (*anyllm.EmbeddingResponse, error) {
-			return &anyllm.EmbeddingResponse{
+		EmbeddingFunc: func(ctx context.Context, params llm.EmbeddingParams) (*llm.EmbeddingResponse, error) {
+			return &llm.EmbeddingResponse{
 				Object: "list",
 				Model:  params.Model,
-				Data: []anyllm.EmbeddingData{
+				Data: []llm.EmbeddingData{
 					{
 						Object:    "embedding",
 						Embedding: []float64{0.1, 0.2, 0.3},
 						Index:     0,
 					},
 				},
-				Usage: &anyllm.EmbeddingUsage{
+				Usage: &llm.EmbeddingUsage{
 					PromptTokens: 5,
 					TotalTokens:  5,
 				},
 			}, nil
 		},
-		ListModelsFunc: func(ctx context.Context) (*anyllm.ModelsResponse, error) {
-			return &anyllm.ModelsResponse{
+		ListModelsFunc: func(ctx context.Context) (*llm.ModelsResponse, error) {
+			return &llm.ModelsResponse{
 				Object: "list",
-				Data: []anyllm.Model{
+				Data: []llm.Model{
 					{ID: "model-1", Object: "model", OwnedBy: "mock"},
 					{ID: "model-2", Object: "model", OwnedBy: "mock"},
 				},
 			}, nil
 		},
-		CapabilitiesFunc: func() anyllm.ProviderCapabilities {
-			return anyllm.ProviderCapabilities{
+		CapabilitiesFunc: func() llm.ProviderCapabilities {
+			return llm.ProviderCapabilities{
 				Completion:          true,
 				CompletionStreaming: true,
 				Embedding:           true,
@@ -133,47 +133,47 @@ func (m *MockProvider) Name() string {
 	return m.NameFunc()
 }
 
-func (m *MockProvider) Completion(ctx context.Context, params anyllm.CompletionParams) (*anyllm.ChatCompletion, error) {
+func (m *MockProvider) Completion(ctx context.Context, params llm.CompletionParams) (*llm.ChatCompletion, error) {
 	m.CompletionCalls = append(m.CompletionCalls, params)
 	return m.CompletionFunc(ctx, params)
 }
 
-func (m *MockProvider) CompletionStream(ctx context.Context, params anyllm.CompletionParams) (<-chan anyllm.ChatCompletionChunk, <-chan error) {
+func (m *MockProvider) CompletionStream(ctx context.Context, params llm.CompletionParams) (<-chan llm.ChatCompletionChunk, <-chan error) {
 	m.CompletionStreamCalls = append(m.CompletionStreamCalls, params)
 	return m.CompletionStreamFunc(ctx, params)
 }
 
-func (m *MockProvider) Embedding(ctx context.Context, params anyllm.EmbeddingParams) (*anyllm.EmbeddingResponse, error) {
+func (m *MockProvider) Embedding(ctx context.Context, params llm.EmbeddingParams) (*llm.EmbeddingResponse, error) {
 	m.EmbeddingCalls = append(m.EmbeddingCalls, params)
 	return m.EmbeddingFunc(ctx, params)
 }
 
-func (m *MockProvider) ListModels(ctx context.Context) (*anyllm.ModelsResponse, error) {
+func (m *MockProvider) ListModels(ctx context.Context) (*llm.ModelsResponse, error) {
 	m.ListModelsCalls++
 	return m.ListModelsFunc(ctx)
 }
 
-func (m *MockProvider) Capabilities() anyllm.ProviderCapabilities {
+func (m *MockProvider) Capabilities() llm.ProviderCapabilities {
 	return m.CapabilitiesFunc()
 }
 
 // MockChatCompletion creates a mock ChatCompletion response.
-func MockChatCompletion(content string) *anyllm.ChatCompletion {
-	return &anyllm.ChatCompletion{
+func MockChatCompletion(content string) *llm.ChatCompletion {
+	return &llm.ChatCompletion{
 		ID:     "mock-id",
 		Object: "chat.completion",
 		Model:  "mock-model",
-		Choices: []anyllm.Choice{
+		Choices: []llm.Choice{
 			{
 				Index: 0,
-				Message: anyllm.Message{
-					Role:    anyllm.RoleAssistant,
+				Message: llm.Message{
+					Role:    llm.RoleAssistant,
 					Content: content,
 				},
-				FinishReason: anyllm.FinishReasonStop,
+				FinishReason: llm.FinishReasonStop,
 			},
 		},
-		Usage: &anyllm.Usage{
+		Usage: &llm.Usage{
 			PromptTokens:     10,
 			CompletionTokens: 5,
 			TotalTokens:      15,
@@ -182,23 +182,23 @@ func MockChatCompletion(content string) *anyllm.ChatCompletion {
 }
 
 // MockChatCompletionWithToolCalls creates a mock ChatCompletion with tool calls.
-func MockChatCompletionWithToolCalls(toolCalls []anyllm.ToolCall) *anyllm.ChatCompletion {
-	return &anyllm.ChatCompletion{
+func MockChatCompletionWithToolCalls(toolCalls []llm.ToolCall) *llm.ChatCompletion {
+	return &llm.ChatCompletion{
 		ID:     "mock-id",
 		Object: "chat.completion",
 		Model:  "mock-model",
-		Choices: []anyllm.Choice{
+		Choices: []llm.Choice{
 			{
 				Index: 0,
-				Message: anyllm.Message{
-					Role:      anyllm.RoleAssistant,
+				Message: llm.Message{
+					Role:      llm.RoleAssistant,
 					Content:   "",
 					ToolCalls: toolCalls,
 				},
-				FinishReason: anyllm.FinishReasonToolCalls,
+				FinishReason: llm.FinishReasonToolCalls,
 			},
 		},
-		Usage: &anyllm.Usage{
+		Usage: &llm.Usage{
 			PromptTokens:     10,
 			CompletionTokens: 20,
 			TotalTokens:      30,
@@ -207,25 +207,25 @@ func MockChatCompletionWithToolCalls(toolCalls []anyllm.ToolCall) *anyllm.ChatCo
 }
 
 // MockChatCompletionWithReasoning creates a mock ChatCompletion with reasoning.
-func MockChatCompletionWithReasoning(content, reasoning string) *anyllm.ChatCompletion {
-	return &anyllm.ChatCompletion{
+func MockChatCompletionWithReasoning(content, reasoning string) *llm.ChatCompletion {
+	return &llm.ChatCompletion{
 		ID:     "mock-id",
 		Object: "chat.completion",
 		Model:  "mock-model",
-		Choices: []anyllm.Choice{
+		Choices: []llm.Choice{
 			{
 				Index: 0,
-				Message: anyllm.Message{
-					Role:    anyllm.RoleAssistant,
+				Message: llm.Message{
+					Role:    llm.RoleAssistant,
 					Content: content,
-					Reasoning: &anyllm.Reasoning{
+					Reasoning: &llm.Reasoning{
 						Content: reasoning,
 					},
 				},
-				FinishReason: anyllm.FinishReasonStop,
+				FinishReason: llm.FinishReasonStop,
 			},
 		},
-		Usage: &anyllm.Usage{
+		Usage: &llm.Usage{
 			PromptTokens:     10,
 			CompletionTokens: 50,
 			TotalTokens:      60,

--- a/options.go
+++ b/options.go
@@ -1,4 +1,4 @@
-package anyllm
+package llm
 
 import (
 	"net/http"

--- a/provider.go
+++ b/provider.go
@@ -1,4 +1,4 @@
-package anyllm
+package llm
 
 import (
 	"context"

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	anyllm "github.com/mozilla-ai/any-llm-go"
+	llm "github.com/mozilla-ai/any-llm-go"
 	"github.com/mozilla-ai/any-llm-go/internal/testutil"
 )
 
 func TestNew(t *testing.T) {
 	t.Run("creates provider with API key", func(t *testing.T) {
-		provider, err := New(anyllm.WithAPIKey("test-api-key"))
+		provider, err := New(llm.WithAPIKey("test-api-key"))
 		require.NoError(t, err)
 		assert.NotNil(t, provider)
 		assert.Equal(t, "openai", provider.Name())
@@ -35,7 +35,7 @@ func TestNew(t *testing.T) {
 		assert.Nil(t, provider)
 		assert.Error(t, err)
 
-		var missingKeyErr *anyllm.MissingAPIKeyError
+		var missingKeyErr *llm.MissingAPIKeyError
 		assert.ErrorAs(t, err, &missingKeyErr)
 		assert.Equal(t, "openai", missingKeyErr.Provider)
 		assert.Equal(t, "OPENAI_API_KEY", missingKeyErr.EnvVar)
@@ -43,7 +43,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestCapabilities(t *testing.T) {
-	provider, err := New(anyllm.WithAPIKey("test-key"))
+	provider, err := New(llm.WithAPIKey("test-key"))
 	require.NoError(t, err)
 
 	caps := provider.Capabilities()
@@ -58,10 +58,10 @@ func TestCapabilities(t *testing.T) {
 
 func TestConvertParams(t *testing.T) {
 	t.Run("converts basic params", func(t *testing.T) {
-		params := anyllm.CompletionParams{
+		params := llm.CompletionParams{
 			Model: "gpt-4",
-			Messages: []anyllm.Message{
-				{Role: anyllm.RoleUser, Content: "Hello"},
+			Messages: []llm.Message{
+				{Role: llm.RoleUser, Content: "Hello"},
 			},
 		}
 
@@ -74,7 +74,7 @@ func TestConvertParams(t *testing.T) {
 	t.Run("converts temperature and top_p", func(t *testing.T) {
 		temp := 0.7
 		topP := 0.9
-		params := anyllm.CompletionParams{
+		params := llm.CompletionParams{
 			Model:       "gpt-4",
 			Messages:    testutil.SimpleMessages(),
 			Temperature: &temp,
@@ -89,7 +89,7 @@ func TestConvertParams(t *testing.T) {
 
 	t.Run("converts max_tokens", func(t *testing.T) {
 		maxTokens := 100
-		params := anyllm.CompletionParams{
+		params := llm.CompletionParams{
 			Model:     "gpt-4",
 			Messages:  testutil.SimpleMessages(),
 			MaxTokens: &maxTokens,
@@ -101,7 +101,7 @@ func TestConvertParams(t *testing.T) {
 	})
 
 	t.Run("converts stop sequences", func(t *testing.T) {
-		params := anyllm.CompletionParams{
+		params := llm.CompletionParams{
 			Model:    "gpt-4",
 			Messages: testutil.SimpleMessages(),
 			Stop:     []string{"END", "STOP"},
@@ -113,10 +113,10 @@ func TestConvertParams(t *testing.T) {
 	})
 
 	t.Run("converts tools", func(t *testing.T) {
-		params := anyllm.CompletionParams{
+		params := llm.CompletionParams{
 			Model:    "gpt-4",
 			Messages: testutil.SimpleMessages(),
-			Tools:    []anyllm.Tool{testutil.WeatherTool()},
+			Tools:    []llm.Tool{testutil.WeatherTool()},
 		}
 
 		req := convertParams(params)
@@ -125,10 +125,10 @@ func TestConvertParams(t *testing.T) {
 	})
 
 	t.Run("converts tool_choice auto", func(t *testing.T) {
-		params := anyllm.CompletionParams{
+		params := llm.CompletionParams{
 			Model:      "gpt-4",
 			Messages:   testutil.SimpleMessages(),
-			Tools:      []anyllm.Tool{testutil.WeatherTool()},
+			Tools:      []llm.Tool{testutil.WeatherTool()},
 			ToolChoice: "auto",
 		}
 
@@ -138,10 +138,10 @@ func TestConvertParams(t *testing.T) {
 	})
 
 	t.Run("converts tool_choice required", func(t *testing.T) {
-		params := anyllm.CompletionParams{
+		params := llm.CompletionParams{
 			Model:      "gpt-4",
 			Messages:   testutil.SimpleMessages(),
-			Tools:      []anyllm.Tool{testutil.WeatherTool()},
+			Tools:      []llm.Tool{testutil.WeatherTool()},
 			ToolChoice: "required",
 		}
 
@@ -151,13 +151,13 @@ func TestConvertParams(t *testing.T) {
 	})
 
 	t.Run("converts tool_choice with specific function", func(t *testing.T) {
-		params := anyllm.CompletionParams{
+		params := llm.CompletionParams{
 			Model:    "gpt-4",
 			Messages: testutil.SimpleMessages(),
-			Tools:    []anyllm.Tool{testutil.WeatherTool()},
-			ToolChoice: anyllm.ToolChoice{
+			Tools:    []llm.Tool{testutil.WeatherTool()},
+			ToolChoice: llm.ToolChoice{
 				Type:     "function",
-				Function: &anyllm.ToolChoiceFunction{Name: "get_weather"},
+				Function: &llm.ToolChoiceFunction{Name: "get_weather"},
 			},
 		}
 
@@ -167,10 +167,10 @@ func TestConvertParams(t *testing.T) {
 	})
 
 	t.Run("converts response_format json_object", func(t *testing.T) {
-		params := anyllm.CompletionParams{
+		params := llm.CompletionParams{
 			Model:    "gpt-4",
 			Messages: testutil.SimpleMessages(),
-			ResponseFormat: &anyllm.ResponseFormat{
+			ResponseFormat: &llm.ResponseFormat{
 				Type: "json_object",
 			},
 		}
@@ -181,10 +181,10 @@ func TestConvertParams(t *testing.T) {
 	})
 
 	t.Run("converts reasoning_effort", func(t *testing.T) {
-		params := anyllm.CompletionParams{
+		params := llm.CompletionParams{
 			Model:           "o1-mini",
 			Messages:        testutil.SimpleMessages(),
-			ReasoningEffort: anyllm.ReasoningEffortHigh,
+			ReasoningEffort: llm.ReasoningEffortHigh,
 		}
 
 		req := convertParams(params)
@@ -194,7 +194,7 @@ func TestConvertParams(t *testing.T) {
 
 	t.Run("converts seed", func(t *testing.T) {
 		seed := 42
-		params := anyllm.CompletionParams{
+		params := llm.CompletionParams{
 			Model:    "gpt-4",
 			Messages: testutil.SimpleMessages(),
 			Seed:     &seed,
@@ -206,7 +206,7 @@ func TestConvertParams(t *testing.T) {
 	})
 
 	t.Run("converts user", func(t *testing.T) {
-		params := anyllm.CompletionParams{
+		params := llm.CompletionParams{
 			Model:    "gpt-4",
 			Messages: testutil.SimpleMessages(),
 			User:     "test-user",
@@ -220,32 +220,32 @@ func TestConvertParams(t *testing.T) {
 
 func TestConvertMessage(t *testing.T) {
 	t.Run("converts system message", func(t *testing.T) {
-		msg := anyllm.Message{Role: anyllm.RoleSystem, Content: "You are helpful"}
+		msg := llm.Message{Role: llm.RoleSystem, Content: "You are helpful"}
 		result := convertMessage(msg)
 		assert.NotNil(t, result)
 	})
 
 	t.Run("converts user message", func(t *testing.T) {
-		msg := anyllm.Message{Role: anyllm.RoleUser, Content: "Hello"}
+		msg := llm.Message{Role: llm.RoleUser, Content: "Hello"}
 		result := convertMessage(msg)
 		assert.NotNil(t, result)
 	})
 
 	t.Run("converts assistant message", func(t *testing.T) {
-		msg := anyllm.Message{Role: anyllm.RoleAssistant, Content: "Hi there!"}
+		msg := llm.Message{Role: llm.RoleAssistant, Content: "Hi there!"}
 		result := convertMessage(msg)
 		assert.NotNil(t, result)
 	})
 
 	t.Run("converts assistant message with tool calls", func(t *testing.T) {
-		msg := anyllm.Message{
-			Role:    anyllm.RoleAssistant,
+		msg := llm.Message{
+			Role:    llm.RoleAssistant,
 			Content: "",
-			ToolCalls: []anyllm.ToolCall{
+			ToolCalls: []llm.ToolCall{
 				{
 					ID:   "call_123",
 					Type: "function",
-					Function: anyllm.FunctionCall{
+					Function: llm.FunctionCall{
 						Name:      "get_weather",
 						Arguments: `{"location": "Paris"}`,
 					},
@@ -257,8 +257,8 @@ func TestConvertMessage(t *testing.T) {
 	})
 
 	t.Run("converts tool result message", func(t *testing.T) {
-		msg := anyllm.Message{
-			Role:       anyllm.RoleTool,
+		msg := llm.Message{
+			Role:       llm.RoleTool,
 			Content:    "sunny, 22°C",
 			ToolCallID: "call_123",
 		}
@@ -267,11 +267,11 @@ func TestConvertMessage(t *testing.T) {
 	})
 
 	t.Run("converts multimodal user message", func(t *testing.T) {
-		msg := anyllm.Message{
-			Role: anyllm.RoleUser,
-			Content: []anyllm.ContentPart{
+		msg := llm.Message{
+			Role: llm.RoleUser,
+			Content: []llm.ContentPart{
 				{Type: "text", Text: "What's in this image?"},
-				{Type: "image_url", ImageURL: &anyllm.ImageURL{URL: "https://example.com/image.png"}},
+				{Type: "image_url", ImageURL: &llm.ImageURL{URL: "https://example.com/image.png"}},
 			},
 		}
 		result := convertMessage(msg)
@@ -297,7 +297,7 @@ func TestIntegrationCompletion(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	params := anyllm.CompletionParams{
+	params := llm.CompletionParams{
 		Model:    testutil.GetTestModel("openai"),
 		Messages: testutil.SimpleMessages(),
 	}
@@ -309,7 +309,7 @@ func TestIntegrationCompletion(t *testing.T) {
 	assert.Equal(t, "chat.completion", resp.Object)
 	assert.Len(t, resp.Choices, 1)
 	assert.NotEmpty(t, resp.Choices[0].Message.Content)
-	assert.Equal(t, anyllm.RoleAssistant, resp.Choices[0].Message.Role)
+	assert.Equal(t, llm.RoleAssistant, resp.Choices[0].Message.Role)
 	assert.NotNil(t, resp.Usage)
 	assert.Greater(t, resp.Usage.TotalTokens, 0)
 }
@@ -323,7 +323,7 @@ func TestIntegrationCompletionStream(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	params := anyllm.CompletionParams{
+	params := llm.CompletionParams{
 		Model:    testutil.GetTestModel("openai"),
 		Messages: testutil.SimpleMessages(),
 		Stream:   true,
@@ -358,10 +358,10 @@ func TestIntegrationCompletionWithTools(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	params := anyllm.CompletionParams{
+	params := llm.CompletionParams{
 		Model:      testutil.GetTestModel("openai"),
 		Messages:   testutil.ToolCallMessages(),
-		Tools:      []anyllm.Tool{testutil.WeatherTool()},
+		Tools:      []llm.Tool{testutil.WeatherTool()},
 		ToolChoice: "auto",
 	}
 
@@ -376,7 +376,7 @@ func TestIntegrationCompletionWithTools(t *testing.T) {
 		tc := resp.Choices[0].Message.ToolCalls[0]
 		assert.Equal(t, "get_weather", tc.Function.Name)
 		assert.Contains(t, tc.Function.Arguments, "Paris")
-		assert.Equal(t, anyllm.FinishReasonToolCalls, resp.Choices[0].FinishReason)
+		assert.Equal(t, llm.FinishReasonToolCalls, resp.Choices[0].FinishReason)
 	}
 }
 
@@ -389,7 +389,7 @@ func TestIntegrationCompletionConversation(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	params := anyllm.CompletionParams{
+	params := llm.CompletionParams{
 		Model:    testutil.GetTestModel("openai"),
 		Messages: testutil.ConversationMessages(),
 	}
@@ -415,7 +415,7 @@ func TestIntegrationEmbedding(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	params := anyllm.EmbeddingParams{
+	params := llm.EmbeddingParams{
 		Model: testutil.GetEmbeddingModel("openai"),
 		Input: "Hello, world!",
 	}
@@ -462,11 +462,11 @@ func TestIntegrationListModels(t *testing.T) {
 }
 
 func TestIntegrationAuthenticationError(t *testing.T) {
-	provider, err := New(anyllm.WithAPIKey("invalid-api-key"))
+	provider, err := New(llm.WithAPIKey("invalid-api-key"))
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	params := anyllm.CompletionParams{
+	params := llm.CompletionParams{
 		Model:    "gpt-4o-mini",
 		Messages: testutil.SimpleMessages(),
 	}
@@ -475,6 +475,6 @@ func TestIntegrationAuthenticationError(t *testing.T) {
 	assert.Error(t, err)
 
 	// Check that it's converted to an authentication error
-	var authErr *anyllm.AuthenticationError
+	var authErr *llm.AuthenticationError
 	assert.ErrorAs(t, err, &authErr)
 }

--- a/providers/platform/platform_test.go
+++ b/providers/platform/platform_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	anyllm "github.com/mozilla-ai/any-llm-go"
+	llm "github.com/mozilla-ai/any-llm-go"
 	_ "github.com/mozilla-ai/any-llm-go/providers/openai" // Register OpenAI as underlying provider
 )
 
@@ -22,7 +22,7 @@ func TestNew(t *testing.T) {
 
 		assert.Nil(t, provider)
 		assert.Error(t, err)
-		assert.ErrorIs(t, err, anyllm.ErrMissingAPIKey)
+		assert.ErrorIs(t, err, llm.ErrMissingAPIKey)
 	})
 
 	t.Run("creates provider with API key from env", func(t *testing.T) {
@@ -38,7 +38,7 @@ func TestNew(t *testing.T) {
 	t.Run("creates provider with explicit API key", func(t *testing.T) {
 		t.Setenv("ANY_LLM_KEY", "")
 
-		provider, err := New(anyllm.WithAPIKey("ANY.v1.test.fingerprint-dGVzdHByaXZhdGVrZXkxMjM0NTY3ODkwMTI="))
+		provider, err := New(llm.WithAPIKey("ANY.v1.test.fingerprint-dGVzdHByaXZhdGVrZXkxMjM0NTY3ODkwMTI="))
 
 		require.NoError(t, err)
 		assert.NotNil(t, provider)
@@ -90,7 +90,7 @@ func TestParseModelString(t *testing.T) {
 }
 
 func TestProvider_Registration(t *testing.T) {
-	assert.True(t, anyllm.IsRegistered("platform"))
+	assert.True(t, llm.IsRegistered("platform"))
 }
 
 // Integration tests - require actual platform connection and ANY_LLM_KEY
@@ -110,10 +110,10 @@ func TestIntegrationOpenAICompletion(t *testing.T) {
 	// 2. Get the decrypted OpenAI API key from the platform
 	// 3. Create an OpenAI provider and delegate the request
 	// 4. Report usage metrics back to the platform
-	response, err := provider.Completion(ctx, anyllm.CompletionParams{
+	response, err := provider.Completion(ctx, llm.CompletionParams{
 		Model: "openai:gpt-4o-mini",
-		Messages: []anyllm.Message{
-			{Role: anyllm.RoleUser, Content: "Say 'hello' and nothing else."},
+		Messages: []llm.Message{
+			{Role: llm.RoleUser, Content: "Say 'hello' and nothing else."},
 		},
 	})
 	require.NoError(t, err)
@@ -147,10 +147,10 @@ func TestIntegrationOpenAIStreaming(t *testing.T) {
 
 	ctx := context.Background()
 
-	chunks, errs := provider.CompletionStream(ctx, anyllm.CompletionParams{
+	chunks, errs := provider.CompletionStream(ctx, llm.CompletionParams{
 		Model: "openai:gpt-4o-mini",
-		Messages: []anyllm.Message{
-			{Role: anyllm.RoleUser, Content: "Count from 1 to 5, one number per line."},
+		Messages: []llm.Message{
+			{Role: llm.RoleUser, Content: "Count from 1 to 5, one number per line."},
 		},
 		Stream: true,
 	})

--- a/registry.go
+++ b/registry.go
@@ -1,4 +1,4 @@
-package anyllm
+package llm
 
 import (
 	"strings"

--- a/types.go
+++ b/types.go
@@ -1,4 +1,4 @@
-package anyllm
+package llm
 
 import (
 	"encoding/json"


### PR DESCRIPTION
## Summary

Renames the Go package from `anyllm` to `llm` for more idiomatic naming. The package name `llm` reads more naturally and aligns with Go conventions for concise, descriptive package names.

```go
// Before
anyllm "github.com/mozilla-ai/any-llm-go"
// Usage: anyllm.Provider, anyllm.Message, anyllm.Completion()

// After  
llm "github.com/mozilla-ai/any-llm-go"
// Usage: llm.Provider, llm.Message, llm.Completion()
```

## Changes

- Updated package declaration from `anyllm` to `llm` in all root-level .go files
- Updated import aliases in all provider packages (openai, anthropic, platform)
- Updated import aliases in internal/testutil
- Updated import aliases in all examples
- Updated documentation to reflect new package name

## Testing

- Ran `go test ./...` - all tests pass
- Ran `golangci-lint run` - 0 issues

## Checklist

- [x] Tests pass locally (`go test -short ./...`)
- [x] Linting passes (`golangci-lint run ./...`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)