### PR TITLE
fix(anthropic): handle []string type for tool required fields & improving overal tests

### DIFF
--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -2,6 +2,7 @@
 package testutil
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -177,6 +178,69 @@ func DateTool() providers.Tool {
 			},
 		},
 	}
+}
+
+// CalculatorTool returns a calculator tool with multiple parameters for testing.
+// This tool is useful for verifying that parameter order and required fields
+// are correctly preserved during conversion.
+func CalculatorTool() providers.Tool {
+	return providers.Tool{
+		Type: "function",
+		Function: providers.Function{
+			Name:        "calculate",
+			Description: "Perform a mathematical calculation on two numbers.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"a": map[string]any{
+						"type":        "number",
+						"description": "The first operand",
+					},
+					"b": map[string]any{
+						"type":        "number",
+						"description": "The second operand",
+					},
+					"operation": map[string]any{
+						"type":        "string",
+						"description": "The operation to perform",
+						"enum":        []string{"add", "subtract", "multiply", "divide"},
+					},
+				},
+				"required": []string{"a", "b", "operation"},
+			},
+		},
+	}
+}
+
+// MockWeatherResult returns a mock weather result for testing agent loops.
+func MockWeatherResult(location string) string {
+	return `{"location": "` + location + `", "temperature": 22, "unit": "celsius", "condition": "sunny"}`
+}
+
+// MockCalculatorResult returns a mock calculator result for testing agent loops.
+func MockCalculatorResult(a, b float64, operation string) string {
+	var result float64
+	switch operation {
+	case "add":
+		result = a + b
+	case "subtract":
+		result = a - b
+	case "multiply":
+		result = a * b
+	case "divide":
+		if b != 0 {
+			result = a / b
+		}
+	}
+	return `{"result": ` + formatFloat(result) + `}`
+}
+
+// formatFloat formats a float for JSON output.
+func formatFloat(f float64) string {
+	if f == float64(int(f)) {
+		return fmt.Sprintf("%.0f", f)
+	}
+	return fmt.Sprintf("%g", f)
 }
 
 // HasAPIKey checks if the API key environment variable is set for a provider.

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -4,6 +4,7 @@ package testutil
 import (
 	"fmt"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/mozilla-ai/any-llm-go/config"
@@ -180,10 +181,12 @@ func DateTool() providers.Tool {
 	}
 }
 
-// CalculatorTool returns a calculator tool with multiple parameters for testing.
+// NewTestCalculatorTool returns a calculator tool with multiple parameters for testing.
 // This tool is useful for verifying that parameter order and required fields
 // are correctly preserved during conversion.
