### PR TITLE
test: Improve test parallelism and consistency

### DIFF
--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/any-llm-go/config"
@@ -19,8 +18,8 @@ func TestNew(t *testing.T) {
 	t.Run("creates provider with API key", func(t *testing.T) {
 		provider, err := New(config.WithAPIKey("test-api-key"))
 		require.NoError(t, err)
-		assert.NotNil(t, provider)
-		assert.Equal(t, "anthropic", provider.Name())
+		require.NotNil(t, provider)
+		require.Equal(t, "anthropic", provider.Name())
 	})
 
 	t.Run("creates provider from environment variable", func(t *testing.T) {
@@ -28,20 +27,20 @@ func TestNew(t *testing.T) {
 
 		provider, err := New()
 		require.NoError(t, err)
-		assert.NotNil(t, provider)
+		require.NotNil(t, provider)
 	})
 
 	t.Run("returns error when API key is missing", func(t *testing.T) {
 		t.Setenv("ANTHROPIC_API_KEY", "")
 
 		provider, err := New()
-		assert.Nil(t, provider)
-		assert.Error(t, err)
+		require.Nil(t, provider)
+		require.Error(t, err)
 
 		var missingKeyErr *errors.MissingAPIKeyError
-		assert.ErrorAs(t, err, &missingKeyErr)
-		assert.Equal(t, "anthropic", missingKeyErr.Provider)
-		assert.Equal(t, "ANTHROPIC_API_KEY", missingKeyErr.EnvVar)
+		require.ErrorAs(t, err, &missingKeyErr)
+		require.Equal(t, "anthropic", missingKeyErr.Provider)
+		require.Equal(t, "ANTHROPIC_API_KEY", missingKeyErr.EnvVar)
 	})
 }
 
@@ -53,13 +52,13 @@ func TestCapabilities(t *testing.T) {
 
 	caps := provider.Capabilities()
 
-	assert.True(t, caps.Completion)
-	assert.True(t, caps.CompletionStreaming)
-	assert.True(t, caps.CompletionReasoning)
-	assert.True(t, caps.CompletionImage)
-	assert.True(t, caps.CompletionPDF)
-	assert.False(t, caps.Embedding) // Anthropic doesn't support embeddings.
-	assert.False(t, caps.ListModels)
+	require.True(t, caps.Completion)
+	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.CompletionReasoning)
+	require.True(t, caps.CompletionImage)
+	require.True(t, caps.CompletionPDF)
+	require.False(t, caps.Embedding) // Anthropic doesn't support embeddings.
+	require.False(t, caps.ListModels)
 }
 
 func TestConvertMessages(t *testing.T) {
@@ -75,8 +74,8 @@ func TestConvertMessages(t *testing.T) {
 
 		result, system := convertMessages(messages)
 
-		assert.Equal(t, "You are a helpful assistant.", system)
-		assert.Len(t, result, 1) // Only user message.
+		require.Equal(t, "You are a helpful assistant.", system)
+		require.Len(t, result, 1) // Only user message.
 	})
 
 	t.Run("concatenates multiple system messages", func(t *testing.T) {
@@ -90,8 +89,8 @@ func TestConvertMessages(t *testing.T) {
 
 		result, system := convertMessages(messages)
 
-		assert.Equal(t, "First part.\nSecond part.", system)
-		assert.Len(t, result, 1)
+		require.Equal(t, "First part.\nSecond part.", system)
+		require.Len(t, result, 1)
 	})
 
 	t.Run("converts user message", func(t *testing.T) {
@@ -103,8 +102,8 @@ func TestConvertMessages(t *testing.T) {
 
 		result, system := convertMessages(messages)
 
-		assert.Empty(t, system)
-		assert.Len(t, result, 1)
+		require.Empty(t, system)
+		require.Len(t, result, 1)
 	})
 
 	t.Run("converts assistant message", func(t *testing.T) {
@@ -117,8 +116,8 @@ func TestConvertMessages(t *testing.T) {
 
 		result, system := convertMessages(messages)
 
-		assert.Empty(t, system)
-		assert.Len(t, result, 2)
+		require.Empty(t, system)
+		require.Len(t, result, 2)
 	})
 
 	t.Run("converts assistant message with tool calls", func(t *testing.T) {
@@ -144,7 +143,7 @@ func TestConvertMessages(t *testing.T) {
 
 		result, _ := convertMessages(messages)
 
-		assert.Len(t, result, 2)
+		require.Len(t, result, 2)
 	})
 
 	t.Run("converts tool result to user message", func(t *testing.T) {
@@ -168,7 +167,7 @@ func TestConvertMessages(t *testing.T) {
 
 		result, _ := convertMessages(messages)
 
-		assert.Len(t, result, 3)
+		require.Len(t, result, 3)
 	})
 }
 
@@ -180,7 +179,7 @@ func TestConvertImagePart(t *testing.T) {
 
 		img := &providers.ImageURL{URL: "https://example.com/image.png"}
 		result := convertImagePart(img)
-		assert.NotNil(t, result)
+		require.NotNil(t, result)
 	})
 
 	t.Run("converts base64 image", func(t *testing.T) {
@@ -188,7 +187,7 @@ func TestConvertImagePart(t *testing.T) {
 
 		img := &providers.ImageURL{URL: "data:image/jpeg;base64,/9j/4AAQSkZJRg=="}
 		result := convertImagePart(img)
-		assert.NotNil(t, result)
+		require.NotNil(t, result)
 	})
 }
 
@@ -232,7 +231,7 @@ func TestConvertStopReason(t *testing.T) {
 			t.Parallel()
 
 			result := convertStopReason(tc.input)
-			assert.Equal(t, tc.expected, result)
+			require.Equal(t, tc.expected, result)
 		})
 	}
 }
