### PR TITLE
Update golangci-lint to v2.4.0 and fix config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.0.2
+          version: v2.4.0
 
   build:
     name: Build

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,14 +8,14 @@ linters:
     - staticcheck
     - unused
   disable:
-    - tagliatelle  # Disabled: OpenAI API uses snake_case JSON tags
+    - tagliatelle  # Disabled: OpenAI API uses snake_case JSON tags.
   settings:
     errcheck:
       check-type-assertions: true
     govet:
       enable-all: true
       disable:
-        - fieldalignment  # Struct layout must match OpenAI API for JSON compatibility
+        - fieldalignment  # Struct layout must match OpenAI API for JSON compatibility.
 
 formatters:
   enable:
@@ -35,11 +35,22 @@ formatters:
     gofumpt:
       extra-rules: true
 
+issues:
+  fix: true
+
+output:
+  formats:
+    text:
+      path: stderr
+  sort-order:
+    - severity
+    - file
+    - linter
+
 run:
   timeout: 5m
   tests: true
-
-issues:
-  exclude-use-default: false
-  max-issues-per-linter: 0
-  max-same-issues: 0
+  relative-path-mode: gomod
+  modules-download-mode: readonly
+  allow-parallel-runners: true
+  allow-serial-runners: true


### PR DESCRIPTION
## Summary

Updates golangci-lint from v2.0.2 to v2.4.0 and fixes the config schema to be compatible with v2.x.

## Changes

- Update CI workflow to use golangci-lint v2.4.0
- Remove deprecated `exclude-use-default` option from issues section (invalid in v2)
- Add `fix: true` to auto-fix issues
- Add output formatting config (sort by severity, file, linter)
- Add run config improvements (`relative-path-mode`, `parallel-runners`)
- Align config style with mcpd project

## Testing

- Ran `golangci-lint run` locally - 0 issues
- Tested with `nektos/act` - lint job passes

## Checklist

- [x] Tests pass locally (`go test -short ./...`)
- [x] Linting passes (`golangci-lint run ./...`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)