### PR TITLE
Extract magic strings to constants in Anthropic provider

### DIFF
--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -186,20 +186,23 @@ func TestConvertStopReason(t *testing.T) {
 	}
 }
 
-func TestReasoningEffortToBudget(t *testing.T) {
+func TestThinkingBudget(t *testing.T) {
 	tests := []struct {
 		effort   providers.ReasoningEffort
 		expected int64
+		ok       bool
 	}{
-		{providers.ReasoningEffortLow, 1024},
-		{providers.ReasoningEffortMedium, 4096},
-		{providers.ReasoningEffortHigh, 16384},
+		{providers.ReasoningEffortLow, 1024, true},
+		{providers.ReasoningEffortMedium, 4096, true},
+		{providers.ReasoningEffortHigh, 16384, true},
+		{providers.ReasoningEffortNone, 0, false},
+		{"invalid", 0, false},
 	}
 
 	for _, tc := range tests {
 		t.Run(string(tc.effort), func(t *testing.T) {
-			budget, ok := reasoningEffortToBudget[tc.effort]
-			assert.True(t, ok)
+			budget, ok := thinkingBudget(tc.effort)
+			assert.Equal(t, tc.ok, ok)
 			assert.Equal(t, tc.expected, budget)
 		})
 	}


### PR DESCRIPTION
## Summary

Extracts magic strings to named constants in the Anthropic provider for improved maintainability.

## Changes

- Add constants for streaming event types (`eventMessageStart`, `eventContentBlockStart`, etc.)
- Add constants for content block types (`blockTypeText`, `blockTypeThinking`, `blockTypeToolUse`)
- Add constants for delta types (`deltaTypeText`, `deltaTypeThinking`, `deltaTypeInputJSON`)
- Add constants for stop reasons (`stopReasonEndTurn`, `stopReasonMaxTokens`, etc.)
- Convert `reasoningEffortToBudget` map to `thinkingBudget()` function
- Update all switch statements to use constants instead of string literals
- Update tests to use new function and add coverage for invalid effort levels

## Testing

- `go build ./...` passes
- `go test -short ./...` passes
- `golangci-lint run ./...` passes

## Checklist

- [x] Tests pass locally (`go test -short ./...`)
- [x] Linting passes (`golangci-lint run ./...`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)