-func CalculatorTool() providers.Tool {
+func NewTestCalculatorTool(t *testing.T) providers.Tool {
+	t.Helper()
+
 	return providers.Tool{
 		Type: "function",
 		Function: providers.Function{
@@ -213,12 +216,16 @@ func CalculatorTool() providers.Tool {
 }
 
 // MockWeatherResult returns a mock weather result for testing agent loops.
-func MockWeatherResult(location string) string {
+func MockWeatherResult(t *testing.T, location string) string {
+	t.Helper()
+
 	return `{"location": "` + location + `", "temperature": 22, "unit": "celsius", "condition": "sunny"}`
 }
 
 // MockCalculatorResult returns a mock calculator result for testing agent loops.
-func MockCalculatorResult(a, b float64, operation string) string {
+func MockCalculatorResult(t *testing.T, a float64, b float64, operation string) string {
+	t.Helper()
+
 	var result float64
 	switch operation {
 	case "add":

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -239,15 +239,14 @@ func MockCalculatorResult(t *testing.T, a float64, b float64, operation string) 
 			result = a / b
 		}
 	}
-	return `{"result": ` + formatFloat(result) + `}`
-}
 
-// formatFloat formats a float for JSON output.
-func formatFloat(f float64) string {
-	if f == float64(int(f)) {
-		return fmt.Sprintf("%.0f", f)
+	var formatted string
+	if result == float64(int(result)) {
+		formatted = fmt.Sprintf("%.0f", result)
+	} else {
+		formatted = fmt.Sprintf("%g", result)
 	}
-	return fmt.Sprintf("%g", f)
+	return `{"result": ` + formatted + `}`
 }
 
 // HasAPIKey checks if the API key environment variable is set for a provider.

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -61,6 +61,12 @@ const (
 	stopReasonToolUse      = "tool_use"
 )
 
+// JSON schema field names.
+const (
+	schemaFieldProperties = "properties"
+	schemaFieldRequired   = "required"
+)
+
 // Ensure Provider implements the required interfaces.
 var (
 	_ providers.CapabilityProvider = (*Provider)(nil)
@@ -537,11 +543,11 @@ func convertTool(tool providers.Tool) (anthropic.ToolUnionParam, error) {
 		return buildToolParam(tool, inputSchema), nil
 	}
 
-	if props, ok := tool.Function.Parameters["properties"]; ok {
+	if props, ok := tool.Function.Parameters[schemaFieldProperties]; ok {
 		inputSchema.Properties = props
 	}
 
-	req, ok := tool.Function.Parameters["required"]
+	req, ok := tool.Function.Parameters[schemaFieldRequired]
 	if !ok {
 		return buildToolParam(tool, inputSchema), nil
 	}

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -532,28 +532,42 @@ func convertTool(tool providers.Tool) (anthropic.ToolUnionParam, error) {
 	inputSchema := anthropic.ToolInputSchemaParam{
 		Type: "object",
 	}
+
+	if tool.Function.Parameters == nil {
+		return buildToolParam(tool, inputSchema), nil
+	}
+
 	if props, ok := tool.Function.Parameters["properties"]; ok {
 		inputSchema.Properties = props
 	}
-	if req, ok := tool.Function.Parameters["required"]; ok {
-		required, err := toStringSlice(req)
-		if err != nil {
-			return anthropic.ToolUnionParam{}, fmt.Errorf(
-				"tool %s: invalid required field: %w",
-				tool.Function.Name,
-				err,
-			)
-		}
-		inputSchema.Required = required
+
+	req, ok := tool.Function.Parameters["required"]
+	if !ok {
+		return buildToolParam(tool, inputSchema), nil
 	}
 
+	required, err := toStringSlice(req)
+	if err != nil {
+		return anthropic.ToolUnionParam{}, fmt.Errorf(
+			"tool %s: invalid required field: %w",
+			tool.Function.Name,
+			err,
+		)
+	}
+	inputSchema.Required = required
+
+	return buildToolParam(tool, inputSchema), nil
+}
+
+// buildToolParam constructs the final ToolUnionParam from tool metadata and schema.
+func buildToolParam(tool providers.Tool, schema anthropic.ToolInputSchemaParam) anthropic.ToolUnionParam {
 	return anthropic.ToolUnionParam{
 		OfTool: &anthropic.ToolParam{
 			Name:        tool.Function.Name,
 			Description: anthropic.String(tool.Function.Description),
-			InputSchema: inputSchema,
+			InputSchema: schema,
 		},
-	}, nil
+	}
 }
 
 // convertToolCall converts a tool call to Anthropic content block format.

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -524,11 +524,15 @@ func convertTool(tool providers.Tool) anthropic.ToolUnionParam {
 		inputSchema.Properties = props
 	}
 	if req, ok := tool.Function.Parameters["required"]; ok {
-		if reqArr, ok := req.([]any); ok {
-			required := make([]string, len(reqArr))
-			for i, r := range reqArr {
+		// Handle both []string (from Go code) and []any (from JSON unmarshaling).
+		switch reqTyped := req.(type) {
+		case []string:
+			inputSchema.Required = reqTyped
+		case []any:
+			required := make([]string, 0, len(reqTyped))
+			for _, r := range reqTyped {
 				if s, ok := r.(string); ok {
-					required[i] = s
+					required = append(required, s)
 				}
 			}
 			inputSchema.Required = required

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -132,7 +132,10 @@ func (p *Provider) Completion(
 	ctx context.Context,
 	params providers.CompletionParams,
 ) (*providers.ChatCompletion, error) {
-	req := p.convertParams(params)
+	req, err := p.convertParams(params)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := p.client.Messages.New(ctx, req)
 	if err != nil {
@@ -143,7 +146,7 @@ func (p *Provider) Completion(
 }
 
 // convertParams converts providers.CompletionParams to Anthropic request parameters.
-func (p *Provider) convertParams(params providers.CompletionParams) anthropic.MessageNewParams {
+func (p *Provider) convertParams(params providers.CompletionParams) (anthropic.MessageNewParams, error) {
 	messages, system := convertMessages(params.Messages)
 
 	maxTokens := int64(defaultMaxTokens)
@@ -178,7 +181,11 @@ func (p *Provider) convertParams(params providers.CompletionParams) anthropic.Me
 	if len(params.Tools) > 0 {
 		tools := make([]anthropic.ToolUnionParam, 0, len(params.Tools))
 		for _, tool := range params.Tools {
-			tools = append(tools, convertTool(tool))
+			converted, err := convertTool(tool)
+			if err != nil {
+				return anthropic.MessageNewParams{}, err
+			}
+			tools = append(tools, converted)
 		}
 		req.Tools = tools
 	}
@@ -189,7 +196,7 @@ func (p *Provider) convertParams(params providers.CompletionParams) anthropic.Me
 
 	applyThinking(&req, params.ReasoningEffort, maxTokens)
 
-	return req
+	return req, nil
 }
 
 // CompletionStream performs a streaming chat completion request.
@@ -204,7 +211,12 @@ func (p *Provider) CompletionStream(
 		defer close(chunks)
 		defer close(errs)
 
-		req := p.convertParams(params)
+		req, err := p.convertParams(params)
+		if err != nil {
+			errs <- err
+			return
+		}
+
 		stream := p.client.Messages.NewStreaming(ctx, req)
 		state := newStreamState()
 
@@ -516,7 +528,7 @@ func convertStopReason(reason string) string {
 }
 
 // convertTool converts a providers.Tool to Anthropic format.
-func convertTool(tool providers.Tool) anthropic.ToolUnionParam {
+func convertTool(tool providers.Tool) (anthropic.ToolUnionParam, error) {
 	inputSchema := anthropic.ToolInputSchemaParam{
 		Type: "object",
 	}
@@ -524,19 +536,15 @@ func convertTool(tool providers.Tool) anthropic.ToolUnionParam {
 		inputSchema.Properties = props
 	}
 	if req, ok := tool.Function.Parameters["required"]; ok {
-		// Handle both []string (from Go code) and []any (from JSON unmarshaling).
-		switch reqTyped := req.(type) {
-		case []string:
-			inputSchema.Required = reqTyped
-		case []any:
-			required := make([]string, 0, len(reqTyped))
-			for _, r := range reqTyped {
-				if s, ok := r.(string); ok {
-					required = append(required, s)
-				}
-			}
-			inputSchema.Required = required
+		required, err := toStringSlice(req)
+		if err != nil {
+			return anthropic.ToolUnionParam{}, fmt.Errorf(
+				"tool %s: invalid required field: %w",
+				tool.Function.Name,
+				err,
+			)
 		}
+		inputSchema.Required = required
 	}
 
 	return anthropic.ToolUnionParam{
@@ -545,7 +553,7 @@ func convertTool(tool providers.Tool) anthropic.ToolUnionParam {
 			Description: anthropic.String(tool.Function.Description),
 			InputSchema: inputSchema,
 		},
-	}
+	}, nil
 }
 
 // convertToolCall converts a tool call to Anthropic content block format.
@@ -647,6 +655,27 @@ func thinkingBudget(effort providers.ReasoningEffort) (int64, bool) {
 		return 16384, true
 	default:
 		return 0, false
+	}
+}
+
+// toStringSlice converts a value to []string.
+// Accepts []string (returned as-is) or []any (each element must be string).
+func toStringSlice(v any) ([]string, error) {
+	switch typed := v.(type) {
+	case []string:
+		return typed, nil
+	case []any:
+		result := make([]string, len(typed))
+		for i, elem := range typed {
+			s, ok := elem.(string)
+			if !ok {
+				return nil, fmt.Errorf("element %d: expected string, got %T", i, elem)
+			}
+			result[i] = s
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("expected []string or []any, got %T", v)
 	}
 }
 

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -555,7 +555,7 @@ func TestConvertTool(t *testing.T) {
 	t.Run("converts tool with multiple parameters", func(t *testing.T) {
 		t.Parallel()
 
-		tool := testutil.CalculatorTool()
+		tool := testutil.NewTestCalculatorTool(t)
 		result, err := convertTool(tool)
 
 		require.NoError(t, err)
@@ -998,7 +998,7 @@ func TestIntegrationAgentLoop(t *testing.T) {
 	messages = append(messages, resp.Choices[0].Message)
 	messages = append(messages, providers.Message{
 		Role:       providers.RoleTool,
-		Content:    testutil.MockWeatherResult(args.Location),
+		Content:    testutil.MockWeatherResult(t, args.Location),
 		ToolCallID: tc.ID,
 	})
 
@@ -1029,7 +1029,7 @@ func TestIntegrationAgentLoopMultipleParams(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	tools := []providers.Tool{testutil.CalculatorTool()}
+	tools := []providers.Tool{testutil.NewTestCalculatorTool(t)}
 
 	// Ask the model to use the calculator with specific values.
 	messages := []providers.Message{
@@ -1069,7 +1069,7 @@ func TestIntegrationAgentLoopMultipleParams(t *testing.T) {
 	messages = append(messages, resp.Choices[0].Message)
 	messages = append(messages, providers.Message{
 		Role:       providers.RoleTool,
-		Content:    testutil.MockCalculatorResult(args.A, args.B, args.Operation),
+		Content:    testutil.MockCalculatorResult(t, args.A, args.B, args.Operation),
 		ToolCallID: tc.ID,
 	})
 

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"net/http"
 	"net/url"
@@ -522,6 +523,115 @@ func TestConvertToolCall(t *testing.T) {
 	}
 }
 
+func TestConvertTool(t *testing.T) {
+	t.Parallel()
+
+	t.Run("converts tool with properties and required fields", func(t *testing.T) {
+		t.Parallel()
+
+		tool := testutil.WeatherTool()
+		result := convertTool(tool)
+
+		require.NotNil(t, result.OfTool)
+		require.Equal(t, "get_weather", result.OfTool.Name)
+		require.Equal(t, "Get the current weather for a location.", result.OfTool.Description.Value)
+		require.Equal(t, "object", string(result.OfTool.InputSchema.Type))
+
+		// Verify properties are preserved.
+		props, ok := result.OfTool.InputSchema.Properties.(map[string]any)
+		require.True(t, ok, "properties should be a map")
+		require.Contains(t, props, "location")
+
+		locationProp, ok := props["location"].(map[string]any)
+		require.True(t, ok, "location property should be a map")
+		require.Equal(t, "string", locationProp["type"])
+		require.Equal(t, "The city name, e.g. 'Paris, France'", locationProp["description"])
+
+		// Verify required fields are preserved.
+		require.Contains(t, result.OfTool.InputSchema.Required, "location")
+	})
+
+	t.Run("converts tool with multiple parameters", func(t *testing.T) {
+		t.Parallel()
+
+		tool := testutil.CalculatorTool()
+		result := convertTool(tool)
+
+		require.NotNil(t, result.OfTool)
+		require.Equal(t, "calculate", result.OfTool.Name)
+		require.Equal(t, "object", string(result.OfTool.InputSchema.Type))
+
+		// Verify all properties are preserved.
+		props, ok := result.OfTool.InputSchema.Properties.(map[string]any)
+		require.True(t, ok, "properties should be a map")
+		require.Contains(t, props, "a")
+		require.Contains(t, props, "b")
+		require.Contains(t, props, "operation")
+
+		// Verify property types.
+		aProp, ok := props["a"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "number", aProp["type"])
+
+		bProp, ok := props["b"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "number", bProp["type"])
+
+		opProp, ok := props["operation"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "string", opProp["type"])
+
+		// Verify enum values are preserved.
+		enum, ok := opProp["enum"].([]string)
+		require.True(t, ok, "enum should be a string slice")
+		require.ElementsMatch(t, []string{"add", "subtract", "multiply", "divide"}, enum)
+
+		// Verify all required fields are preserved.
+		require.Len(t, result.OfTool.InputSchema.Required, 3)
+		require.Contains(t, result.OfTool.InputSchema.Required, "a")
+		require.Contains(t, result.OfTool.InputSchema.Required, "b")
+		require.Contains(t, result.OfTool.InputSchema.Required, "operation")
+	})
+
+	t.Run("converts tool with no required fields", func(t *testing.T) {
+		t.Parallel()
+
+		tool := providers.Tool{
+			Type: "function",
+			Function: providers.Function{
+				Name:        "optional_params",
+				Description: "A tool with optional parameters.",
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"optional_field": map[string]any{
+							"type":        "string",
+							"description": "An optional field",
+						},
+					},
+					// No "required" field.
+				},
+			},
+		}
+		result := convertTool(tool)
+
+		require.NotNil(t, result.OfTool)
+		require.Equal(t, "optional_params", result.OfTool.Name)
+		require.Empty(t, result.OfTool.InputSchema.Required)
+	})
+
+	t.Run("converts tool with empty parameters", func(t *testing.T) {
+		t.Parallel()
+
+		tool := testutil.DateTool()
+		result := convertTool(tool)
+
+		require.NotNil(t, result.OfTool)
+		require.Equal(t, "get_current_date", result.OfTool.Name)
+		require.Equal(t, "object", string(result.OfTool.InputSchema.Type))
+	})
+}
+
 func TestThinkingBudget(t *testing.T) {
 	t.Parallel()
 
@@ -727,6 +837,142 @@ func TestIntegrationCompletionWithToolsParallelDisabled(t *testing.T) {
 	require.Len(t, resp.Choices, 1)
 }
 
+func TestIntegrationAgentLoop(t *testing.T) {
+	t.Parallel()
+
+	if testutil.SkipIfNoAPIKey("anthropic") {
+		t.Skip("ANTHROPIC_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tools := []providers.Tool{testutil.WeatherTool()}
+
+	// Step 1: Send initial message asking about weather.
+	messages := []providers.Message{
+		{Role: providers.RoleUser, Content: "What is the weather in Paris? Use the get_weather tool."},
+	}
+
+	resp, err := provider.Completion(ctx, providers.CompletionParams{
+		Model:      testutil.TestModel("anthropic"),
+		Messages:   messages,
+		Tools:      tools,
+		ToolChoice: "auto",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+
+	// Step 2: Verify the model called the tool.
+	require.NotEmpty(t, resp.Choices[0].Message.ToolCalls, "expected model to call get_weather tool")
+	require.Equal(t, providers.FinishReasonToolCalls, resp.Choices[0].FinishReason)
+
+	tc := resp.Choices[0].Message.ToolCalls[0]
+	require.Equal(t, "get_weather", tc.Function.Name)
+	require.NotEmpty(t, tc.ID)
+
+	// Step 3: Parse the arguments - this verifies parameters were sent correctly.
+	var args struct {
+		Location string `json:"location"`
+	}
+	err = json.Unmarshal([]byte(tc.Function.Arguments), &args)
+	require.NoError(t, err, "tool arguments should be valid JSON")
+	require.NotEmpty(t, args.Location, "location argument should be present")
+	require.Contains(t, strings.ToLower(args.Location), "paris")
+
+	// Step 4: Add assistant message with tool call and tool result.
+	messages = append(messages, resp.Choices[0].Message)
+	messages = append(messages, providers.Message{
+		Role:       providers.RoleTool,
+		Content:    testutil.MockWeatherResult(args.Location),
+		ToolCallID: tc.ID,
+	})
+
+	// Step 5: Continue conversation with tool result.
+	resp, err = provider.Completion(ctx, providers.CompletionParams{
+		Model:    testutil.TestModel("anthropic"),
+		Messages: messages,
+		Tools:    tools,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+
+	// Step 6: Verify the model produced a final response.
+	require.Equal(t, providers.FinishReasonStop, resp.Choices[0].FinishReason)
+	contentStr, ok := resp.Choices[0].Message.Content.(string)
+	require.True(t, ok, "expected string content in final response")
+	require.NotEmpty(t, contentStr)
+}
+
+func TestIntegrationAgentLoopMultipleParams(t *testing.T) {
+	t.Parallel()
+
+	if testutil.SkipIfNoAPIKey("anthropic") {
+		t.Skip("ANTHROPIC_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tools := []providers.Tool{testutil.CalculatorTool()}
+
+	// Ask the model to use the calculator with specific values.
+	messages := []providers.Message{
+		{Role: providers.RoleUser, Content: "Use the calculate tool to add 15 and 27 together."},
+	}
+
+	resp, err := provider.Completion(ctx, providers.CompletionParams{
+		Model:      testutil.TestModel("anthropic"),
+		Messages:   messages,
+		Tools:      tools,
+		ToolChoice: "auto",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+
+	// Verify the model called the tool with correct parameters.
+	require.NotEmpty(t, resp.Choices[0].Message.ToolCalls, "expected model to call calculate tool")
+
+	tc := resp.Choices[0].Message.ToolCalls[0]
+	require.Equal(t, "calculate", tc.Function.Name)
+
+	// Parse and verify all required parameters are present.
+	var args struct {
+		A         float64 `json:"a"`
+		B         float64 `json:"b"`
+		Operation string  `json:"operation"`
+	}
+	err = json.Unmarshal([]byte(tc.Function.Arguments), &args)
+	require.NoError(t, err, "tool arguments should be valid JSON")
+
+	// Verify the parameters - this catches "wrong order" bugs.
+	require.Equal(t, 15.0, args.A, "first operand should be 15")
+	require.Equal(t, 27.0, args.B, "second operand should be 27")
+	require.Equal(t, "add", args.Operation, "operation should be 'add'")
+
+	// Complete the agent loop with tool result.
+	messages = append(messages, resp.Choices[0].Message)
+	messages = append(messages, providers.Message{
+		Role:       providers.RoleTool,
+		Content:    testutil.MockCalculatorResult(args.A, args.B, args.Operation),
+		ToolCallID: tc.ID,
+	})
+
+	resp, err = provider.Completion(ctx, providers.CompletionParams{
+		Model:    testutil.TestModel("anthropic"),
+		Messages: messages,
+		Tools:    tools,
+	})
+	require.NoError(t, err)
+
+	// Verify final response mentions the result.
+	contentStr, ok := resp.Choices[0].Message.Content.(string)
+	require.True(t, ok)
+	require.Contains(t, contentStr, "42")
+}
+
 func TestIntegrationCompletionConversation(t *testing.T) {
 	t.Parallel()
 
@@ -792,7 +1038,7 @@ func TestIntegrationCompletionReasoning(t *testing.T) {
 	}
 }
 
-func TestIntegrationAgentLoop(t *testing.T) {
+func TestIntegrationAgentLoopContinuation(t *testing.T) {
 	t.Parallel()
 
 	if testutil.SkipIfNoAPIKey("anthropic") {

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -530,8 +530,9 @@ func TestConvertTool(t *testing.T) {
 		t.Parallel()
 
 		tool := testutil.WeatherTool()
-		result := convertTool(tool)
+		result, err := convertTool(tool)
 
+		require.NoError(t, err)
 		require.NotNil(t, result.OfTool)
 		require.Equal(t, "get_weather", result.OfTool.Name)
 		require.Equal(t, "Get the current weather for a location.", result.OfTool.Description.Value)
@@ -555,8 +556,9 @@ func TestConvertTool(t *testing.T) {
 		t.Parallel()
 
 		tool := testutil.CalculatorTool()
-		result := convertTool(tool)
+		result, err := convertTool(tool)
 
+		require.NoError(t, err)
 		require.NotNil(t, result.OfTool)
 		require.Equal(t, "calculate", result.OfTool.Name)
 		require.Equal(t, "object", string(result.OfTool.InputSchema.Type))
@@ -613,8 +615,9 @@ func TestConvertTool(t *testing.T) {
 				},
 			},
 		}
-		result := convertTool(tool)
+		result, err := convertTool(tool)
 
+		require.NoError(t, err)
 		require.NotNil(t, result.OfTool)
 		require.Equal(t, "optional_params", result.OfTool.Name)
 		require.Empty(t, result.OfTool.InputSchema.Required)
@@ -624,11 +627,56 @@ func TestConvertTool(t *testing.T) {
 		t.Parallel()
 
 		tool := testutil.DateTool()
-		result := convertTool(tool)
+		result, err := convertTool(tool)
 
+		require.NoError(t, err)
 		require.NotNil(t, result.OfTool)
 		require.Equal(t, "get_current_date", result.OfTool.Name)
 		require.Equal(t, "object", string(result.OfTool.InputSchema.Type))
+	})
+
+	t.Run("returns error for invalid required field type", func(t *testing.T) {
+		t.Parallel()
+
+		tool := providers.Tool{
+			Type: "function",
+			Function: providers.Function{
+				Name:        "bad_tool",
+				Description: "A tool with invalid required field.",
+				Parameters: map[string]any{
+					"type":       "object",
+					"properties": map[string]any{},
+					"required":   123, // Invalid type.
+				},
+			},
+		}
+		_, err := convertTool(tool)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bad_tool")
+		require.Contains(t, err.Error(), "invalid required field")
+	})
+
+	t.Run("returns error for non-string element in required array", func(t *testing.T) {
+		t.Parallel()
+
+		tool := providers.Tool{
+			Type: "function",
+			Function: providers.Function{
+				Name:        "mixed_required",
+				Description: "A tool with mixed types in required.",
+				Parameters: map[string]any{
+					"type":       "object",
+					"properties": map[string]any{},
+					"required":   []any{"valid", 42, "also_valid"}, // Mixed types.
+				},
+			},
+		}
+		_, err := convertTool(tool)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "mixed_required")
+		require.Contains(t, err.Error(), "element 1")
 	})
 }
 
@@ -682,6 +730,71 @@ func TestThinkingBudget(t *testing.T) {
 			require.Equal(t, tc.expected, budget)
 		})
 	}
+}
+
+func TestToStringSlice(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns []string input unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		input := []string{"a", "b", "c"}
+		result, err := toStringSlice(input)
+
+		require.NoError(t, err)
+		require.Equal(t, input, result)
+	})
+
+	t.Run("converts []any with all strings", func(t *testing.T) {
+		t.Parallel()
+
+		input := []any{"x", "y", "z"}
+		result, err := toStringSlice(input)
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"x", "y", "z"}, result)
+	})
+
+	t.Run("converts empty []any to empty []string", func(t *testing.T) {
+		t.Parallel()
+
+		input := []any{}
+		result, err := toStringSlice(input)
+
+		require.NoError(t, err)
+		require.Empty(t, result)
+	})
+
+	t.Run("returns error for []any with non-string element", func(t *testing.T) {
+		t.Parallel()
+
+		input := []any{"valid", 42, "another"}
+		_, err := toStringSlice(input)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "element 1")
+		require.Contains(t, err.Error(), "expected string")
+		require.Contains(t, err.Error(), "int")
+	})
+
+	t.Run("returns error for unexpected type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := toStringSlice(123)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected []string or []any")
+		require.Contains(t, err.Error(), "int")
+	})
+
+	t.Run("returns error for nil input", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := toStringSlice(nil)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected []string or []any")
+	})
 }
 
 // Integration tests - only run if API key is available.

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -386,7 +386,7 @@ func TestConvertTools(t *testing.T) {
 	t.Run("converts tool with multiple parameters", func(t *testing.T) {
 		t.Parallel()
 
-		tools := []providers.Tool{testutil.CalculatorTool()}
+		tools := []providers.Tool{testutil.NewTestCalculatorTool(t)}
 		result := convertTools(tools)
 
 		require.Len(t, result, 1)
@@ -588,7 +588,7 @@ func TestIntegrationAgentLoop(t *testing.T) {
 	messages = append(messages, resp.Choices[0].Message)
 	messages = append(messages, providers.Message{
 		Role:       providers.RoleTool,
-		Content:    testutil.MockWeatherResult(args.Location),
+		Content:    testutil.MockWeatherResult(t, args.Location),
 		ToolCallID: tc.ID,
 	})
 
@@ -619,7 +619,7 @@ func TestIntegrationAgentLoopMultipleParams(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	tools := []providers.Tool{testutil.CalculatorTool()}
+	tools := []providers.Tool{testutil.NewTestCalculatorTool(t)}
 
 	// Ask the model to use the calculator with specific values.
 	messages := []providers.Message{
@@ -659,7 +659,7 @@ func TestIntegrationAgentLoopMultipleParams(t *testing.T) {
 	messages = append(messages, resp.Choices[0].Message)
 	messages = append(messages, providers.Message{
 		Role:       providers.RoleTool,
-		Content:    testutil.MockCalculatorResult(args.A, args.B, args.Operation),
+		Content:    testutil.MockCalculatorResult(t, args.A, args.B, args.Operation),
 		ToolCallID: tc.ID,
 	})
 

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"net/http"
 	"net/url"
@@ -350,6 +351,95 @@ func TestConvertResponse(t *testing.T) {
 	})
 }
 
+func TestConvertTools(t *testing.T) {
+	t.Parallel()
+
+	t.Run("converts tool with properties and required fields", func(t *testing.T) {
+		t.Parallel()
+
+		tools := []providers.Tool{testutil.WeatherTool()}
+		result := convertTools(tools)
+
+		require.Len(t, result, 1)
+		require.Equal(t, "get_weather", result[0].Function.Name)
+		require.Equal(t, "Get the current weather for a location.", result[0].Function.Description.Value)
+
+		// FunctionParameters is map[string]any - access directly.
+		params := result[0].Function.Parameters
+		require.Equal(t, "object", params["type"])
+
+		props, ok := params["properties"].(map[string]any)
+		require.True(t, ok, "properties should be a map")
+		require.Contains(t, props, "location")
+
+		locationProp, ok := props["location"].(map[string]any)
+		require.True(t, ok, "location property should be a map")
+		require.Equal(t, "string", locationProp["type"])
+		require.Equal(t, "The city name, e.g. 'Paris, France'", locationProp["description"])
+
+		// Verify required fields are preserved.
+		required, ok := params["required"].([]string)
+		require.True(t, ok, "required should be a string slice")
+		require.Contains(t, required, "location")
+	})
+
+	t.Run("converts tool with multiple parameters", func(t *testing.T) {
+		t.Parallel()
+
+		tools := []providers.Tool{testutil.CalculatorTool()}
+		result := convertTools(tools)
+
+		require.Len(t, result, 1)
+		require.Equal(t, "calculate", result[0].Function.Name)
+
+		// FunctionParameters is map[string]any - access directly.
+		params := result[0].Function.Parameters
+
+		props, ok := params["properties"].(map[string]any)
+		require.True(t, ok)
+		require.Contains(t, props, "a")
+		require.Contains(t, props, "b")
+		require.Contains(t, props, "operation")
+
+		// Verify property types.
+		aProp, ok := props["a"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "number", aProp["type"])
+
+		bProp, ok := props["b"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "number", bProp["type"])
+
+		opProp, ok := props["operation"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "string", opProp["type"])
+
+		// Verify enum values are preserved.
+		enum, ok := opProp["enum"].([]string)
+		require.True(t, ok, "enum should be a string slice")
+		require.ElementsMatch(t, []string{"add", "subtract", "multiply", "divide"}, enum)
+
+		// Verify all required fields are preserved.
+		required, ok := params["required"].([]string)
+		require.True(t, ok)
+		require.Len(t, required, 3)
+		require.Contains(t, required, "a")
+		require.Contains(t, required, "b")
+		require.Contains(t, required, "operation")
+	})
+
+	t.Run("converts multiple tools", func(t *testing.T) {
+		t.Parallel()
+
+		tools := []providers.Tool{testutil.WeatherTool(), testutil.DateTool()}
+		result := convertTools(tools)
+
+		require.Len(t, result, 2)
+		require.Equal(t, "get_weather", result[0].Function.Name)
+		require.Equal(t, "get_current_date", result[1].Function.Name)
+	})
+}
+
 // Integration tests - only run if API key is available.
 
 func TestIntegrationCompletion(t *testing.T) {
@@ -448,6 +538,142 @@ func TestIntegrationCompletionWithTools(t *testing.T) {
 		require.Contains(t, tc.Function.Arguments, "Paris")
 		require.Equal(t, providers.FinishReasonToolCalls, resp.Choices[0].FinishReason)
 	}
+}
+
+func TestIntegrationAgentLoop(t *testing.T) {
+	t.Parallel()
+
+	if testutil.SkipIfNoAPIKey("openai") {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tools := []providers.Tool{testutil.WeatherTool()}
+
+	// Step 1: Send initial message asking about weather.
+	messages := []providers.Message{
+		{Role: providers.RoleUser, Content: "What is the weather in Paris? Use the get_weather tool."},
+	}
+
+	resp, err := provider.Completion(ctx, providers.CompletionParams{
+		Model:      testutil.TestModel("openai"),
+		Messages:   messages,
+		Tools:      tools,
+		ToolChoice: "auto",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+
+	// Step 2: Verify the model called the tool.
+	require.NotEmpty(t, resp.Choices[0].Message.ToolCalls, "expected model to call get_weather tool")
+	require.Equal(t, providers.FinishReasonToolCalls, resp.Choices[0].FinishReason)
+
+	tc := resp.Choices[0].Message.ToolCalls[0]
+	require.Equal(t, "get_weather", tc.Function.Name)
+	require.NotEmpty(t, tc.ID)
+
+	// Step 3: Parse the arguments - this verifies parameters were sent correctly.
+	var args struct {
+		Location string `json:"location"`
+	}
+	err = json.Unmarshal([]byte(tc.Function.Arguments), &args)
+	require.NoError(t, err, "tool arguments should be valid JSON")
+	require.NotEmpty(t, args.Location, "location argument should be present")
+	require.Contains(t, strings.ToLower(args.Location), "paris")
+
+	// Step 4: Add assistant message with tool call and tool result.
+	messages = append(messages, resp.Choices[0].Message)
+	messages = append(messages, providers.Message{
+		Role:       providers.RoleTool,
+		Content:    testutil.MockWeatherResult(args.Location),
+		ToolCallID: tc.ID,
+	})
+
+	// Step 5: Continue conversation with tool result.
+	resp, err = provider.Completion(ctx, providers.CompletionParams{
+		Model:    testutil.TestModel("openai"),
+		Messages: messages,
+		Tools:    tools,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+
+	// Step 6: Verify the model produced a final response.
+	require.Equal(t, providers.FinishReasonStop, resp.Choices[0].FinishReason)
+	contentStr, ok := resp.Choices[0].Message.Content.(string)
+	require.True(t, ok, "expected string content in final response")
+	require.NotEmpty(t, contentStr)
+}
+
+func TestIntegrationAgentLoopMultipleParams(t *testing.T) {
+	t.Parallel()
+
+	if testutil.SkipIfNoAPIKey("openai") {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tools := []providers.Tool{testutil.CalculatorTool()}
+
+	// Ask the model to use the calculator with specific values.
+	messages := []providers.Message{
+		{Role: providers.RoleUser, Content: "Use the calculate tool to add 15 and 27 together."},
+	}
+
+	resp, err := provider.Completion(ctx, providers.CompletionParams{
+		Model:      testutil.TestModel("openai"),
+		Messages:   messages,
+		Tools:      tools,
+		ToolChoice: "auto",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+
+	// Verify the model called the tool with correct parameters.
+	require.NotEmpty(t, resp.Choices[0].Message.ToolCalls, "expected model to call calculate tool")
+
+	tc := resp.Choices[0].Message.ToolCalls[0]
+	require.Equal(t, "calculate", tc.Function.Name)
+
+	// Parse and verify all required parameters are present.
+	var args struct {
+		A         float64 `json:"a"`
+		B         float64 `json:"b"`
+		Operation string  `json:"operation"`
+	}
+	err = json.Unmarshal([]byte(tc.Function.Arguments), &args)
+	require.NoError(t, err, "tool arguments should be valid JSON")
+
+	// Verify the parameters - this catches "wrong order" bugs.
+	require.Equal(t, 15.0, args.A, "first operand should be 15")
+	require.Equal(t, 27.0, args.B, "second operand should be 27")
+	require.Equal(t, "add", args.Operation, "operation should be 'add'")
+
+	// Complete the agent loop with tool result.
+	messages = append(messages, resp.Choices[0].Message)
+	messages = append(messages, providers.Message{
+		Role:       providers.RoleTool,
+		Content:    testutil.MockCalculatorResult(args.A, args.B, args.Operation),
+		ToolCallID: tc.ID,
+	})
+
+	resp, err = provider.Completion(ctx, providers.CompletionParams{
+		Model:    testutil.TestModel("openai"),
+		Messages: messages,
+		Tools:    tools,
+	})
+	require.NoError(t, err)
+
+	// Verify final response mentions the result.
+	contentStr, ok := resp.Choices[0].Message.Content.(string)
+	require.True(t, ok)
+	require.Contains(t, contentStr, "42")
 }
 
 func TestIntegrationCompletionConversation(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix bug where tool `required` fields defined as `[]string` in Go code were silently ignored
- Add comprehensive test coverage for tool conversion and agent loop scenarios

## Changes

- **fix(anthropic)**: Add type switch in `convertTool` to handle both `[]string` (Go-defined) and `[]any` (JSON-unmarshaled) for the required field
- **test(fixtures)**: Add `CalculatorTool`, `MockWeatherResult`, and `MockCalculatorResult` helpers
- **test(anthropic)**: Add `TestConvertTool` unit tests and `TestIntegrationAgentLoop` / `TestIntegrationAgentLoopMultipleParams` integration tests
- **test(openai)**: Add `TestConvertTools` unit tests and matching agent loop integration tests

## Testing

- `make test-unit` - all unit tests pass
- `make test` - integration tests verify full agent loop with real API calls

## Checklist

- [x] Tests pass locally (`go test -short ./...`)
- [x] Linting passes (`golangci-lint run ./...`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)