@@ -241,11 +240,11 @@ func TestNewStreamState(t *testing.T) {
 	t.Parallel()
 
 	state := newStreamState()
-	assert.NotNil(t, state)
-	assert.Equal(t, -1, state.currentToolIdx)
-	assert.Empty(t, state.messageID)
-	assert.Empty(t, state.model)
-	assert.Nil(t, state.toolCalls)
+	require.NotNil(t, state)
+	require.Equal(t, -1, state.currentToolIdx)
+	require.Empty(t, state.messageID)
+	require.Empty(t, state.model)
+	require.Nil(t, state.toolCalls)
 }
 
 func TestStreamStateHandleTextDelta(t *testing.T) {
@@ -257,17 +256,17 @@ func TestStreamStateHandleTextDelta(t *testing.T) {
 
 	chunk := state.handleTextDelta("Hello ")
 	require.NotNil(t, chunk)
-	assert.Equal(t, "msg_123", chunk.ID)
-	assert.Equal(t, "claude-3", chunk.Model)
-	assert.Equal(t, "chat.completion.chunk", chunk.Object)
+	require.Equal(t, "msg_123", chunk.ID)
+	require.Equal(t, "claude-3", chunk.Model)
+	require.Equal(t, "chat.completion.chunk", chunk.Object)
 	require.Len(t, chunk.Choices, 1)
-	assert.Equal(t, "Hello ", chunk.Choices[0].Delta.Content)
+	require.Equal(t, "Hello ", chunk.Choices[0].Delta.Content)
 
 	// Verify content is accumulated.
 	chunk2 := state.handleTextDelta("world!")
 	require.NotNil(t, chunk2)
-	assert.Equal(t, "world!", chunk2.Choices[0].Delta.Content)
-	assert.Equal(t, "Hello world!", state.content.String())
+	require.Equal(t, "world!", chunk2.Choices[0].Delta.Content)
+	require.Equal(t, "Hello world!", state.content.String())
 }
 
 func TestStreamStateHandleThinkingDelta(t *testing.T) {
@@ -279,13 +278,13 @@ func TestStreamStateHandleThinkingDelta(t *testing.T) {
 
 	chunk := state.handleThinkingDelta("Let me think...")
 	require.NotNil(t, chunk)
-	assert.Equal(t, "msg_123", chunk.ID)
+	require.Equal(t, "msg_123", chunk.ID)
 	require.Len(t, chunk.Choices, 1)
 	require.NotNil(t, chunk.Choices[0].Delta.Reasoning)
-	assert.Equal(t, "Let me think...", chunk.Choices[0].Delta.Reasoning.Content)
+	require.Equal(t, "Let me think...", chunk.Choices[0].Delta.Reasoning.Content)
 
 	// Verify reasoning is accumulated.
-	assert.Equal(t, "Let me think...", state.reasoning.String())
+	require.Equal(t, "Let me think...", state.reasoning.String())
 }
 
 func TestStreamStateHandleInputJSONDelta(t *testing.T) {
@@ -296,7 +295,7 @@ func TestStreamStateHandleInputJSONDelta(t *testing.T) {
 
 		state := newStreamState()
 		chunk := state.handleInputJSONDelta(`{"key":`)
-		assert.Nil(t, chunk)
+		require.Nil(t, chunk)
 	})
 
 	t.Run("returns nil when tool index out of bounds", func(t *testing.T) {
@@ -308,7 +307,7 @@ func TestStreamStateHandleInputJSONDelta(t *testing.T) {
 			{ID: "call_1", Type: "function", Function: providers.FunctionCall{Name: "get_weather", Arguments: ""}},
 		}
 		chunk := state.handleInputJSONDelta(`{"key":`)
-		assert.Nil(t, chunk)
+		require.Nil(t, chunk)
 	})
 
 	t.Run("appends to current tool call arguments", func(t *testing.T) {
@@ -324,11 +323,11 @@ func TestStreamStateHandleInputJSONDelta(t *testing.T) {
 
 		chunk := state.handleInputJSONDelta(`{"location":`)
 		require.NotNil(t, chunk)
-		assert.Equal(t, `{"location":`, state.toolCalls[0].Function.Arguments)
+		require.Equal(t, `{"location":`, state.toolCalls[0].Function.Arguments)
 
 		chunk2 := state.handleInputJSONDelta(`"Paris"}`)
 		require.NotNil(t, chunk2)
-		assert.Equal(t, `{"location":"Paris"}`, state.toolCalls[0].Function.Arguments)
+		require.Equal(t, `{"location":"Paris"}`, state.toolCalls[0].Function.Arguments)
 	})
 }
 
@@ -399,9 +398,9 @@ func TestApplyThinking(t *testing.T) {
 
 			req := &anthropic.MessageNewParams{MaxTokens: tc.initialMaxTokens}
 			applyThinking(req, tc.effort, tc.initialMaxTokens)
-			assert.Equal(t, tc.expectedMaxTokens, req.MaxTokens)
+			require.Equal(t, tc.expectedMaxTokens, req.MaxTokens)
 			if tc.expectThinking {
-				assert.NotNil(t, req.Thinking)
+				require.NotNil(t, req.Thinking)
 			}
 		})
 	}
