### PR TITLE
Update Go version to 1.25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.25'
 
       - name: Download dependencies
         run: go mod download
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.25'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.25'
 
       - name: Build
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to any-llm-go! This guide will help 
 
 ### Prerequisites
 
-- **Go 1.23+** - [Download Go](https://go.dev/dl/)
+- **Go 1.25+** - [Download Go](https://go.dev/dl/)
 - **Git** - For version control
 - **API Keys** - For running integration tests (optional)
 - **golangci-lint** - For linting (optional but recommended)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/mozilla-ai/any-llm-go.svg)](https://pkg.go.dev/github.com/mozilla-ai/any-llm-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/mozilla-ai/any-llm-go)](https://goreportcard.com/report/github.com/mozilla-ai/any-llm-go)
 
-![Go 1.23+](https://img.shields.io/badge/go-1.23%2B-blue.svg)
+![Go 1.25+](https://img.shields.io/badge/go-1.25%2B-blue.svg)
 
 **Communicate with any LLM provider using a single, unified interface.**
 Switch between OpenAI, Anthropic, Mistral, Ollama, and more without changing your code.
@@ -60,7 +60,7 @@ func main() {
 
 ### Requirements
 
-- Go 1.23 or newer
+- Go 1.25 or newer
 - API keys for whichever LLM providers you want to use
 
 ### Basic Installation

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/mozilla-ai/any-llm-go
 
-go 1.24.0
-
-toolchain go1.24.4
+go 1.25
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.19.0


### PR DESCRIPTION
## Summary

Updates Go version requirement from 1.23 to 1.25 across the project.

## Changes

- Update `go.mod` to require Go 1.25
- Update CI workflow to use Go 1.25
- Update README.md version badge and requirements
- Update CONTRIBUTING.md prerequisites

## Testing

- `go build ./...` passes
- `go test -short ./...` passes
- `golangci-lint run ./...` passes

## Checklist

- [x] Tests pass locally (`go test -short ./...`)
- [x] Linting passes (`golangci-lint run ./...`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)