### PR TITLE
Fix argument order in OpenAI tool function call

### DIFF
--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -434,7 +434,7 @@ func convertMessage(msg providers.Message) (openai.ChatCompletionMessageParamUni
 	case providers.RoleSystem:
 		return openai.SystemMessage(msg.ContentString()), nil
 	case providers.RoleTool:
-		return openai.ToolMessage(msg.ToolCallID, msg.ContentString()), nil
+		return openai.ToolMessage(msg.ContentString(), msg.ToolCallID), nil
 	case providers.RoleUser:
 		return convertUserMessage(msg), nil
 	default:


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

Fixes order in `ToolMessage` function call. Order is defined in the openai SDK [here](https://github.com/openai/openai-go/blob/9fbaa589b733e1fb7dc73899492eda93364982bd/chatcompletion.go#L1937)

Found because the tool example failed. Adding debug logs you could see the call being serialized out of order:

```log
[DEBUG convertMessage] Tool message serialized:{"content":"call_RurNYYceBkKaxxJmSh5A5NLX","tool_call_id":"{\"location\": \"Paris\", \"temperature\": 22, \"unit\": \"celsius\", \"condition\": \"sunny\"}","role":"tool"}
DEBUG: Error from second API call: [openai] invalid_request: POST "https://api.openai.com/v1/chat/completions": 400 Bad Request {
    "message": "Invalid 'messages[2].tool_call_id': string too long. Expected a string with maximum length 40, but got a string with length 81 instead.",
    "type": "invalid_request_error",
    "param": "messages[2].tool_call_id",
    "code": "string_above_max_length"
  }
```

## Changes

<!-- List the changes made -->
- Just fixes the order

## Testing

<!-- How were these changes tested? -->

after the change, a successful call was made with openAI sdk:

```log
[DEBUG convertMessage] Tool message serialized: {"content":"{\"location\": \"Paris\", \"temperature\": 22, \"unit\": \"celsius\", \"condition\": \"sunny\"}","tool_call_id":"call_aoeIOWD4H2EZebJOsM1FOkCz","role":"tool"}
Assistant: The weather in Paris is currently sunny with a temperature of 22°C.
```

## Checklist

- [ ] Tests pass locally (`go test -short ./...`)
- [ ] Linting passes (`golangci-lint run ./...`)
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or documented in summary)