@@ -448,9 +447,9 @@ func TestConvertMessage(t *testing.T) {
 
 			result := convertMessage(tc.msg)
 			if tc.expectNil {
-				assert.Nil(t, result)
+				require.Nil(t, result)
 			} else {
-				assert.NotNil(t, result)
+				require.NotNil(t, result)
 			}
 		})
 	}
@@ -508,13 +507,13 @@ func TestConvertToolCall(t *testing.T) {
 
 			result := convertToolCall(tc.toolCall)
 			require.NotNil(t, result.OfToolUse)
-			assert.Equal(t, tc.toolCall.ID, result.OfToolUse.ID)
-			assert.Equal(t, tc.toolCall.Function.Name, result.OfToolUse.Name)
-			assert.Equal(t, "tool_use", string(result.OfToolUse.Type))
+			require.Equal(t, tc.toolCall.ID, result.OfToolUse.ID)
+			require.Equal(t, tc.toolCall.Function.Name, result.OfToolUse.Name)
+			require.Equal(t, "tool_use", string(result.OfToolUse.Type))
 			if tc.expectInput {
-				assert.NotNil(t, result.OfToolUse.Input)
+				require.NotNil(t, result.OfToolUse.Input)
 			} else {
-				assert.Nil(t, result.OfToolUse.Input)
+				require.Nil(t, result.OfToolUse.Input)
 			}
 		})
 	}
@@ -566,8 +565,8 @@ func TestThinkingBudget(t *testing.T) {
 			t.Parallel()
 
 			budget, ok := thinkingBudget(tc.effort)
-			assert.Equal(t, tc.ok, ok)
-			assert.Equal(t, tc.expected, budget)
+			require.Equal(t, tc.ok, ok)
+			require.Equal(t, tc.expected, budget)
 		})
 	}
 }
