### PR TITLE
feat(platform): add User-Agent header and SDK version management

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -1,0 +1,39 @@
+name: Check Version Consistency
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Validate tag matches version const
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          code=$(sed -n 's/^const Version = "\(.*\)"/\1/p' sdk/version.go)
+
+          if [[ -z "$code" ]]; then
+            echo "::error::Could not extract Version const from sdk/version.go."
+            exit 1
+          fi
+
+          if [[ "$TAG" != "$code" ]]; then
+            echo "::error::Tag ($TAG) does not match sdk/version.go const ($code). Update the Version const before tagging."
+            echo "Deleting mismatched tag $TAG to prevent inconsistent releases."
+            git push origin --delete "$TAG"
+            exit 1
+          fi
+
+          echo "Tag $TAG matches sdk/version.go const."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,55 @@ export OPENAI_API_KEY="sk-..."
 export ANTHROPIC_API_KEY="sk-ant-..."
 ```
 
+## Version Management
+
+The library version is managed using build-time injection via Go's `-ldflags` mechanism.
+
+### For Developers
+
+During development, the version defaults to `"dev"`. No special action is needed.
+
+```bash
+make build              # Builds with version from git tags
+go build ./...          # Builds with default version "dev"
+```
+
+### For Maintainers
+
+When creating a release:
+
+1. **Tag the release:**
+   ```bash
+   git tag -a v0.7.0 -m "Release v0.7.0"
+   git push origin v0.7.0
+   ```
+
+2. **Build with version:**
+   ```bash
+   # Automatic version detection from git tags
+   make build
+
+   # Or explicitly set version
+   make build VERSION=0.7.0
+
+   # Or using go build directly
+   go build -ldflags="-X github.com/mozilla-ai/any-llm-go/version.Version=0.7.0" ./...
+   ```
+
+3. **Verify version:**
+   ```bash
+   git describe --tags --always
+   ```
+
+The version is used in the `User-Agent` header for platform API requests: `go-any-llm/{version}`
+
+### Version Format
+
+- **Development builds**: `dev`
+- **Tagged releases**: `v0.7.0` (from git tags)
+- **Dirty builds**: `v0.7.0-dirty` (uncommitted changes)
+- **Between releases**: `v0.7.0-3-g6244a29` (3 commits after v0.7.0)
+
 ## Project Structure
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,52 +44,34 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 
 ## Version Management
 
-The library version is managed using build-time injection via Go's `-ldflags` mechanism.
+The library version is a `const` in `sdk/version.go`. This is the single source of truth.
 
-### For Developers
-
-During development, the version defaults to `"dev"`. No special action is needed.
-
-```bash
-make build              # Builds with version from git tags
-go build ./...          # Builds with default version "dev"
-```
+The version is used in the `User-Agent` header for API requests using the `platform` provider: `go-any-llm/{version}`
 
 ### For Maintainers
 
 When creating a release:
 
-1. **Tag the release:**
+1. **Create a release branch and bump the version const** in `sdk/version.go`:
    ```bash
-   git tag -a v0.7.0 -m "Release v0.7.0"
-   git push origin v0.7.0
+   git checkout -b release/v0.8.0
+   # Edit sdk/version.go: const Version = "v0.8.0"
+   git add sdk/version.go
+   git commit -m "release: v0.8.0"
+   git push -u origin release/v0.8.0
    ```
 
-2. **Build with version:**
+2. **Create a PR** and merge into `main`.
+
+3. **Tag the release** from `main` after the PR is merged:
    ```bash
