### PR TITLE
refactor(anthropic): Flatten control flow and extract helpers

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -15,18 +15,11 @@ import (
 	"github.com/mozilla-ai/any-llm-go/providers"
 )
 
+// Provider configuration constants.
 const (
-	providerName     = "anthropic"
-	envAPIKey        = "ANTHROPIC_API_KEY"
 	defaultMaxTokens = 4096
-)
-
-// Anthropic streaming event types.
-const (
-	eventMessageStart      = "message_start"
-	eventContentBlockStart = "content_block_start"
-	eventContentBlockDelta = "content_block_delta"
-	eventMessageDelta      = "message_delta"
+	envAPIKey        = "ANTHROPIC_API_KEY"
+	providerName     = "anthropic"
 )
 
 // Anthropic content block types.
@@ -38,33 +31,32 @@ const (
 
 // Anthropic delta types.
 const (
+	deltaTypeInputJSON = "input_json_delta"
 	deltaTypeText      = "text_delta"
 	deltaTypeThinking  = "thinking_delta"
-	deltaTypeInputJSON = "input_json_delta"
+)
+
+// Anthropic streaming event types.
+const (
+	eventContentBlockDelta = "content_block_delta"
+	eventContentBlockStart = "content_block_start"
+	eventMessageDelta      = "message_delta"
+	eventMessageStart      = "message_start"
 )
 
 // Anthropic stop reasons.
 const (
 	stopReasonEndTurn      = "end_turn"
 	stopReasonMaxTokens    = "max_tokens"
-	stopReasonToolUse      = "tool_use"
 	stopReasonStopSequence = "stop_sequence"
+	stopReasonToolUse      = "tool_use"
 )
 
-// thinkingBudget returns the token budget for the given reasoning effort.
-// Returns the budget and true if the effort level is supported, or 0 and false otherwise.
-func thinkingBudget(effort providers.ReasoningEffort) (int64, bool) {
-	switch effort {
-	case providers.ReasoningEffortLow:
-		return 1024, true
-	case providers.ReasoningEffortMedium:
-		return 4096, true
-	case providers.ReasoningEffortHigh:
-		return 16384, true
-	default:
-		return 0, false
-	}
-}
+// Ensure Provider implements the required interfaces.
+var (
+	_ providers.CapabilityProvider = (*Provider)(nil)
+	_ providers.Provider           = (*Provider)(nil)
+)
 
 // Provider implements the providers.Provider interface for Anthropic.
 type Provider struct {
@@ -72,11 +64,17 @@ type Provider struct {
 	config *config.Config
 }
 
-// Ensure Provider implements the required interfaces.
-var (
-	_ providers.Provider           = (*Provider)(nil)
-	_ providers.CapabilityProvider = (*Provider)(nil)
-)
+// streamState tracks accumulated state during streaming.
+// Note: Only accessed from a single goroutine, so no synchronization needed.
+type streamState struct {
+	messageID      string
+	model          string
+	content        strings.Builder
+	reasoning      strings.Builder
+	toolCalls      []providers.ToolCall
+	currentToolIdx int
+	inputUsage     int64
+}
 
 // New creates a new Anthropic provider.
 func New(opts ...config.Option) (*Provider, error) {
@@ -106,11 +104,6 @@ func New(opts ...config.Option) (*Provider, error) {
 	}, nil
 }
 
-// Name returns the provider name.
-func (p *Provider) Name() string {
-	return providerName
-}
-
 // Capabilities returns the provider's capabilities.
 func (p *Provider) Capabilities() providers.Capabilities {
 	return providers.Capabilities{
@@ -134,149 +127,6 @@ func (p *Provider) Completion(ctx context.Context, params providers.CompletionPa
 	}
 
 	return convertResponse(resp), nil
-}
-
-// CompletionStream performs a streaming chat completion request.
-func (p *Provider) CompletionStream(ctx context.Context, params providers.CompletionParams) (<-chan providers.ChatCompletionChunk, <-chan error) {
-	chunks := make(chan providers.ChatCompletionChunk)
-	errs := make(chan error, 1)
-
-	go func() {
-		defer close(chunks)
-		defer close(errs)
-
-		req := p.convertParams(params)
-
-		stream := p.client.Messages.NewStreaming(ctx, req)
-
-		// Track accumulated state for streaming.
-		var (
-			messageID        string
-			model            string
-			contentBuilder   strings.Builder
-			reasoningBuilder strings.Builder
-			toolCalls        []providers.ToolCall
-			currentToolIdx   = -1
-			inputUsage       int64
-		)
-
-		for stream.Next() {
-			event := stream.Current()
-
-			switch event.Type {
-			case eventMessageStart:
-				e := event.AsMessageStart()
-				messageID = e.Message.ID
-				model = string(e.Message.Model)
-				inputUsage = e.Message.Usage.InputTokens
-
-				// Send initial chunk.
-				chunks <- providers.ChatCompletionChunk{
-					ID:     messageID,
-					Object: "chat.completion.chunk",
-					Model:  model,
-					Choices: []providers.ChunkChoice{{
-						Index: 0,
-						Delta: providers.ChunkDelta{
-							Role: providers.RoleAssistant,
-						},
-					}},
-				}
-
-			case eventContentBlockStart:
-				e := event.AsContentBlockStart()
-				switch e.ContentBlock.Type {
-				case blockTypeThinking:
-					// Reasoning block started.
-				case blockTypeToolUse:
-					currentToolIdx++
-					toolCalls = append(toolCalls, providers.ToolCall{
-						ID:   e.ContentBlock.ID,
-						Type: "function",
-						Function: providers.FunctionCall{
-							Name: e.ContentBlock.Name,
-						},
-					})
-				}
-
-			case eventContentBlockDelta:
-				e := event.AsContentBlockDelta()
-				switch e.Delta.Type {
-				case deltaTypeText:
-					text := e.Delta.Text
-					contentBuilder.WriteString(text)
-					chunks <- providers.ChatCompletionChunk{
-						ID:     messageID,
-						Object: "chat.completion.chunk",
-						Model:  model,
-						Choices: []providers.ChunkChoice{{
-							Index: 0,
-							Delta: providers.ChunkDelta{
-								Content: text,
-							},
-						}},
-					}
-
-				case deltaTypeThinking:
-					thinking := e.Delta.Thinking
-					reasoningBuilder.WriteString(thinking)
-					chunks <- providers.ChatCompletionChunk{
-						ID:     messageID,
-						Object: "chat.completion.chunk",
-						Model:  model,
-						Choices: []providers.ChunkChoice{{
-							Index: 0,
-							Delta: providers.ChunkDelta{
-								Reasoning: &providers.Reasoning{
-									Content: thinking,
-								},
-							},
-						}},
-					}
-
-				case deltaTypeInputJSON:
-					if currentToolIdx >= 0 && currentToolIdx < len(toolCalls) {
-						toolCalls[currentToolIdx].Function.Arguments += e.Delta.PartialJSON
-						chunks <- providers.ChatCompletionChunk{
-							ID:     messageID,
-							Object: "chat.completion.chunk",
-							Model:  model,
-							Choices: []providers.ChunkChoice{{
-								Index: 0,
-								Delta: providers.ChunkDelta{
-									ToolCalls: []providers.ToolCall{toolCalls[currentToolIdx]},
-								},
-							}},
-						}
-					}
-				}
-
-			case eventMessageDelta:
-				e := event.AsMessageDelta()
-				finishReason := convertStopReason(string(e.Delta.StopReason))
-				chunks <- providers.ChatCompletionChunk{
-					ID:     messageID,
-					Object: "chat.completion.chunk",
-					Model:  model,
-					Choices: []providers.ChunkChoice{{
-						Index:        0,
-						FinishReason: finishReason,
-					}},
-					Usage: &providers.Usage{
-						PromptTokens:     int(inputUsage),
-						CompletionTokens: int(e.Usage.OutputTokens),
-						TotalTokens:      int(inputUsage + e.Usage.OutputTokens),
-					},
-				}
-			}
-		}
-
-		if err := stream.Err(); err != nil {
-			errs <- errors.Convert(providerName, err)
-		}
-	}()
-
-	return chunks, errs
 }
 
 // convertParams converts providers.CompletionParams to Anthropic request parameters.
@@ -324,82 +174,199 @@ func (p *Provider) convertParams(params providers.CompletionParams) anthropic.Me
 		req.ToolChoice = convertToolChoice(params.ToolChoice, params.ParallelToolCalls)
 	}
 
-	// Handle reasoning/thinking.
-	if params.ReasoningEffort != "" && params.ReasoningEffort != providers.ReasoningEffortNone {
-		if budget, ok := thinkingBudget(params.ReasoningEffort); ok {
-			req.Thinking = anthropic.ThinkingConfigParamOfEnabled(budget)
-			// Increase max tokens to accommodate thinking.
-			if maxTokens < budget*2 {
-				req.MaxTokens = budget * 2
-			}
-		}
-	}
+	applyThinking(&req, params.ReasoningEffort, maxTokens)
 
 	return req
 }
 
-// convertMessages converts providers messages to Anthropic format.
-// Returns the messages and the combined system message.
-func convertMessages(messages []providers.Message) ([]anthropic.MessageParam, string) {
-	result := make([]anthropic.MessageParam, 0, len(messages))
-	var systemParts []string
+// CompletionStream performs a streaming chat completion request.
+func (p *Provider) CompletionStream(ctx context.Context, params providers.CompletionParams) (<-chan providers.ChatCompletionChunk, <-chan error) {
+	chunks := make(chan providers.ChatCompletionChunk)
+	errs := make(chan error, 1)
 
-	for _, msg := range messages {
-		switch msg.Role {
-		case providers.RoleSystem:
-			systemParts = append(systemParts, msg.GetContentString())
+	go func() {
+		defer close(chunks)
+		defer close(errs)
 
-		case providers.RoleUser:
-			if msg.IsMultiModal() {
-				content := make([]anthropic.ContentBlockParamUnion, 0)
-				for _, part := range msg.GetContentParts() {
-					if part.Type == "text" {
-						content = append(content, anthropic.NewTextBlock(part.Text))
-					} else if part.Type == "image_url" && part.ImageURL != nil {
-						content = append(content, convertImagePart(part.ImageURL))
-					}
+		req := p.convertParams(params)
+		stream := p.client.Messages.NewStreaming(ctx, req)
+		state := newStreamState()
+
+		for stream.Next() {
+			event := stream.Current()
+
+			switch event.Type {
+			case eventMessageStart:
+				chunks <- state.handleMessageStart(event.AsMessageStart())
+
+			case eventContentBlockStart:
+				state.handleContentBlockStart(event.AsContentBlockStart())
+
+			case eventContentBlockDelta:
+				if chunk := state.handleContentBlockDelta(event.AsContentBlockDelta()); chunk != nil {
+					chunks <- *chunk
 				}
-				result = append(result, anthropic.NewUserMessage(content...))
-			} else {
-				result = append(result, anthropic.NewUserMessage(
-					anthropic.NewTextBlock(msg.GetContentString()),
-				))
+
+			case eventMessageDelta:
+				chunks <- state.handleMessageDelta(event.AsMessageDelta())
 			}
-
-		case providers.RoleAssistant:
-			if len(msg.ToolCalls) > 0 {
-				content := make([]anthropic.ContentBlockParamUnion, 0)
-				if msg.GetContentString() != "" {
-					content = append(content, anthropic.NewTextBlock(msg.GetContentString()))
-				}
-				for _, tc := range msg.ToolCalls {
-					// Parse arguments JSON to map.
-					var input map[string]interface{}
-					_ = json.Unmarshal([]byte(tc.Function.Arguments), &input) // Ignore error: use empty map on failure.
-					content = append(content, anthropic.ContentBlockParamUnion{
-						OfToolUse: &anthropic.ToolUseBlockParam{
-							Type:  "tool_use",
-							ID:    tc.ID,
-							Name:  tc.Function.Name,
-							Input: input,
-						},
-					})
-				}
-				result = append(result, anthropic.NewAssistantMessage(content...))
-			} else {
-				result = append(result, anthropic.NewAssistantMessage(
-					anthropic.NewTextBlock(msg.GetContentString()),
-				))
-			}
-
-		case providers.RoleTool:
-			result = append(result, anthropic.NewUserMessage(
-				anthropic.NewToolResultBlock(msg.ToolCallID, msg.GetContentString(), false),
-			))
 		}
+
+		if err := stream.Err(); err != nil {
+			errs <- errors.Convert(providerName, err)
+		}
+	}()
+
+	return chunks, errs
+}
+
+// Name returns the provider name.
+func (p *Provider) Name() string {
+	return providerName
+}
+
+// newStreamState creates a new stream state with default values.
+func newStreamState() *streamState {
+	return &streamState{
+		currentToolIdx: -1,
+	}
+}
+
+// chunk creates a ChatCompletionChunk with the given delta.
+func (s *streamState) chunk(delta providers.ChunkDelta) providers.ChatCompletionChunk {
+	return providers.ChatCompletionChunk{
+		ID:     s.messageID,
+		Object: "chat.completion.chunk",
+		Model:  s.model,
+		Choices: []providers.ChunkChoice{{
+			Index: 0,
+			Delta: delta,
+		}},
+	}
+}
+
+// handleContentBlockDelta processes a content_block_delta event and returns a chunk if applicable.
+func (s *streamState) handleContentBlockDelta(event anthropic.ContentBlockDeltaEvent) *providers.ChatCompletionChunk {
+	switch event.Delta.Type {
+	case deltaTypeText:
+		return s.handleTextDelta(event.Delta.Text)
+	case deltaTypeThinking:
+		return s.handleThinkingDelta(event.Delta.Thinking)
+	case deltaTypeInputJSON:
+		return s.handleInputJSONDelta(event.Delta.PartialJSON)
+	default:
+		return nil
+	}
+}
+
+// handleContentBlockStart processes a content_block_start event.
+func (s *streamState) handleContentBlockStart(event anthropic.ContentBlockStartEvent) {
+	switch event.ContentBlock.Type {
+	case blockTypeThinking:
+		// Reasoning block started - no action needed.
+	case blockTypeToolUse:
+		s.currentToolIdx++
+		// TODO: Extract to newToolCallFromBlock() if this pattern is needed elsewhere.
+		tc := providers.ToolCall{
+			ID:   event.ContentBlock.ID,
+			Type: "function",
+			Function: providers.FunctionCall{
+				Name: event.ContentBlock.Name,
+			},
+		}
+		s.toolCalls = append(s.toolCalls, tc)
+	}
+}
+
+// handleInputJSONDelta processes a tool input JSON delta and returns a chunk if applicable.
+func (s *streamState) handleInputJSONDelta(partialJSON string) *providers.ChatCompletionChunk {
+	if s.currentToolIdx < 0 || s.currentToolIdx >= len(s.toolCalls) {
+		return nil
 	}
 
-	return result, strings.Join(systemParts, "\n")
+	s.toolCalls[s.currentToolIdx].Function.Arguments += partialJSON
+	chunk := s.chunk(providers.ChunkDelta{
+		ToolCalls: []providers.ToolCall{s.toolCalls[s.currentToolIdx]},
+	})
+	return &chunk
+}
+
+// handleMessageDelta processes a message_delta event and returns the final chunk.
+func (s *streamState) handleMessageDelta(event anthropic.MessageDeltaEvent) providers.ChatCompletionChunk {
+	finishReason := convertStopReason(string(event.Delta.StopReason))
+	chunk := s.chunk(providers.ChunkDelta{})
+	chunk.Choices[0].FinishReason = finishReason
+	chunk.Usage = &providers.Usage{
+		PromptTokens:     int(s.inputUsage),
+		CompletionTokens: int(event.Usage.OutputTokens),
+		TotalTokens:      int(s.inputUsage + event.Usage.OutputTokens),
+	}
+	return chunk
+}
+
+// handleMessageStart processes a message_start event and returns the initial chunk.
+func (s *streamState) handleMessageStart(event anthropic.MessageStartEvent) providers.ChatCompletionChunk {
+	s.messageID = event.Message.ID
+	s.model = string(event.Message.Model)
+	s.inputUsage = event.Message.Usage.InputTokens
+
+	return s.chunk(providers.ChunkDelta{Role: providers.RoleAssistant})
+}
+
+// handleThinkingDelta processes a thinking delta and returns a chunk.
+func (s *streamState) handleThinkingDelta(thinking string) *providers.ChatCompletionChunk {
+	s.reasoning.WriteString(thinking)
+	chunk := s.chunk(providers.ChunkDelta{
+		Reasoning: &providers.Reasoning{Content: thinking},
+	})
+	return &chunk
+}
+
+// handleTextDelta processes a text delta and returns a chunk.
+func (s *streamState) handleTextDelta(text string) *providers.ChatCompletionChunk {
+	s.content.WriteString(text)
+	chunk := s.chunk(providers.ChunkDelta{Content: text})
+	return &chunk
+}
+
+// applyThinking configures thinking/reasoning on the request if applicable.
+func applyThinking(req *anthropic.MessageNewParams, effort providers.ReasoningEffort, maxTokens int64) {
+	if effort == "" || effort == providers.ReasoningEffortNone {
+		return
+	}
+
+	budget, ok := thinkingBudget(effort)
+	if !ok {
+		return
+	}
+
+	req.Thinking = anthropic.ThinkingConfigParamOfEnabled(budget)
+
+	// Increase max tokens to accommodate thinking.
+	minTokens := budget * 2
+	if maxTokens < minTokens {
+		req.MaxTokens = minTokens
+	}
+}
+
+// convertAssistantMessage converts an assistant message to Anthropic format.
+func convertAssistantMessage(msg providers.Message) *anthropic.MessageParam {
+	if len(msg.ToolCalls) == 0 {
+		m := anthropic.NewAssistantMessage(anthropic.NewTextBlock(msg.GetContentString()))
+		return &m
+	}
+
+	content := make([]anthropic.ContentBlockParamUnion, 0)
+	if msg.GetContentString() != "" {
+		content = append(content, anthropic.NewTextBlock(msg.GetContentString()))
+	}
+
+	for _, tc := range msg.ToolCalls {
+		content = append(content, convertToolCall(tc))
+	}
+
+	m := anthropic.NewAssistantMessage(content...)
+	return &m
 }
 
 // convertImagePart converts an image URL to Anthropic format.
@@ -408,7 +375,7 @@ func convertImagePart(img *providers.ImageURL) anthropic.ContentBlockParamUnion 
 
 	// Check if it's a base64 data URL.
 	if strings.HasPrefix(url, "data:") {
-		// Parse data URL: data:image/jpeg;base64,<data>
+		// Parse data URL: data:image/jpeg;base64,<data>.
 		parts := strings.SplitN(url, ",", 2)
 		if len(parts) == 2 {
 			// Extract media type from the first part.
@@ -424,76 +391,38 @@ func convertImagePart(img *providers.ImageURL) anthropic.ContentBlockParamUnion 
 	return anthropic.NewImageBlock(anthropic.URLImageSourceParam{URL: url})
 }
 
-// convertTool converts a providers.Tool to Anthropic format.
-func convertTool(tool providers.Tool) anthropic.ToolUnionParam {
-	inputSchema := anthropic.ToolInputSchemaParam{
-		Type: "object",
-	}
-	if props, ok := tool.Function.Parameters["properties"]; ok {
-		inputSchema.Properties = props
-	}
-	if req, ok := tool.Function.Parameters["required"]; ok {
-		if reqArr, ok := req.([]interface{}); ok {
-			required := make([]string, len(reqArr))
-			for i, r := range reqArr {
-				if s, ok := r.(string); ok {
-					required[i] = s
-				}
-			}
-			inputSchema.Required = required
-		}
-	}
-
-	return anthropic.ToolUnionParam{
-		OfTool: &anthropic.ToolParam{
-			Name:        tool.Function.Name,
-			Description: anthropic.String(tool.Function.Description),
-			InputSchema: inputSchema,
-		},
+// convertMessage converts a single message to Anthropic format.
+func convertMessage(msg providers.Message) *anthropic.MessageParam {
+	switch msg.Role {
+	case providers.RoleUser:
+		return convertUserMessage(msg)
+	case providers.RoleAssistant:
+		return convertAssistantMessage(msg)
+	case providers.RoleTool:
+		return convertToolMessage(msg)
+	default:
+		return nil
 	}
 }
 
-// convertToolChoice converts providers tool choice to Anthropic format.
-func convertToolChoice(choice any, parallelToolCalls *bool) anthropic.ToolChoiceUnionParam {
-	disableParallel := parallelToolCalls != nil && !*parallelToolCalls
+// convertMessages converts providers messages to Anthropic format.
+// Returns the messages and the combined system message.
+func convertMessages(messages []providers.Message) ([]anthropic.MessageParam, string) {
+	result := make([]anthropic.MessageParam, 0, len(messages))
+	var systemParts []string
 
-	switch v := choice.(type) {
-	case string:
-		switch v {
-		case "auto":
-			return anthropic.ToolChoiceUnionParam{
-				OfAuto: &anthropic.ToolChoiceAutoParam{
-					DisableParallelToolUse: anthropic.Bool(disableParallel),
-				},
-			}
-		case "none":
-			// Anthropic has "none" now.
-			return anthropic.ToolChoiceUnionParam{
-				OfNone: &anthropic.ToolChoiceNoneParam{},
-			}
-		case "required", "any":
-			return anthropic.ToolChoiceUnionParam{
-				OfAny: &anthropic.ToolChoiceAnyParam{
-					DisableParallelToolUse: anthropic.Bool(disableParallel),
-				},
-			}
+	for _, msg := range messages {
+		if msg.Role == providers.RoleSystem {
+			systemParts = append(systemParts, msg.GetContentString())
+			continue
 		}
-	case providers.ToolChoice:
-		if v.Function != nil {
-			return anthropic.ToolChoiceUnionParam{
-				OfTool: &anthropic.ToolChoiceToolParam{
-					Name:                   v.Function.Name,
-					DisableParallelToolUse: anthropic.Bool(disableParallel),
-				},
-			}
+
+		if converted := convertMessage(msg); converted != nil {
+			result = append(result, *converted)
 		}
 	}
 
-	return anthropic.ToolChoiceUnionParam{
-		OfAuto: &anthropic.ToolChoiceAutoParam{
-			DisableParallelToolUse: anthropic.Bool(disableParallel),
-		},
-	}
+	return result, strings.Join(systemParts, "\n")
 }
 
 // convertResponse converts an Anthropic response to providers format.
@@ -567,5 +496,136 @@ func convertStopReason(reason string) string {
 		return providers.FinishReasonStop
 	default:
 		return providers.FinishReasonStop
+	}
+}
+
+// convertTool converts a providers.Tool to Anthropic format.
+func convertTool(tool providers.Tool) anthropic.ToolUnionParam {
+	inputSchema := anthropic.ToolInputSchemaParam{
+		Type: "object",
+	}
+	if props, ok := tool.Function.Parameters["properties"]; ok {
+		inputSchema.Properties = props
+	}
+	if req, ok := tool.Function.Parameters["required"]; ok {
+		if reqArr, ok := req.([]interface{}); ok {
+			required := make([]string, len(reqArr))
+			for i, r := range reqArr {
+				if s, ok := r.(string); ok {
+					required[i] = s
+				}
+			}
+			inputSchema.Required = required
+		}
+	}
+
+	return anthropic.ToolUnionParam{
+		OfTool: &anthropic.ToolParam{
+			Name:        tool.Function.Name,
+			Description: anthropic.String(tool.Function.Description),
+			InputSchema: inputSchema,
+		},
+	}
+}
+
+// convertToolCall converts a tool call to Anthropic content block format.
+func convertToolCall(tc providers.ToolCall) anthropic.ContentBlockParamUnion {
+	var input map[string]any
+	_ = json.Unmarshal([]byte(tc.Function.Arguments), &input) // Ignore error: use nil on failure.
+
+	return anthropic.ContentBlockParamUnion{
+		OfToolUse: &anthropic.ToolUseBlockParam{
+			Type:  "tool_use",
+			ID:    tc.ID,
+			Name:  tc.Function.Name,
+			Input: input,
+		},
+	}
+}
+
+// convertToolChoice converts providers tool choice to Anthropic format.
+func convertToolChoice(choice any, parallelToolCalls *bool) anthropic.ToolChoiceUnionParam {
+	disableParallel := parallelToolCalls != nil && !*parallelToolCalls
+
+	switch v := choice.(type) {
+	case string:
+		switch v {
+		case "auto":
+			return anthropic.ToolChoiceUnionParam{
+				OfAuto: &anthropic.ToolChoiceAutoParam{
+					DisableParallelToolUse: anthropic.Bool(disableParallel),
+				},
+			}
+		case "none":
+			return anthropic.ToolChoiceUnionParam{
+				OfNone: &anthropic.ToolChoiceNoneParam{},
+			}
+		case "required", "any":
+			return anthropic.ToolChoiceUnionParam{
+				OfAny: &anthropic.ToolChoiceAnyParam{
+					DisableParallelToolUse: anthropic.Bool(disableParallel),
+				},
+			}
+		}
+	case providers.ToolChoice:
+		if v.Function != nil {
+			return anthropic.ToolChoiceUnionParam{
+				OfTool: &anthropic.ToolChoiceToolParam{
+					Name:                   v.Function.Name,
+					DisableParallelToolUse: anthropic.Bool(disableParallel),
+				},
+			}
+		}
+	}
+
+	return anthropic.ToolChoiceUnionParam{
+		OfAuto: &anthropic.ToolChoiceAutoParam{
+			DisableParallelToolUse: anthropic.Bool(disableParallel),
+		},
+	}
+}
+
+// convertToolMessage converts a tool result message to Anthropic format.
+func convertToolMessage(msg providers.Message) *anthropic.MessageParam {
+	m := anthropic.NewUserMessage(
+		anthropic.NewToolResultBlock(msg.ToolCallID, msg.GetContentString(), false),
+	)
+	return &m
+}
+
+// convertUserMessage converts a user message to Anthropic format.
+func convertUserMessage(msg providers.Message) *anthropic.MessageParam {
+	if !msg.IsMultiModal() {
+		m := anthropic.NewUserMessage(anthropic.NewTextBlock(msg.GetContentString()))
+		return &m
+	}
+
+	content := make([]anthropic.ContentBlockParamUnion, 0)
+	for _, part := range msg.GetContentParts() {
+		switch part.Type {
+		case "text":
+			content = append(content, anthropic.NewTextBlock(part.Text))
+		case "image_url":
+			if part.ImageURL != nil {
+				content = append(content, convertImagePart(part.ImageURL))
+			}
+		}
+	}
+	m := anthropic.NewUserMessage(content...)
+	return &m
+}
+
+// thinkingBudget returns the token budget for the given reasoning effort.
+// Returns the budget and true if the effort level is supported, or 0 and false otherwise.
+func thinkingBudget(effort providers.ReasoningEffort) (int64, bool) {
+	switch effort {
+	case providers.ReasoningEffortLow:
+		return 1024, true
+	case providers.ReasoningEffortMedium:
+		return 4096, true
+	case providers.ReasoningEffortHigh:
+		return 16384, true
+	default:
+		return 0, false
 	}
 }


### PR DESCRIPTION
## Summary

- Extract `streamState` struct to track accumulated state during streaming
- Add handler methods for different event types (text delta, thinking delta, etc.)
- Add `chunk()` helper method to reduce duplication in chunk creation
- Extract `applyThinking()` function with early returns pattern
- Simplify `convertMessages()` by extracting per-role helper functions
- Reorganize file structure following Go conventions
- Add comprehensive table-driven unit tests for new functions
- Add `t.Parallel()` to unit tests for faster execution

## Test plan

- [x] All existing tests pass
- [x] New unit tests added for extracted functions
- [x] Linting passes with no issues