@@ -575,6 +574,8 @@ func TestThinkingBudget(t *testing.T) {
 // Integration tests - only run if API key is available.
 
 func TestIntegrationCompletion(t *testing.T) {
+	t.Parallel()
+
 	if testutil.SkipIfNoAPIKey("anthropic") {
 		t.Skip("ANTHROPIC_API_KEY not set")
 	}
@@ -591,16 +592,18 @@ func TestIntegrationCompletion(t *testing.T) {
 	resp, err := provider.Completion(ctx, params)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, resp.ID)
-	assert.Equal(t, "chat.completion", resp.Object)
-	assert.Len(t, resp.Choices, 1)
-	assert.NotEmpty(t, resp.Choices[0].Message.Content)
-	assert.Equal(t, providers.RoleAssistant, resp.Choices[0].Message.Role)
-	assert.NotNil(t, resp.Usage)
-	assert.Greater(t, resp.Usage.TotalTokens, 0)
+	require.NotEmpty(t, resp.ID)
+	require.Equal(t, "chat.completion", resp.Object)
+	require.Len(t, resp.Choices, 1)
+	require.NotEmpty(t, resp.Choices[0].Message.Content)
+	require.Equal(t, providers.RoleAssistant, resp.Choices[0].Message.Role)
+	require.NotNil(t, resp.Usage)
+	require.Greater(t, resp.Usage.TotalTokens, 0)
 }
 
 func TestIntegrationCompletionWithSystemMessage(t *testing.T) {
+	t.Parallel()
+
 	if testutil.SkipIfNoAPIKey("anthropic") {
 		t.Skip("ANTHROPIC_API_KEY not set")
 	}
@@ -617,12 +620,14 @@ func TestIntegrationCompletionWithSystemMessage(t *testing.T) {
 	resp, err := provider.Completion(ctx, params)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, resp.ID)
-	assert.Len(t, resp.Choices, 1)
-	assert.NotEmpty(t, resp.Choices[0].Message.Content)
+	require.NotEmpty(t, resp.ID)
+	require.Len(t, resp.Choices, 1)
+	require.NotEmpty(t, resp.Choices[0].Message.Content)
 }
 
 func TestIntegrationCompletionStream(t *testing.T) {
+	t.Parallel()
+
 	if testutil.SkipIfNoAPIKey("anthropic") {
 		t.Skip("ANTHROPIC_API_KEY not set")
 	}
@@ -644,7 +649,7 @@ func TestIntegrationCompletionStream(t *testing.T) {
 
 	for chunk := range chunks {
 		chunkCount++
-		assert.Equal(t, "chat.completion.chunk", chunk.Object)
+		require.Equal(t, "chat.completion.chunk", chunk.Object)
 		if len(chunk.Choices) > 0 {
 			content.WriteString(chunk.Choices[0].Delta.Content)
 		}
@@ -653,11 +658,13 @@ func TestIntegrationCompletionStream(t *testing.T) {
 	err = <-errs
 	require.NoError(t, err)
 
-	assert.Greater(t, chunkCount, 0)
-	assert.NotEmpty(t, content.String())
+	require.Greater(t, chunkCount, 0)
+	require.NotEmpty(t, content.String())
 }
 
 func TestIntegrationCompletionWithTools(t *testing.T) {
+	t.Parallel()
+
 	if testutil.SkipIfNoAPIKey("anthropic") {
 		t.Skip("ANTHROPIC_API_KEY not set")
 	}
@@ -676,19 +683,21 @@ func TestIntegrationCompletionWithTools(t *testing.T) {
 	resp, err := provider.Completion(ctx, params)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, resp.ID)
-	assert.Len(t, resp.Choices, 1)
+	require.NotEmpty(t, resp.ID)
+	require.Len(t, resp.Choices, 1)
 
 	// The model should call the weather tool.
 	if len(resp.Choices[0].Message.ToolCalls) > 0 {
 		tc := resp.Choices[0].Message.ToolCalls[0]
-		assert.Equal(t, "get_weather", tc.Function.Name)
-		assert.Contains(t, strings.ToLower(tc.Function.Arguments), "paris")
-		assert.Equal(t, providers.FinishReasonToolCalls, resp.Choices[0].FinishReason)
+		require.Equal(t, "get_weather", tc.Function.Name)
+		require.Contains(t, strings.ToLower(tc.Function.Arguments), "paris")
+		require.Equal(t, providers.FinishReasonToolCalls, resp.Choices[0].FinishReason)
 	}
 }
 
 func TestIntegrationCompletionWithToolsParallelDisabled(t *testing.T) {
+	t.Parallel()
+
 	if testutil.SkipIfNoAPIKey("anthropic") {
 		t.Skip("ANTHROPIC_API_KEY not set")
 	}
@@ -711,11 +720,13 @@ func TestIntegrationCompletionWithToolsParallelDisabled(t *testing.T) {
 	resp, err := provider.Completion(ctx, params)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, resp.ID)
-	assert.Len(t, resp.Choices, 1)
+	require.NotEmpty(t, resp.ID)
+	require.Len(t, resp.Choices, 1)
 }
 
 func TestIntegrationCompletionConversation(t *testing.T) {
+	t.Parallel()
+
 	if testutil.SkipIfNoAPIKey("anthropic") {
 		t.Skip("ANTHROPIC_API_KEY not set")
 	}
@@ -732,16 +743,18 @@ func TestIntegrationCompletionConversation(t *testing.T) {
 	resp, err := provider.Completion(ctx, params)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, resp.ID)
-	assert.Len(t, resp.Choices, 1)
+	require.NotEmpty(t, resp.ID)
+	require.Len(t, resp.Choices, 1)
 
 	// The model should remember the name "Alice".
 	contentStr, ok := resp.Choices[0].Message.Content.(string)
 	require.True(t, ok, "expected string content")
-	assert.Contains(t, strings.ToLower(contentStr), "alice")
+	require.Contains(t, strings.ToLower(contentStr), "alice")
 }
 
 func TestIntegrationCompletionReasoning(t *testing.T) {
+	t.Parallel()
+
 	if testutil.SkipIfNoAPIKey("anthropic") {
 		t.Skip("ANTHROPIC_API_KEY not set")
 	}
@@ -766,17 +779,19 @@ func TestIntegrationCompletionReasoning(t *testing.T) {
 	resp, err := provider.Completion(ctx, params)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, resp.ID)
-	assert.Len(t, resp.Choices, 1)
-	assert.NotEmpty(t, resp.Choices[0].Message.Content)
+	require.NotEmpty(t, resp.ID)
+	require.Len(t, resp.Choices, 1)
+	require.NotEmpty(t, resp.Choices[0].Message.Content)
 
 	// With reasoning effort, we should get reasoning content.
 	if resp.Choices[0].Message.Reasoning != nil {
-		assert.NotEmpty(t, resp.Choices[0].Message.Reasoning.Content)
+		require.NotEmpty(t, resp.Choices[0].Message.Reasoning.Content)
 	}
 }
 
 func TestIntegrationAgentLoop(t *testing.T) {
+	t.Parallel()
+
 	if testutil.SkipIfNoAPIKey("anthropic") {
 		t.Skip("ANTHROPIC_API_KEY not set")
 	}
@@ -799,14 +814,14 @@ func TestIntegrationAgentLoop(t *testing.T) {
 	resp, err := provider.Completion(ctx, params)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, resp.ID)
-	assert.Len(t, resp.Choices, 1)
+	require.NotEmpty(t, resp.ID)
+	require.Len(t, resp.Choices, 1)
 
 	// Should have a content response (not another tool call).
 	if contentStr, ok := resp.Choices[0].Message.Content.(string); ok && contentStr != "" {
 		content := strings.ToLower(contentStr)
 		// Should mention the weather or sunny.
-		assert.True(
+		require.True(
 			t,
 			strings.Contains(content, "sunny") || strings.Contains(content, "weather") ||
 				strings.Contains(content, "salvaterra"),
@@ -815,6 +830,8 @@ func TestIntegrationAgentLoop(t *testing.T) {
 }
 
 func TestIntegrationAuthenticationError(t *testing.T) {
+	t.Parallel()
+
 	provider, err := New(config.WithAPIKey("invalid-api-key"))
 	require.NoError(t, err)
 
@@ -825,9 +842,9 @@ func TestIntegrationAuthenticationError(t *testing.T) {
 	}
 
 	_, err = provider.Completion(ctx, params)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Check that it's converted to an authentication error.
 	var authErr *errors.AuthenticationError
-	assert.ErrorAs(t, err, &authErr)
+	require.ErrorAs(t, err, &authErr)
 }

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/any-llm-go/config"
@@ -18,8 +17,8 @@ func TestNew(t *testing.T) {
 	t.Run("creates provider with API key", func(t *testing.T) {
 		provider, err := New(config.WithAPIKey("test-api-key"))
 		require.NoError(t, err)
-		assert.NotNil(t, provider)
-		assert.Equal(t, "openai", provider.Name())
+		require.NotNil(t, provider)
+		require.Equal(t, "openai", provider.Name())
 	})
 
 	t.Run("creates provider from environment variable", func(t *testing.T) {
@@ -27,39 +26,44 @@ func TestNew(t *testing.T) {
 
 		provider, err := New()
 		require.NoError(t, err)
-		assert.NotNil(t, provider)
+		require.NotNil(t, provider)
 	})
 
 	t.Run("returns error when API key is missing", func(t *testing.T) {
 		t.Setenv("OPENAI_API_KEY", "")
 
 		provider, err := New()
-		assert.Nil(t, provider)
-		assert.Error(t, err)
+		require.Nil(t, provider)
+		require.Error(t, err)
 
 		var missingKeyErr *errors.MissingAPIKeyError
-		assert.ErrorAs(t, err, &missingKeyErr)
-		assert.Equal(t, "openai", missingKeyErr.Provider)
-		assert.Equal(t, "OPENAI_API_KEY", missingKeyErr.EnvVar)
+		require.ErrorAs(t, err, &missingKeyErr)
+		require.Equal(t, "openai", missingKeyErr.Provider)
+		require.Equal(t, "OPENAI_API_KEY", missingKeyErr.EnvVar)
 	})
 }
 
 func TestCapabilities(t *testing.T) {
+	t.Parallel()
+
 	provider, err := New(config.WithAPIKey("test-key"))
 	require.NoError(t, err)
 
 	caps := provider.Capabilities()
 
-	assert.True(t, caps.Completion)
-	assert.True(t, caps.CompletionStreaming)
-	assert.True(t, caps.CompletionReasoning)
-	assert.True(t, caps.CompletionImage)
-	assert.True(t, caps.Embedding)
-	assert.True(t, caps.ListModels)
+	require.True(t, caps.Completion)
+	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.CompletionReasoning)
+	require.True(t, caps.CompletionImage)
+	require.True(t, caps.Embedding)
+	require.True(t, caps.ListModels)
 }
 
 func TestConvertParams(t *testing.T) {
+	t.Parallel()
+
 	t.Run("converts basic params", func(t *testing.T) {
+		t.Parallel()
 		params := providers.CompletionParams{
 			Model: "gpt-4",
 			Messages: []providers.Message{
@@ -69,11 +73,13 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
-		assert.Equal(t, "gpt-4", string(req.Model))
-		assert.Len(t, req.Messages, 1)
+		require.Equal(t, "gpt-4", string(req.Model))
+		require.Len(t, req.Messages, 1)
 	})
 
 	t.Run("converts temperature and top_p", func(t *testing.T) {
+		t.Parallel()
+
 		temp := 0.7
 		topP := 0.9
 		params := providers.CompletionParams{
@@ -85,11 +91,13 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
-		assert.Equal(t, 0.7, req.Temperature.Value)
-		assert.Equal(t, 0.9, req.TopP.Value)
+		require.Equal(t, 0.7, req.Temperature.Value)
+		require.Equal(t, 0.9, req.TopP.Value)
 	})
 
 	t.Run("converts max_tokens", func(t *testing.T) {
+		t.Parallel()
+
 		maxTokens := 100
 		params := providers.CompletionParams{
 			Model:     "gpt-4",
@@ -99,10 +107,12 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
-		assert.Equal(t, int64(100), req.MaxCompletionTokens.Value)
+		require.Equal(t, int64(100), req.MaxCompletionTokens.Value)
 	})
 
 	t.Run("converts stop sequences", func(t *testing.T) {
+		t.Parallel()
+
 		params := providers.CompletionParams{
 			Model:    "gpt-4",
 			Messages: testutil.SimpleMessages(),
@@ -111,10 +121,12 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
-		assert.NotNil(t, req.Stop)
+		require.NotNil(t, req.Stop)
 	})
 
 	t.Run("converts tools", func(t *testing.T) {
+		t.Parallel()
+
 		params := providers.CompletionParams{
 			Model:    "gpt-4",
 			Messages: testutil.SimpleMessages(),
@@ -123,10 +135,12 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
-		assert.Len(t, req.Tools, 1)
+		require.Len(t, req.Tools, 1)
 	})
 
 	t.Run("converts tool_choice auto", func(t *testing.T) {
+		t.Parallel()
+
 		params := providers.CompletionParams{
 			Model:      "gpt-4",
 			Messages:   testutil.SimpleMessages(),
@@ -136,10 +150,12 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
-		assert.NotNil(t, req.ToolChoice)
+		require.NotNil(t, req.ToolChoice)
 	})
 
 	t.Run("converts tool_choice required", func(t *testing.T) {
+		t.Parallel()
+
 		params := providers.CompletionParams{
 			Model:      "gpt-4",
 			Messages:   testutil.SimpleMessages(),
@@ -149,10 +165,12 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
-		assert.NotNil(t, req.ToolChoice)
+		require.NotNil(t, req.ToolChoice)
 	})
 
 	t.Run("converts tool_choice with specific function", func(t *testing.T) {
+		t.Parallel()
+
 		params := providers.CompletionParams{
 			Model:    "gpt-4",
 			Messages: testutil.SimpleMessages(),
@@ -165,10 +183,12 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
-		assert.NotNil(t, req.ToolChoice)
+		require.NotNil(t, req.ToolChoice)
 	})
 
 	t.Run("converts response_format json_object", func(t *testing.T) {
+		t.Parallel()
+
 		params := providers.CompletionParams{
 			Model:    "gpt-4",
 			Messages: testutil.SimpleMessages(),
@@ -179,10 +199,12 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
-		assert.NotNil(t, req.ResponseFormat)
+		require.NotNil(t, req.ResponseFormat)
 	})
 
 	t.Run("converts reasoning_effort", func(t *testing.T) {
+		t.Parallel()
+
 		params := providers.CompletionParams{
 			Model:           "o1-mini",
 			Messages:        testutil.SimpleMessages(),
@@ -191,10 +213,12 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
-		assert.NotNil(t, req.ReasoningEffort)
+		require.NotNil(t, req.ReasoningEffort)
 	})
 
 	t.Run("converts seed", func(t *testing.T) {
+		t.Parallel()
+
 		seed := 42
 		params := providers.CompletionParams{
 			Model:    "gpt-4",
@@ -204,10 +228,12 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
-		assert.Equal(t, int64(42), req.Seed.Value)
+		require.Equal(t, int64(42), req.Seed.Value)
 	})
 
 	t.Run("converts user", func(t *testing.T) {
+		t.Parallel()
+
 		params := providers.CompletionParams{
 			Model:    "gpt-4",
 			Messages: testutil.SimpleMessages(),
@@ -216,30 +242,40 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
-		assert.Equal(t, "test-user", req.User.Value)
+		require.Equal(t, "test-user", req.User.Value)
 	})
 }
 
 func TestConvertMessage(t *testing.T) {
+	t.Parallel()
+
 	t.Run("converts system message", func(t *testing.T) {
+		t.Parallel()
+
 		msg := providers.Message{Role: providers.RoleSystem, Content: "You are helpful"}
 		result := convertMessage(msg)
-		assert.NotNil(t, result)
+		require.NotNil(t, result)
 	})
 
 	t.Run("converts user message", func(t *testing.T) {
+		t.Parallel()
+
 		msg := providers.Message{Role: providers.RoleUser, Content: "Hello"}
 		result := convertMessage(msg)
-		assert.NotNil(t, result)
+		require.NotNil(t, result)
 	})
 
 	t.Run("converts assistant message", func(t *testing.T) {
+		t.Parallel()
+
 		msg := providers.Message{Role: providers.RoleAssistant, Content: "Hi there!"}
 		result := convertMessage(msg)
-		assert.NotNil(t, result)
+		require.NotNil(t, result)
 	})
 
 	t.Run("converts assistant message with tool calls", func(t *testing.T) {
+		t.Parallel()
+
 		msg := providers.Message{
 			Role:    providers.RoleAssistant,
 			Content: "",
@@ -255,20 +291,24 @@ func TestConvertMessage(t *testing.T) {
 			},
 		}
 		result := convertMessage(msg)
-		assert.NotNil(t, result)
+		require.NotNil(t, result)
 	})
 
 	t.Run("converts tool result message", func(t *testing.T) {
+		t.Parallel()
+
 		msg := providers.Message{
 			Role:       providers.RoleTool,
 			Content:    "sunny, 22°C",
 			ToolCallID: "call_123",
 		}
 		result := convertMessage(msg)
-		assert.NotNil(t, result)
+		require.NotNil(t, result)
 	})
 
 	t.Run("converts multimodal user message", func(t *testing.T) {
+		t.Parallel()
+
 		msg := providers.Message{
 			Role: providers.RoleUser,
 			Content: []providers.ContentPart{
@@ -277,12 +317,15 @@ func TestConvertMessage(t *testing.T) {
 			},
 		}
 		result := convertMessage(msg)
-		assert.NotNil(t, result)
+		require.NotNil(t, result)
 	})
 }
 
 func TestConvertResponse(t *testing.T) {
+	t.Parallel()
+
 	t.Run("converts basic response", func(t *testing.T) {
+		t.Parallel()
 		// We can't easily test this without mocking the OpenAI SDK response.
 		// This would be tested in integration tests.
 	})
@@ -291,6 +334,8 @@ func TestConvertResponse(t *testing.T) {
 // Integration tests - only run if API key is available.
 
 func TestIntegrationCompletion(t *testing.T) {
+	t.Parallel()
+
 	if testutil.SkipIfNoAPIKey("openai") {
 		t.Skip("OPENAI_API_KEY not set")
 	}
@@ -307,16 +352,18 @@ func TestIntegrationCompletion(t *testing.T) {
 	resp, err := provider.Completion(ctx, params)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, resp.ID)
-	assert.Equal(t, "chat.completion", resp.Object)
-	assert.Len(t, resp.Choices, 1)
-	assert.NotEmpty(t, resp.Choices[0].Message.Content)
-	assert.Equal(t, providers.RoleAssistant, resp.Choices[0].Message.Role)
-	assert.NotNil(t, resp.Usage)
-	assert.Greater(t, resp.Usage.TotalTokens, 0)
+	require.NotEmpty(t, resp.ID)
+	require.Equal(t, "chat.completion", resp.Object)
+	require.Len(t, resp.Choices, 1)
+	require.NotEmpty(t, resp.Choices[0].Message.Content)
+	require.Equal(t, providers.RoleAssistant, resp.Choices[0].Message.Role)
+	require.NotNil(t, resp.Usage)
+	require.Greater(t, resp.Usage.TotalTokens, 0)
 }
 
 func TestIntegrationCompletionStream(t *testing.T) {
+	t.Parallel()
+
 	if testutil.SkipIfNoAPIKey("openai") {
 		t.Skip("OPENAI_API_KEY not set")
 	}
@@ -338,7 +385,7 @@ func TestIntegrationCompletionStream(t *testing.T) {
 
 	for chunk := range chunks {
 		chunkCount++
-		assert.Equal(t, "chat.completion.chunk", chunk.Object)
+		require.Equal(t, "chat.completion.chunk", chunk.Object)
 		if len(chunk.Choices) > 0 {
 			content.WriteString(chunk.Choices[0].Delta.Content)
 		}
@@ -347,11 +394,13 @@ func TestIntegrationCompletionStream(t *testing.T) {
 	err = <-errs
 	require.NoError(t, err)
 
-	assert.Greater(t, chunkCount, 0)
-	assert.NotEmpty(t, content.String())
+	require.Greater(t, chunkCount, 0)
+	require.NotEmpty(t, content.String())
 }
 
 func TestIntegrationCompletionWithTools(t *testing.T) {
+	t.Parallel()
+
 	if testutil.SkipIfNoAPIKey("openai") {
 		t.Skip("OPENAI_API_KEY not set")
 	}
@@ -370,19 +419,21 @@ func TestIntegrationCompletionWithTools(t *testing.T) {
 	resp, err := provider.Completion(ctx, params)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, resp.ID)
-	assert.Len(t, resp.Choices, 1)
+	require.NotEmpty(t, resp.ID)
+	require.Len(t, resp.Choices, 1)
 
 	// The model should call the weather tool.
 	if len(resp.Choices[0].Message.ToolCalls) > 0 {
 		tc := resp.Choices[0].Message.ToolCalls[0]
-		assert.Equal(t, "get_weather", tc.Function.Name)
-		assert.Contains(t, tc.Function.Arguments, "Paris")
-		assert.Equal(t, providers.FinishReasonToolCalls, resp.Choices[0].FinishReason)
+		require.Equal(t, "get_weather", tc.Function.Name)
+		require.Contains(t, tc.Function.Arguments, "Paris")
+		require.Equal(t, providers.FinishReasonToolCalls, resp.Choices[0].FinishReason)
 	}
 }
 
 func TestIntegrationCompletionConversation(t *testing.T) {
+	t.Parallel()
+
 	if testutil.SkipIfNoAPIKey("openai") {
 		t.Skip("OPENAI_API_KEY not set")
 	}
@@ -399,16 +450,18 @@ func TestIntegrationCompletionConversation(t *testing.T) {
 	resp, err := provider.Completion(ctx, params)
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, resp.ID)
-	assert.Len(t, resp.Choices, 1)
+	require.NotEmpty(t, resp.ID)
+	require.Len(t, resp.Choices, 1)
 
 	// The model should remember the name "Alice".
 	contentStr, ok := resp.Choices[0].Message.Content.(string)
 	require.True(t, ok, "expected string content")
-	assert.Contains(t, strings.ToLower(contentStr), "alice")
+	require.Contains(t, strings.ToLower(contentStr), "alice")
 }
 
 func TestIntegrationEmbedding(t *testing.T) {
+	t.Parallel()
+
 	if testutil.SkipIfNoAPIKey("openai") {
 		t.Skip("OPENAI_API_KEY not set")
 	}
@@ -425,13 +478,15 @@ func TestIntegrationEmbedding(t *testing.T) {
 	resp, err := provider.Embedding(ctx, params)
 	require.NoError(t, err)
 
-	assert.Equal(t, "list", resp.Object)
-	assert.Len(t, resp.Data, 1)
-	assert.Greater(t, len(resp.Data[0].Embedding), 0)
-	assert.NotNil(t, resp.Usage)
+	require.Equal(t, "list", resp.Object)
+	require.Len(t, resp.Data, 1)
+	require.Greater(t, len(resp.Data[0].Embedding), 0)
+	require.NotNil(t, resp.Usage)
 }
 
 func TestIntegrationListModels(t *testing.T) {
+	t.Parallel()
+
 	if testutil.SkipIfNoAPIKey("openai") {
 		t.Skip("OPENAI_API_KEY not set")
 	}
@@ -443,8 +498,8 @@ func TestIntegrationListModels(t *testing.T) {
 	resp, err := provider.ListModels(ctx)
 	require.NoError(t, err)
 
-	assert.Equal(t, "list", resp.Object)
-	assert.Greater(t, len(resp.Data), 0)
+	require.Equal(t, "list", resp.Object)
+	require.Greater(t, len(resp.Data), 0)
 
 	// Check that some expected models are present.
 	modelIDs := make([]string, len(resp.Data))
@@ -460,10 +515,12 @@ func TestIntegrationListModels(t *testing.T) {
 			break
 		}
 	}
-	assert.True(t, found, "Expected to find GPT models in the list")
+	require.True(t, found, "Expected to find GPT models in the list")
 }
 
 func TestIntegrationAuthenticationError(t *testing.T) {
+	t.Parallel()
+
 	provider, err := New(config.WithAPIKey("invalid-api-key"))
 	require.NoError(t, err)
 
@@ -474,9 +531,9 @@ func TestIntegrationAuthenticationError(t *testing.T) {
 	}
 
 	_, err = provider.Completion(ctx, params)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Check that it's converted to an authentication error.
 	var authErr *errors.AuthenticationError
-	assert.ErrorAs(t, err, &authErr)
+	require.ErrorAs(t, err, &authErr)
 }


### PR DESCRIPTION
## Summary
- Add `t.Parallel()` to all test functions and subtests where safe
- Replace `assert` with `require` for fail-fast behavior  
- Rename `tt` to `tc` for test case variables per project conventions

## Test plan
- [x] All tests pass with `go test ./...`
- [x] Tests pass with `-race` flag enabled
- [x] Linter passes with `golangci-lint run`

Note: Tests using `t.Setenv()` cannot be parallelized due to Go test framework constraints, so those are left sequential.