### PR TITLE
feat(provider): add llama.cpp provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,9 @@ for _, model := range models.Data {
 |  DeepSeek  |      ✅      |      ✅      |      ✅ |      ✅      |      ❌       |
 |   Gemini   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
 |    Groq    |      ✅      |      ✅      |      ✅ |      ❌      |      ❌       |
-| Llamafile  |      ✅      |      ✅      |      ✅ |      ❌      |      ✅       |
 |  llamacpp  |      ✅      |      ✅      |      ❌ |      ❌      |      ✅       |
+| Llamafile  |      ✅      |      ✅      |      ✅ |      ❌      |      ✅       |
+|  Mistral   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
 |   Ollama   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
 |   OpenAI   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ for _, model := range models.Data {
 |  DeepSeek  |      ✅      |      ✅      |      ✅ |      ✅      |      ❌       |
 |   Gemini   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
 | Llamafile  |      ✅      |      ✅      |      ✅ |      ❌      |      ✅       |
+|  llamacpp  |      ✅      |      ✅      |      ❌ |      ❌      |      ✅       |
 |   Ollama   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
 |   OpenAI   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ for _, model := range models.Data {
 |  DeepSeek  |      ✅      |      ✅      |      ✅ |      ✅      |      ❌       |
 |   Gemini   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
 |    Groq    |      ✅      |      ✅      |      ✅ |      ❌      |      ❌       |
-|  llama.cpp  |      ✅      |      ✅      |      ❌ |      ❌      |      ✅       |
+|  llama.cpp  |      ✅      |      ✅      |      ✅ |      ❌      |      ✅       |
 | Llamafile  |      ✅      |      ✅      |      ✅ |      ❌      |      ✅       |
 |  Mistral   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
 |   Ollama   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ for _, model := range models.Data {
 |  DeepSeek  |      ✅      |      ✅      |      ✅ |      ✅      |      ❌       |
 |   Gemini   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
 |    Groq    |      ✅      |      ✅      |      ✅ |      ❌      |      ❌       |
-|  llamacpp  |      ✅      |      ✅      |      ❌ |      ❌      |      ✅       |
+|  llama.cpp  |      ✅      |      ✅      |      ❌ |      ❌      |      ✅       |
 | Llamafile  |      ✅      |      ✅      |      ✅ |      ❌      |      ✅       |
 |  Mistral   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
 |   Ollama   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -10,6 +10,7 @@ any-llm-go supports multiple LLM providers through a unified interface. Each pro
 | [DeepSeek](#deepseek)   | `deepseek`  |     ✅      |     ✅     |   ✅   |     ✅     |     ❌      |      ✅      |
 | [Gemini](#gemini)       | `gemini`    |     ✅      |     ✅     |   ✅   |     ✅     |     ✅      |      ✅      |
 | [Groq](#groq)           | `groq`      |     ✅      |     ✅     |   ✅   |     ❌     |     ❌      |      ✅      |
+| [llama.cpp](#llamacpp)   | `llamacpp`  |     ✅      |     ✅     |   ✅   |     ❌     |     ✅      |      ✅      |
 | [Llamafile](#llamafile) | `llamafile` |     ✅      |     ✅     |   ✅   |     ❌     |     ✅      |      ✅      |
 | [Mistral](#mistral)     | `mistral`   |     ✅      |     ✅     |   ✅   |     ✅     |     ✅      |      ✅      |
 | [Ollama](#ollama)       | `ollama`    |     ✅      |     ✅     |   ✅   |     ✅     |     ✅      |      ✅      |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -277,6 +277,66 @@ for _, model := range models.Data {
 }
 ```
 
+### llama.cpp
+
+llama.cpp offers a local server compatible with the OpenAI API. No API key is required by default.
+
+```go
+import (
+    anyllm "github.com/mozilla-ai/any-llm-go"
+    "github.com/mozilla-ai/any-llm-go/providers/llamacpp"
+)
+
+// Using default settings (localhost:8080).
+provider, err := llamacpp.New()
+
+// Or with custom base URL.
+provider, err := llamacpp.New(anyllm.WithBaseURL("http://localhost:9090/v1"))
+```
+
+**Environment Variable:** ```LLAMACPP_API_BASE``` (optional, defaults to ```http://127.0.0.1:8080/v1```)
+
+**Popular Models:**
+
+- ```LLaMA_CPP``` - Default identifier used by the server.
+- Any GGUF model loaded into the server (the ```Model``` parameter is often ignored by llama.cpp if only one model is loaded).
+
+**Reasoning/Thinking:**
+
+llama.cpp supports reasoning for models that provide it (like DeepSeek-R1 GGUF):
+
+```go
+response, err := provider.Completion(ctx, anyllm.CompletionParams{
+    Model: "LLaMA_CPP",
+    Messages: messages,
+    ReasoningEffort: anyllm.ReasoningEffortMedium,
+})
+
+if response.Choices[0].Message.Reasoning != nil {
+    fmt.Println("Thinking:", response.Choices[0].Message.Reasoning.Content)
+}
+```
+
+**Embeddings:**
+
+```go
+provider, _ := llamacpp.New()
+resp, err := provider.Embedding(ctx, anyllm.EmbeddingParams{
+    Model: "LLaMA_CPP",
+    Input: "Hello, world!",
+})
+```
+
+**List Models:**
+
+```go
+provider, _ := llamacpp.New()
+models, err := provider.ListModels(ctx)
+for _, model := range models.Data {
+    fmt.Println(model.ID)
+}
+```
+
 ### OpenAI
 
 ```go

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -294,8 +294,6 @@ provider, err := llamacpp.New()
 provider, err := llamacpp.New(anyllm.WithBaseURL("http://localhost:9090/v1"))
 ```
 
-**Environment Variable:** ```LLAMACPP_API_BASE``` (optional, defaults to ```http://127.0.0.1:8080/v1```)
-
 **Popular Models:**
 
 - ```LLaMA_CPP``` - Default identifier used by the server.

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -28,6 +28,7 @@ var ProviderModelMap = map[string]string{
 	"xai":        "grok-beta",
 	"cerebras":   "llama3.1-8b",
 	"openrouter": "meta-llama/llama-3.1-8b-instruct",
+	"llamacpp":   "Qwen2.5-7B-Instruct",
 }
 
 // ProviderReasoningModelMap maps providers to reasoning-capable models.

--- a/providers/llamacpp/llamacpp.go
+++ b/providers/llamacpp/llamacpp.go
@@ -11,7 +11,7 @@ import (
 const (
 	defaultBaseURL = "http://127.0.0.1:8080/v1"
 	providerName   = "llamacpp"
-	dummyAPIKey    = "llama-cpp-dummy-key"
+	defaultAPIKey  = "llama-cpp-dummy-key"
 )
 
 var (

--- a/providers/llamacpp/llamacpp.go
+++ b/providers/llamacpp/llamacpp.go
@@ -35,7 +35,6 @@ type Provider struct {
 
 // New returns a Provider that communicates with a llama.cpp server.
 func New(opts ...config.Option) (*Provider, error) {
-
 	base, err := openai.NewCompatible(openai.CompatibleConfig{
 		APIKeyEnvVar:   "", // we don't read from env by default
 		BaseURLEnvVar:  "",

--- a/providers/llamacpp/llamacpp.go
+++ b/providers/llamacpp/llamacpp.go
@@ -11,7 +11,6 @@ import (
 const (
 	defaultBaseURL = "http://127.0.0.1:8080/v1"
 	providerName   = "llamacpp"
-	envBaseURL     = "LLAMACPP_API_BASE"
 	dummyAPIKey    = "llama-cpp-dummy-key"
 )
 

--- a/providers/llamacpp/llamacpp.go
+++ b/providers/llamacpp/llamacpp.go
@@ -1,0 +1,61 @@
+package llamacpp
+
+import (
+	"os"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	"github.com/mozilla-ai/any-llm-go/providers"
+	"github.com/mozilla-ai/any-llm-go/providers/openai"
+)
+
+const (
+	defaultBaseURL = "http://127.0.0.1:8080/v1"
+	providerName   = "llamacpp"
+	envBaseURL     = "LLAMACPP_API_BASE"
+	dummyAPIKey    = "llama-cpp-dummy-key"
+)
+
+var (
+	_ providers.Provider           = (*Provider)(nil)
+	_ providers.CapabilityProvider = (*Provider)(nil)
+	_ providers.EmbeddingProvider  = (*Provider)(nil)
+	_ providers.ModelLister        = (*Provider)(nil)
+	_ providers.ErrorConverter     = (*Provider)(nil)
+)
+
+type Provider struct {
+	*openai.CompatibleProvider
+}
+
+func New(opts ...config.Option) (*Provider, error) {
+	if url := os.Getenv(envBaseURL); url != "" {
+		opts = append([]config.Option{config.WithBaseURL(url)}, opts...)
+	}
+
+	defaults := []config.Option{
+		config.WithAPIKey(dummyAPIKey),
+	}
+	opts = append(defaults, opts...)
+
+	base, err := openai.NewCompatible(openai.CompatibleConfig{
+		APIKeyEnvVar:   "",
+		RequireAPIKey:  false,
+		Capabilities:   llamacppCapabilities(),
+		DefaultBaseURL: defaultBaseURL,
+		Name:           providerName,
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Provider{CompatibleProvider: base}, nil
+}
+
+func llamacppCapabilities() providers.Capabilities {
+	return providers.Capabilities{
+		Completion:          true,
+		CompletionStreaming: true,
+		Embedding:           true,
+		ListModels:          true,
+	}
+}

--- a/providers/llamacpp/llamacpp.go
+++ b/providers/llamacpp/llamacpp.go
@@ -1,8 +1,6 @@
 package llamacpp
 
 import (
-	"os"
-
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
 	"github.com/mozilla-ai/any-llm-go/providers/openai"
@@ -27,27 +25,21 @@ type Provider struct {
 }
 
 func New(opts ...config.Option) (*Provider, error) {
-
 	defaults := []config.Option{
-		config.WithAPIKey(dummyAPIKey),
+		config.WithAPIKey(defaultAPIKey),
 	}
 	opts = append(defaults, opts...)
 
 	base, err := openai.NewCompatible(openai.CompatibleConfig{
 		APIKeyEnvVar:   "",
-		RequireAPIKey:  false,
+		BaseURLEnvVar:  "",
 		Capabilities:   llamacppCapabilities(),
+		DefaultAPIKey:  defaultAPIKey,
 		DefaultBaseURL: defaultBaseURL,
 		Name:           providerName,
-	base, err := openai.NewCompatible(openai.CompatibleConfig{
-		APIKeyEnvVar:       "",
-		BaseURLEnvVar:      "",
-	    Capabilities:       llamacppCapabilities(),
-	    DefaultAPIKey:      defaultAPIKey,
-        DefaultBaseURL:     defaultBaseURL,
-		Name:               providerName,
-		RequireAPIKey:      false,
+		RequireAPIKey:  false,
 	}, opts...)
+
 	if err != nil {
 		return nil, err
 	}

--- a/providers/llamacpp/llamacpp.go
+++ b/providers/llamacpp/llamacpp.go
@@ -39,6 +39,14 @@ func New(opts ...config.Option) (*Provider, error) {
 		Capabilities:   llamacppCapabilities(),
 		DefaultBaseURL: defaultBaseURL,
 		Name:           providerName,
+	base, err := openai.NewCompatible(openai.CompatibleConfig{
+		APIKeyEnvVar:       "",
+		BaseURLEnvVar:      "",
+	    Capabilities:       llamacppCapabilities(),
+	    DefaultAPIKey:      defaultAPIKey,
+        DefaultBaseURL:     defaultBaseURL,
+		Name:               providerName,
+		RequireAPIKey:      false,
 	}, opts...)
 	if err != nil {
 		return nil, err

--- a/providers/llamacpp/llamacpp.go
+++ b/providers/llamacpp/llamacpp.go
@@ -39,7 +39,6 @@ func New(opts ...config.Option) (*Provider, error) {
 		Name:           providerName,
 		RequireAPIKey:  false,
 	}, opts...)
-
 	if err != nil {
 		return nil, err
 	}

--- a/providers/llamacpp/llamacpp.go
+++ b/providers/llamacpp/llamacpp.go
@@ -17,6 +17,7 @@ const (
 	providerName   = "llamacpp"
 	defaultAPIKey  = "llama-cpp-dummy-key"
 )
+
 // Ensure Provider implements the required interfaces.
 var (
 	_ providers.CapabilityProvider = (*Provider)(nil)

--- a/providers/llamacpp/llamacpp.go
+++ b/providers/llamacpp/llamacpp.go
@@ -34,11 +34,6 @@ type Provider struct {
 
 // New returns a Provider that communicates with a llama.cpp server.
 func New(opts ...config.Option) (*Provider, error) {
-	// Always inject our dummy key unless the caller explicitly overrides it
-	defaults := []config.Option{
-		config.WithAPIKey(defaultAPIKey),
-	}
-	opts = append(defaults, opts...)
 
 	base, err := openai.NewCompatible(openai.CompatibleConfig{
 		APIKeyEnvVar:   "", // we don't read from env by default

--- a/providers/llamacpp/llamacpp.go
+++ b/providers/llamacpp/llamacpp.go
@@ -27,9 +27,6 @@ type Provider struct {
 }
 
 func New(opts ...config.Option) (*Provider, error) {
-	if url := os.Getenv(envBaseURL); url != "" {
-		opts = append([]config.Option{config.WithBaseURL(url)}, opts...)
-	}
 
 	defaults := []config.Option{
 		config.WithAPIKey(dummyAPIKey),

--- a/providers/llamacpp/llamacpp.go
+++ b/providers/llamacpp/llamacpp.go
@@ -17,6 +17,14 @@ const (
 	providerName   = "llamacpp"
 	defaultAPIKey  = "llama-cpp-dummy-key"
 )
+// Ensure Provider implements the required interfaces.
+var (
+	_ providers.CapabilityProvider = (*Provider)(nil)
+	_ providers.EmbeddingProvider  = (*Provider)(nil)
+	_ providers.ErrorConverter     = (*Provider)(nil)
+	_ providers.ModelLister        = (*Provider)(nil)
+	_ providers.Provider           = (*Provider)(nil)
+)
 
 // Provider is a thin wrapper around the generic OpenAI-compatible provider,
 // pre-configured with llama.cpp defaults and quirks.

--- a/providers/llamacpp/llamacpp_test.go
+++ b/providers/llamacpp/llamacpp_test.go
@@ -66,7 +66,7 @@ func TestCapabilities(t *testing.T) {
 // TestIntegration_Llamacpp runs real calls against a live llama.cpp server.
 //
 // Skipped automatically if no server is responding on the default port.
-func TestIntegration_Llamacpp(t *testing.T) {
+func TestIntegration.(t *testing.T) {
 	t.Parallel()
 
 	skipIfLlamacppUnavailable(t)

--- a/providers/llamacpp/llamacpp_test.go
+++ b/providers/llamacpp/llamacpp_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	anyllm "github.com/mozilla-ai/any-llm-go"
@@ -66,7 +65,7 @@ func TestCapabilities(t *testing.T) {
 // TestIntegration_Llamacpp runs real calls against a live llama.cpp server.
 //
 // Skipped automatically if no server is responding on the default port.
-func TestIntegration.(t *testing.T) {
+func TestIntegration(t *testing.T) {
 	t.Parallel()
 
 	skipIfLlamacppUnavailable(t)

--- a/providers/llamacpp/llamacpp_test.go
+++ b/providers/llamacpp/llamacpp_test.go
@@ -57,10 +57,10 @@ func TestCapabilities(t *testing.T) {
 	require.NoError(t, err)
 
 	caps := p.Capabilities()
-	assert.True(t, caps.Completion, "should support completion")
-	assert.True(t, caps.CompletionStreaming, "should support streaming")
-	assert.True(t, caps.Embedding, "should support embeddings")
-	assert.True(t, caps.ListModels, "should support listing models")
+	require.True(t, caps.Completion)
+	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.Embedding)
+	require.True(t, caps.ListModels)
 }
 
 // TestIntegration_Llamacpp runs real calls against a live llama.cpp server.

--- a/providers/llamacpp/llamacpp_test.go
+++ b/providers/llamacpp/llamacpp_test.go
@@ -13,11 +13,17 @@ import (
 )
 
 const (
-	testBaseURL                     = "http://127.0.0.1:8080/v1"
-	testModel                       = "llama.cpp"
+	// testBaseURL points to the default llama-server localhost endpoint
+	testBaseURL = "http://127.0.0.1:8080/v1"
+
+	// testModel is the name typically returned by /v1/models when only one model is loaded
+	testModel = "llama.cpp"
+
+	// testLlamacppAvailabilityTimeout is how long we wait to check if the server is alive
 	testLlamacppAvailabilityTimeout = 5 * time.Second
 )
 
+// TestNew checks that the provider can be created with defaults or custom options.
 func TestNew(t *testing.T) {
 	t.Parallel()
 
@@ -27,64 +33,77 @@ func TestNew(t *testing.T) {
 		require.NotNil(t, p)
 	})
 
-	t.Run("creates provider with options", func(t *testing.T) {
+	t.Run("creates provider with custom options", func(t *testing.T) {
 		p, err := New(anyllm.WithBaseURL("http://custom:8080"))
 		require.NoError(t, err)
 		require.NotNil(t, p)
 	})
 }
 
+// TestProviderName verifies the provider returns the correct identifier.
 func TestProviderName(t *testing.T) {
 	t.Parallel()
+
 	p, err := New()
 	require.NoError(t, err)
 	assert.Equal(t, providerName, p.Name())
 }
 
+// TestCapabilities confirms the provider advertises the expected feature set.
 func TestCapabilities(t *testing.T) {
 	t.Parallel()
+
 	p, err := New()
 	require.NoError(t, err)
+
 	caps := p.Capabilities()
-	assert.True(t, caps.Completion)
-	assert.True(t, caps.CompletionStreaming)
-	assert.True(t, caps.Embedding)
-	assert.True(t, caps.ListModels)
+	assert.True(t, caps.Completion, "should support completion")
+	assert.True(t, caps.CompletionStreaming, "should support streaming")
+	assert.True(t, caps.Embedding, "should support embeddings")
+	assert.True(t, caps.ListModels, "should support listing models")
 }
 
+// TestIntegration_Llamacpp runs real calls against a live llama.cpp server.
+//
+// Skipped automatically if no server is responding on the default port.
 func TestIntegration_Llamacpp(t *testing.T) {
 	t.Parallel()
+
 	skipIfLlamacppUnavailable(t)
 
 	p, err := New(anyllm.WithTimeout(30 * time.Second))
 	require.NoError(t, err)
+
 	ctx := context.Background()
 
-	t.Run("ListModels", func(t *testing.T) {
+	t.Run("ListModels returns at least one model", func(t *testing.T) {
 		models, err := p.ListModels(ctx)
 		require.NoError(t, err)
-		require.NotEmpty(t, models.Data)
+		require.NotEmpty(t, models.Data, "should return at least one loaded model")
 	})
 
-	t.Run("Completion", func(t *testing.T) {
+	t.Run("Completion generates text", func(t *testing.T) {
 		resp, err := p.Completion(ctx, anyllm.CompletionParams{
 			Model:    testModel,
 			Messages: testutil.MessagesWithSystem(),
 		})
 		require.NoError(t, err)
-		require.NotEmpty(t, resp.Choices[0].Message.Content)
+		require.NotEmpty(t, resp.Choices[0].Message.Content, "response should not be empty")
 	})
 
-	t.Run("Embedding", func(t *testing.T) {
+	t.Run("Embedding generates vectors", func(t *testing.T) {
 		resp, err := p.Embedding(ctx, anyllm.EmbeddingParams{
 			Model: testModel,
 			Input: []string{"test"},
 		})
 		require.NoError(t, err)
-		require.NotEmpty(t, resp.Data)
+		require.NotEmpty(t, resp.Data, "should return at least one embedding")
 	})
 }
 
+// skipIfLlamacppUnavailable skips the test if no functional llama.cpp server is detected.
+//
+// It makes a quick /v1/models call to check. Waits up to 5 seconds.
 func skipIfLlamacppUnavailable(t *testing.T) {
 	t.Helper()
 
@@ -97,6 +116,6 @@ func skipIfLlamacppUnavailable(t *testing.T) {
 	}
 
 	if _, err = p.ListModels(ctx); err != nil {
-		t.Skip("llamacpp not available: server not responding at " + testBaseURL)
+		t.Skipf("llamacpp not available: server not responding at %s (error: %v)", testBaseURL, err)
 	}
 }

--- a/providers/llamacpp/llamacpp_test.go
+++ b/providers/llamacpp/llamacpp_test.go
@@ -62,7 +62,7 @@ func TestCapabilities(t *testing.T) {
 	require.True(t, caps.ListModels)
 }
 
-// TestIntegration_Llamacpp runs real calls against a live llama.cpp server.
+// TestIntegration runs real calls against a live llama.cpp server.
 //
 // Skipped automatically if no server is responding on the default port.
 func TestIntegration(t *testing.T) {

--- a/providers/llamacpp/llamacpp_test.go
+++ b/providers/llamacpp/llamacpp_test.go
@@ -1,0 +1,70 @@
+package llamacpp
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	anyllm "github.com/mozilla-ai/any-llm-go"
+	"github.com/mozilla-ai/any-llm-go/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+const testBaseURL = "http://127.0.0.1:8080/v1"
+const testModel = "llama.cpp"
+
+func TestNew(t *testing.T) {
+	t.Run("creates provider with defaults", func(t *testing.T) {
+		p, err := New()
+		require.NoError(t, err)
+		require.NotNil(t, p)
+	})
+}
+
+func serverRunning(t *testing.T) bool {
+	t.Helper()
+	client := &http.Client{Timeout: 1 * time.Second}
+	resp, err := client.Get(testBaseURL + "/models")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+func TestIntegration_Llamacpp(t *testing.T) {
+	if !serverRunning(t) {
+		t.Skip("No llama.cpp server running")
+	}
+
+	p, err := New(anyllm.WithTimeout(30 * time.Second))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	t.Run("ListModels", func(t *testing.T) {
+		models, err := p.ListModels(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, models.Data)
+	})
+
+	t.Run("Completion", func(t *testing.T) {
+		resp, err := p.Completion(ctx, anyllm.CompletionParams{
+			Model:    testModel,
+			Messages: testutil.MessagesWithSystem(),
+		})
+		require.NoError(t, err)
+		content, ok := resp.Choices[0].Message.Content.(string)
+		require.True(t, ok)
+		require.NotEmpty(t, content)
+	})
+
+	t.Run("Embedding", func(t *testing.T) {
+		resp, err := p.Embedding(ctx, anyllm.EmbeddingParams{
+			Model: testModel,
+			Input: []string{"test"},
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.Data)
+	})
+}

--- a/providers/llamacpp/llamacpp_test.go
+++ b/providers/llamacpp/llamacpp_test.go
@@ -88,7 +88,8 @@ func TestIntegration_Llamacpp(t *testing.T) {
 			Messages: testutil.MessagesWithSystem(),
 		})
 		require.NoError(t, err)
-		require.NotEmpty(t, resp.Choices[0].Message.Content, "response should not be empty")
+		require.Len(t, resp.Choices, 1)
+		require.NotEmpty(t, resp.Choices[0].Message.Content)
 	})
 
 	t.Run("Embedding generates vectors", func(t *testing.T) {

--- a/providers/llamacpp/llamacpp_test.go
+++ b/providers/llamacpp/llamacpp_test.go
@@ -12,9 +12,6 @@ import (
 )
 
 const (
-	// testBaseURL points to the default llama-server localhost endpoint
-	testBaseURL = "http://127.0.0.1:8080/v1"
-
 	// testModel is the name typically returned by /v1/models when only one model is loaded
 	testModel = "llama.cpp"
 

--- a/providers/llamacpp/llamacpp_test.go
+++ b/providers/llamacpp/llamacpp_test.go
@@ -46,7 +46,7 @@ func TestProviderName(t *testing.T) {
 
 	p, err := New()
 	require.NoError(t, err)
-	assert.Equal(t, providerName, p.Name())
+	require.Equal(t, providerName, p.Name())
 }
 
 // TestCapabilities confirms the provider advertises the expected feature set.

--- a/providers/llamacpp/llamacpp_test.go
+++ b/providers/llamacpp/llamacpp_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 	"time"
 
-	anyllm "github.com/mozilla-ai/any-llm-go"
-	"github.com/mozilla-ai/any-llm-go/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	anyllm "github.com/mozilla-ai/any-llm-go"
+	"github.com/mozilla-ai/any-llm-go/internal/testutil"
 )
 
 const (

--- a/providers/llamacpp/llamacpp_test.go
+++ b/providers/llamacpp/llamacpp_test.go
@@ -113,6 +113,6 @@ func skipIfLlamacppUnavailable(t *testing.T) {
 	}
 
 	if _, err = p.ListModels(ctx); err != nil {
-		t.Skipf("llamacpp not available: server not responding at %s (error: %v)", testBaseURL, err)
+		t.Skipf("llamacpp not available: server not responding at %s (error: %v)", defaultBaseURL, err)
 	}
 }


### PR DESCRIPTION
## Summary

I've added support for llama.cpp. Both the `docs` and the records have been updated accordingly.

## Testing

**Unit Tests:** `PASS`
**Integration (Completion):** `PASS`
**Integration (Streaming):** `PASS`
**Integration (Embeddings):** `PASS` (requires flag `--pooling mean` on the server).