### PR TITLE
Refactor config package to use functional options with validation

### DIFF
--- a/anyllm.go
+++ b/anyllm.go
@@ -112,6 +112,7 @@ type (
 
 // Configuration options.
 var (
+	NewConfig      = config.New
 	WithAPIKey     = config.WithAPIKey
 	WithBaseURL    = config.WithBaseURL
 	WithExtra      = config.WithExtra

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,12 @@
 package config
 
 import (
+	"fmt"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
+	"sync"
 	"time"
 )
 
@@ -14,124 +18,154 @@ type Config struct {
 	// BaseURL is the base URL for the API. If empty, the provider's default is used.
 	BaseURL string
 
+	// Extra holds provider-specific configuration options.
+	Extra map[string]any
+
 	// Timeout is the request timeout. If zero, a default timeout is used.
 	Timeout time.Duration
 
-	// HTTPClient is a custom HTTP client to use. If nil, a default client is created.
-	HTTPClient *http.Client
-
-	// Extra holds provider-specific configuration options.
-	Extra map[string]any
+	// httpClient is a custom HTTP client. Access via HTTPClient() method which
+	// handles lazy creation with the configured Timeout if not explicitly set on the client.
+	httpClient     *http.Client
+	httpClientOnce sync.Once
 }
 
 // Option is a function that modifies the Config.
-type Option func(*Config)
+type Option func(*Config) error
 
-// WithAPIKey sets the API key.
+// New creates a Config with the given options applied.
+// Note: HTTPClient is not created here by default; it is lazily created via the HTTPClient()
+// method using the configured Timeout when first accessed.
+func New(opts ...Option) (*Config, error) {
+	// Configure default values.
+	cfg := &Config{
+		Timeout: 120 * time.Second,
+	}
+
+	// Apply options.
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		if err := opt(cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	return cfg, nil
+}
+
+// WithAPIKey sets the API key. Whitespace is automatically trimmed.
 func WithAPIKey(key string) Option {
-	return func(c *Config) {
+	return func(c *Config) error {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return fmt.Errorf("API key cannot be empty")
+		}
+
 		c.APIKey = key
+		return nil
 	}
 }
 
 // WithBaseURL sets the base URL.
-func WithBaseURL(url string) Option {
-	return func(c *Config) {
-		c.BaseURL = url
+func WithBaseURL(baseURL string) Option {
+	return func(c *Config) error {
+		baseURL = strings.TrimSpace(baseURL)
+		if baseURL == "" {
+			return fmt.Errorf("base URL cannot be empty")
+		}
+
+		parsed, err := url.Parse(baseURL)
+		if err != nil {
+			return fmt.Errorf("invalid base URL: %w", err)
+		}
+
+		if parsed.Scheme == "" || parsed.Host == "" {
+			return fmt.Errorf("base URL must have scheme and host")
+		}
+
+		c.BaseURL = baseURL
+		return nil
+	}
+}
+
+// WithExtra sets extra provider-specific configuration.
+// Whitespace is automatically trimmed from the key.
+func WithExtra(key string, value any) Option {
+	return func(c *Config) error {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return fmt.Errorf("extra key cannot be empty")
+		}
+
+		if c.Extra == nil {
+			c.Extra = make(map[string]any)
+		}
+
+		c.Extra[key] = value
+		return nil
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client.
+// When a custom client is provided, the Timeout field is ignored for HTTP requests
+// since the custom client manages its own timeout configuration.
+// If both WithHTTPClient and WithTimeout are used, the custom client takes precedence.
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *Config) error {
+		if client == nil {
+			return fmt.Errorf("HTTP client cannot be nil")
+		}
+
+		c.httpClient = client
+		return nil
 	}
 }
 
 // WithTimeout sets the request timeout.
 func WithTimeout(d time.Duration) Option {
-	return func(c *Config) {
-		c.Timeout = d
-	}
-}
-
-// WithHTTPClient sets a custom HTTP client.
-func WithHTTPClient(client *http.Client) Option {
-	return func(c *Config) {
-		c.HTTPClient = client
-	}
-}
-
-// WithExtra sets a provider-specific configuration option.
-func WithExtra(key string, value any) Option {
-	return func(c *Config) {
-		if c.Extra == nil {
-			c.Extra = make(map[string]any)
+	return func(c *Config) error {
+		if d <= 0 {
+			return fmt.Errorf("timeout must be positive, got %v", d)
 		}
-		c.Extra[key] = value
+
+		c.Timeout = d
+		return nil
 	}
 }
 
-// New returns a Config with default values.
-func New() *Config {
-	return &Config{
-		Timeout: 120 * time.Second,
-	}
-}
-
-// ApplyOptions applies the given options to the config.
-func (c *Config) ApplyOptions(opts ...Option) {
-	for _, opt := range opts {
-		opt(c)
-	}
-}
-
-// GetAPIKeyFromEnv retrieves the API key from environment variable if not set.
-func (c *Config) GetAPIKeyFromEnv(envVar string) string {
-	if c.APIKey != "" {
-		return c.APIKey
-	}
-	return os.Getenv(envVar)
-}
-
-// GetHTTPClient returns the configured HTTP client or creates a default one.
-func (c *Config) GetHTTPClient() *http.Client {
-	if c.HTTPClient != nil {
-		return c.HTTPClient
-	}
-	return &http.Client{
-		Timeout: c.Timeout,
-	}
-}
-
-// GetExtra retrieves a provider-specific configuration value.
-func (c *Config) GetExtra(key string) (any, bool) {
+// ExtraValue retrieves a provider-specific configuration value.
+func (c *Config) ExtraValue(key string) (any, bool) {
 	if c.Extra == nil {
 		return nil, false
 	}
+
 	v, ok := c.Extra[key]
 	return v, ok
 }
 
-// GetExtraString retrieves a provider-specific string configuration value.
-func (c *Config) GetExtraString(key string) string {
-	v, ok := c.GetExtra(key)
-	if !ok {
-		return ""
-	}
-	s, _ := v.(string)
-	return s
+// HTTPClient returns the configured HTTP client, or lazily creates one using
+// the configured Timeout if no custom client was provided via WithHTTPClient.
+// The lazily-created client is cached and reused on subsequent calls.
+//
+// Note: If a custom client was provided via WithHTTPClient, that pointer is returned.
+func (c *Config) HTTPClient() *http.Client {
+	c.httpClientOnce.Do(func() {
+		if c.httpClient == nil {
+			c.httpClient = &http.Client{Timeout: c.Timeout}
+		}
+	})
+
+	return c.httpClient
 }
 
-// GetExtraInt retrieves a provider-specific int configuration value.
-func (c *Config) GetExtraInt(key string) int {
-	v, ok := c.GetExtra(key)
-	if !ok {
-		return 0
+// ResolveAPIKey returns the API key from config if set, otherwise falls back
+// to the specified environment variable.
+func (c *Config) ResolveAPIKey(envVar string) string {
+	if c.APIKey != "" {
+		return c.APIKey
 	}
-	i, _ := v.(int)
-	return i
-}
 
-// GetExtraBool retrieves a provider-specific bool configuration value.
-func (c *Config) GetExtraBool(key string) bool {
-	v, ok := c.GetExtra(key)
-	if !ok {
-		return false
-	}
-	b, _ := v.(bool)
-	return b
+	return os.Getenv(envVar)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,489 @@
+package config
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithAPIKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		key     string
+		wantErr bool
+		wantKey string
+	}{
+		{
+			name:    "valid key",
+			key:     "sk-123456",
+			wantErr: false,
+			wantKey: "sk-123456",
+		},
+		{
+			name:    "valid key with whitespace trimmed",
+			key:     "  sk-123456  ",
+			wantErr: false,
+			wantKey: "sk-123456",
+		},
+		{
+			name:    "empty key",
+			key:     "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only key",
+			key:     "   ",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := New(WithAPIKey(tc.key))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantKey, cfg.APIKey)
+		})
+	}
+}
+
+func TestWithBaseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+		wantURL string
+	}{
+		{
+			name:    "valid https URL",
+			url:     "https://api.example.com",
+			wantErr: false,
+			wantURL: "https://api.example.com",
+		},
+		{
+			name:    "valid http URL",
+			url:     "http://localhost:8080",
+			wantErr: false,
+			wantURL: "http://localhost:8080",
+		},
+		{
+			name:    "valid URL with path",
+			url:     "https://api.example.com/v1",
+			wantErr: false,
+			wantURL: "https://api.example.com/v1",
+		},
+		{
+			name:    "valid URL with whitespace trimmed",
+			url:     "  https://api.example.com  ",
+			wantErr: false,
+			wantURL: "https://api.example.com",
+		},
+		{
+			name:    "empty URL",
+			url:     "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only URL",
+			url:     "   ",
+			wantErr: true,
+		},
+		{
+			name:    "URL without scheme",
+			url:     "api.example.com",
+			wantErr: true,
+		},
+		{
+			name:    "URL without host",
+			url:     "https://",
+			wantErr: true,
+		},
+		{
+			name:    "relative path only",
+			url:     "/v1/chat",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := New(WithBaseURL(tc.url))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantURL, cfg.BaseURL)
+		})
+	}
+}
+
+func TestWithTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		timeout     time.Duration
+		wantErr     bool
+		wantTimeout time.Duration
+	}{
+		{
+			name:        "valid timeout",
+			timeout:     30 * time.Second,
+			wantErr:     false,
+			wantTimeout: 30 * time.Second,
+		},
+		{
+			name:        "one nanosecond",
+			timeout:     time.Nanosecond,
+			wantErr:     false,
+			wantTimeout: time.Nanosecond,
+		},
+		{
+			name:    "zero timeout",
+			timeout: 0,
+			wantErr: true,
+		},
+		{
+			name:    "negative timeout",
+			timeout: -1 * time.Second,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := New(WithTimeout(tc.timeout))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantTimeout, cfg.Timeout)
+		})
+	}
+}
+
+func TestWithHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		client  *http.Client
+		wantErr bool
+	}{
+		{
+			name:    "valid client",
+			client:  &http.Client{Timeout: 10 * time.Second},
+			wantErr: false,
+		},
+		{
+			name:    "nil client",
+			client:  nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := New(WithHTTPClient(tc.client))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Same(t, tc.client, cfg.HTTPClient())
+		})
+	}
+}
+
+func TestHTTPClientLazyCreation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses configured timeout", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := New(WithTimeout(45 * time.Second))
+		require.NoError(t, err)
+
+		client := cfg.HTTPClient()
+		require.NotNil(t, client)
+		require.Equal(t, 45*time.Second, client.Timeout)
+	})
+
+	t.Run("uses default timeout when not configured", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := New()
+		require.NoError(t, err)
+
+		client := cfg.HTTPClient()
+		require.NotNil(t, client)
+		require.Equal(t, 120*time.Second, client.Timeout)
+	})
+
+	t.Run("custom client takes precedence", func(t *testing.T) {
+		t.Parallel()
+
+		customClient := &http.Client{Timeout: 5 * time.Second}
+		cfg, err := New(
+			WithTimeout(60*time.Second),
+			WithHTTPClient(customClient),
+		)
+		require.NoError(t, err)
+
+		require.Same(t, customClient, cfg.HTTPClient())
+	})
+}
+
+func TestWithExtra(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		key     string
+		value   any
+		wantErr bool
+	}{
+		{
+			name:    "valid string value",
+			key:     "client_name",
+			value:   "my-client",
+			wantErr: false,
+		},
+		{
+			name:    "valid int value",
+			key:     "max_retries",
+			value:   3,
+			wantErr: false,
+		},
+		{
+			name:    "key with whitespace trimmed",
+			key:     "  client_name  ",
+			value:   "my-client",
+			wantErr: false,
+		},
+		{
+			name:    "empty key",
+			key:     "",
+			value:   "value",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only key",
+			key:     "   ",
+			value:   "value",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := New(WithExtra(tc.key, tc.value))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, cfg.Extra)
+		})
+	}
+}
+
+func TestExtraValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cfg       *Config
+		key       string
+		wantValue any
+		wantOK    bool
+	}{
+		{
+			name: "returns value when present",
+			cfg: &Config{
+				Extra: map[string]any{"key": "value"},
+			},
+			key:       "key",
+			wantValue: "value",
+			wantOK:    true,
+		},
+		{
+			name: "returns false when key missing",
+			cfg: &Config{
+				Extra: map[string]any{"other": "value"},
+			},
+			key:       "nonexistent",
+			wantValue: nil,
+			wantOK:    false,
+		},
+		{
+			name:      "returns false when Extra is nil",
+			cfg:       &Config{},
+			key:       "key",
+			wantValue: nil,
+			wantOK:    false,
+		},
+		{
+			name: "returns int value",
+			cfg: &Config{
+				Extra: map[string]any{"count": 42},
+			},
+			key:       "count",
+			wantValue: 42,
+			wantOK:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			v, ok := tc.cfg.ExtraValue(tc.key)
+			require.Equal(t, tc.wantOK, ok)
+			require.Equal(t, tc.wantValue, v)
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		opts        []Option
+		wantErr     bool
+		wantTimeout time.Duration
+		wantAPIKey  string
+		wantBaseURL string
+	}{
+		{
+			name:        "no options uses defaults",
+			opts:        nil,
+			wantErr:     false,
+			wantTimeout: 120 * time.Second,
+		},
+		{
+			name:        "nil option is skipped",
+			opts:        []Option{nil, WithAPIKey("test-key"), nil},
+			wantErr:     false,
+			wantTimeout: 120 * time.Second,
+			wantAPIKey:  "test-key",
+		},
+		{
+			name:        "multiple options applied",
+			opts:        []Option{WithAPIKey("my-key"), WithBaseURL("https://api.example.com"), WithTimeout(30 * time.Second)},
+			wantErr:     false,
+			wantTimeout: 30 * time.Second,
+			wantAPIKey:  "my-key",
+			wantBaseURL: "https://api.example.com",
+		},
+		{
+			name:    "error from option propagates",
+			opts:    []Option{WithAPIKey("")},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := New(tc.opts...)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+			require.Equal(t, tc.wantTimeout, cfg.Timeout)
+			require.Equal(t, tc.wantAPIKey, cfg.APIKey)
+			require.Equal(t, tc.wantBaseURL, cfg.BaseURL)
+		})
+	}
+}
+
+func TestResolveAPIKey(t *testing.T) {
+	// Note: Cannot use t.Parallel() with t.Setenv().
+
+	tests := []struct {
+		name       string
+		configKey  string
+		envVar     string
+		envValue   string
+		wantAPIKey string
+	}{
+		{
+			name:       "returns config key when set",
+			configKey:  "config-key",
+			envVar:     "TEST_API_KEY",
+			envValue:   "env-key",
+			wantAPIKey: "config-key",
+		},
+		{
+			name:       "falls back to env when config key empty",
+			configKey:  "",
+			envVar:     "TEST_API_KEY_FALLBACK",
+			envValue:   "env-key",
+			wantAPIKey: "env-key",
+		},
+		{
+			name:       "returns empty when both empty",
+			configKey:  "",
+			envVar:     "TEST_API_KEY_EMPTY",
+			envValue:   "",
+			wantAPIKey: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envValue != "" {
+				t.Setenv(tc.envVar, tc.envValue)
+			}
+
+			cfg := &Config{APIKey: tc.configKey}
+			result := cfg.ResolveAPIKey(tc.envVar)
+			require.Equal(t, tc.wantAPIKey, result)
+		})
+	}
+}
+
+func TestHTTPClientCaching(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := New()
+	require.NoError(t, err)
+
+	// Get client twice - should return same instance.
+	client1 := cfg.HTTPClient()
+	client2 := cfg.HTTPClient()
+
+	require.Same(t, client1, client2)
+}

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -4,6 +4,7 @@ package anthropic
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -41,10 +42,12 @@ var (
 
 // New creates a new Anthropic provider.
 func New(opts ...config.Option) (*Provider, error) {
-	cfg := config.New()
-	cfg.ApplyOptions(opts...)
+	cfg, err := config.New(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("invalid options: %w", err)
+	}
 
-	apiKey := cfg.GetAPIKeyFromEnv(envAPIKey)
+	apiKey := cfg.ResolveAPIKey(envAPIKey)
 	if apiKey == "" {
 		return nil, errors.NewMissingAPIKeyError(providerName, envAPIKey)
 	}

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -4,6 +4,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -35,10 +36,12 @@ type Provider struct {
 
 // New creates a new OpenAI provider.
 func New(opts ...config.Option) (*Provider, error) {
-	cfg := config.New()
-	cfg.ApplyOptions(opts...)
+	cfg, err := config.New(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("invalid options: %w", err)
+	}
 
-	apiKey := cfg.GetAPIKeyFromEnv(envAPIKey)
+	apiKey := cfg.ResolveAPIKey(envAPIKey)
 	if apiKey == "" {
 		return nil, errors.NewMissingAPIKeyError(providerName, envAPIKey)
 	}


### PR DESCRIPTION
## Summary

Refactors the config package to use Go's functional options pattern with proper validation and error handling.

## Changes

- Change `Option` type signature from `func(*Config)` to `func(*Config) error` for validation support
- Add `config.New()` function that applies options and returns errors
- Add validation to all `With*` functions:
  - `WithAPIKey`: trims whitespace, rejects empty
  - `WithBaseURL`: trims whitespace, validates URL format (scheme + host)
  - `WithTimeout`: rejects non-positive durations
  - `WithHTTPClient`: rejects nil
  - `WithExtra`: trims key whitespace, rejects empty keys
- Rename `GetAPIKeyFromEnv` to `ResolveAPIKey` for clarity
- Rename `GetExtra` to `ExtraValue` and remove unused typed getters (`GetExtraString`, `GetExtraInt`, `GetExtraBool`)
- Implement lazy `HTTPClient()` creation with `sync.Once` caching
- Change `Config` to pointer type to support `sync.Once`
- Fix platform provider bug where `client_name` wasn't being read from Extra
- Add comprehensive table-driven tests for all config functions

## Testing

- Added `config/config_test.go` with table-driven tests for all functions
- All tests pass: `go test ./...`
- Linting passes: `golangci-lint run ./...`

## Checklist

- [x] Tests pass locally (`go test -short ./...`)
- [x] Linting passes (`golangci-lint run ./...`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)