-   # Automatic version detection from git tags
-   make build
-
-   # Or explicitly set version
-   make build VERSION=0.7.0
-
-   # Or using go build directly
-   go build -ldflags="-X github.com/mozilla-ai/any-llm-go/version.Version=0.7.0" ./...
+   git checkout main
+   git pull
+   git tag -a v0.8.0 -m "Release v0.8.0"
+   git push origin v0.8.0
    ```
 
-3. **Verify version:**
-   ```bash
-   git describe --tags --always
-   ```
-
-The version is used in the `User-Agent` header for platform API requests: `go-any-llm/{version}`
-
-### Version Format
-
-- **Development builds**: `dev`
-- **Tagged releases**: `v0.7.0` (from git tags)
-- **Dirty builds**: `v0.7.0-dirty` (uncommitted changes)
-- **Between releases**: `v0.7.0-3-g6244a29` (3 commits after v0.7.0)
+A CI workflow (`.github/workflows/version.yaml`) validates that the pushed tag matches the `Version` const. If they differ, the workflow deletes the mismatched tag and fails the job.
 
 ## Project Structure
 

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,12 @@
 .PHONY: lint test build clean fmt
 
-# Version management
-# Automatically detected from git tags, or "dev" for development builds
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-LDFLAGS := -X github.com/mozilla-ai/any-llm-go/version.Version=$(VERSION)
-
 # Run linting with auto-fix
 lint:
 	golangci-lint run --fix ./...
 
 # Run all tests
 test: lint
-	go test -v -race ./...
+	go test -race ./...
 
 # Run tests without linting (faster)
 test-only:
@@ -21,9 +16,9 @@ test-only:
 test-unit:
 	go test -v -race -short ./...
 
-# Build and verify compilation with version injection
+# Build and verify compilation
 build:
-	go build -ldflags="$(LDFLAGS)" ./...
+	go build ./...
 
 # Format code
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 .PHONY: lint test build clean fmt
 
+# Version management
+# Automatically detected from git tags, or "dev" for development builds
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+LDFLAGS := -X github.com/mozilla-ai/any-llm-go/version.Version=$(VERSION)
+
 # Run linting with auto-fix
 lint:
 	golangci-lint run --fix ./...
@@ -16,9 +21,9 @@ test-only:
 test-unit:
 	go test -v -race -short ./...
 
-# Build and verify compilation
+# Build and verify compilation with version injection
 build:
-	go build ./...
+	go build -ldflags="$(LDFLAGS)" ./...
 
 # Format code
 fmt:

--- a/providers/platform/platform.go
+++ b/providers/platform/platform.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -21,7 +22,7 @@ import (
 	"github.com/mozilla-ai/any-llm-go/providers"
 	"github.com/mozilla-ai/any-llm-go/providers/anthropic"
 	"github.com/mozilla-ai/any-llm-go/providers/openai"
-	"github.com/mozilla-ai/any-llm-go/version"
+	"github.com/mozilla-ai/any-llm-go/sdk"
 )
 
 const (
@@ -472,7 +473,7 @@ func (p *Provider) postUsageEvent(
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+accessToken)
-	req.Header.Set("User-Agent", fmt.Sprintf("go-any-llm/%s", version.Version))
+	req.Header.Set("User-Agent", userAgent())
 
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
@@ -482,4 +483,10 @@ func (p *Provider) postUsageEvent(
 	// Drain and close the response body to allow connection reuse
 	_, _ = io.Copy(io.Discard, resp.Body)
 	_ = resp.Body.Close()
+}
+
+// userAgent returns the formatted User-Agent header value per RFC 9110 section 10.1.5.
+func userAgent() string {
+	goVersion := strings.TrimPrefix(runtime.Version(), "go")
+	return fmt.Sprintf("%s/%s go/%s", sdk.Name, strings.TrimPrefix(sdk.Version, "v"), goVersion)
 }

--- a/providers/platform/platform.go
+++ b/providers/platform/platform.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mozilla-ai/any-llm-go/providers"
 	"github.com/mozilla-ai/any-llm-go/providers/anthropic"
 	"github.com/mozilla-ai/any-llm-go/providers/openai"
+	"github.com/mozilla-ai/any-llm-go/version"
 )
 
 const (
@@ -471,6 +472,7 @@ func (p *Provider) postUsageEvent(
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("User-Agent", fmt.Sprintf("go-any-llm/%s", version.Version))
 
 	resp, err := p.httpClient.Do(req)
 	if err != nil {

--- a/providers/platform/platform_test.go
+++ b/providers/platform/platform_test.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"context"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/errors"
 	"github.com/mozilla-ai/any-llm-go/providers"
+	"github.com/mozilla-ai/any-llm-go/sdk"
 )
 
 func TestNew(t *testing.T) {
@@ -91,6 +93,22 @@ func TestParseModelString(t *testing.T) {
 			require.Equal(t, tc.wantModel, model)
 		})
 	}
+}
+
+func TestUserAgent(t *testing.T) {
+	t.Parallel()
+
+	ua := userAgent()
+
+	// Verify RFC 9110 product/version format: "any-llm/X.Y.Z go/X.Y.Z".
+	parts := strings.SplitN(ua, " ", 2)
+	require.Len(t, parts, 2, "expected sdk/version and language/version pair")
+
+	require.True(t, strings.HasPrefix(parts[0], sdk.Name+"/"), "first token should start with library name")
+	require.NotContains(t, parts[0], "/v", "version should not have v prefix")
+
+	require.True(t, strings.HasPrefix(parts[1], "go/"), "second token should be the go runtime product")
+	require.Contains(t, parts[1], strings.TrimPrefix(runtime.Version(), "go"), "should contain the go runtime version")
 }
 
 func TestCompletionDoesNotMutateParams(t *testing.T) {

--- a/sdk/name.go
+++ b/sdk/name.go
@@ -1,0 +1,4 @@
+package sdk
+
+// Name is the library product name shared across all any-llm SDKs.
+const Name = "any-llm"

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -1,0 +1,5 @@
+// Package sdk provides metadata for the any-llm-go library.
+package sdk
+
+// Version is the library version string.
+const Version = "v0.7.0"

--- a/sdk/version_test.go
+++ b/sdk/version_test.go
@@ -1,0 +1,33 @@
+package sdk
+
+import (
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestVersionFormat validates the Version const matches the semver pattern.
+func TestVersionFormat(t *testing.T) {
+	t.Parallel()
+
+	versionPattern := `^v\d+\.\d+\.\d+$`
+	regex := regexp.MustCompile(versionPattern)
+	require.True(t, regex.MatchString(Version))
+}
+
+// TestVersionMatchesLatestTag validates the Version const matches the latest git tag.
+func TestVersionMatchesLatestTag(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command("git", "describe", "--tags", "--abbrev=0")
+	output, err := cmd.Output()
+	if err != nil {
+		t.Skip("no git tags available")
+	}
+
+	expected := strings.TrimSpace(string(output))
+	require.Equal(t, expected, Version)
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,8 @@
+// Package version provides version information for the any-llm-go library.
+package version
+
+// Version is the library version. Defaults to "dev" for development builds.
+// Can be set at build time via:
+//
+//	go build -ldflags="-X github.com/mozilla-ai/any-llm-go/version.Version=x.y.z"
+var Version = "dev"

--- a/version/version.go
+++ b/version/version.go
@@ -1,8 +1,0 @@
-// Package version provides version information for the any-llm-go library.
-package version
-
-// Version is the library version. Defaults to "dev" for development builds.
-// Can be set at build time via:
-//
-//	go build -ldflags="-X github.com/mozilla-ai/any-llm-go/version.Version=x.y.z"
-var Version = "dev"


### PR DESCRIPTION
## Summary

- Adds `sdk` package with `Name` and `Version` consts as the single source of truth for library metadata
- Sets `User-Agent` header on platform usage-event requests in RFC 9110 format: `any-llm/{version} go/{version}`
- Adds CI workflow (`.github/workflows/version.yaml`) that validates git tags match the `Version` const
- Documents the release workflow in CONTRIBUTING.md

## Changes

- `sdk/name.go` / `sdk/version.go`: Library name and version consts
- `sdk/version_test.go`: Validates semver format and tag consistency
- `providers/platform/platform.go`: Adds `userAgent()` helper and sets header on usage-event requests
- `providers/platform/platform_test.go`: Tests User-Agent format
- `.github/workflows/version.yaml`: Tag validation workflow
- `CONTRIBUTING.md`: Release process documentation
- `Makefile`: Removes `-v` flag from test target

## Test plan

- [x] `TestVersionFormat` validates semver pattern
- [x] `TestVersionMatchesLatestTag` checks const matches git tag (skips gracefully if no tags)
- [x] `TestUserAgent` validates RFC 9110 product/version format
- [x] All existing tests pass