### PR TITLE
fix(llamacpp): tidy constants, comments and test assertions

### DIFF
--- a/providers/llamacpp/llamacpp.go
+++ b/providers/llamacpp/llamacpp.go
@@ -12,10 +12,14 @@ import (
 )
 
 const (
+	// defaultAPIKey is a dummy key for the OpenAI-compatible client.
+	defaultAPIKey = "llama-cpp-dummy-key"
+
 	// defaultBaseURL is where most people run llama-server locally.
 	defaultBaseURL = "http://127.0.0.1:8080/v1"
-	providerName   = "llamacpp"
-	defaultAPIKey  = "llama-cpp-dummy-key"
+
+	// providerName identifies this provider in error messages and lookups.
+	providerName = "llamacpp"
 )
 
 // Ensure Provider implements the required interfaces.
@@ -36,13 +40,13 @@ type Provider struct {
 // New returns a Provider that communicates with a llama.cpp server.
 func New(opts ...config.Option) (*Provider, error) {
 	base, err := openai.NewCompatible(openai.CompatibleConfig{
-		APIKeyEnvVar:   "", // we don't read from env by default
+		APIKeyEnvVar:   "",
 		BaseURLEnvVar:  "",
-		Capabilities:   llamacppCapabilities(),
+		Capabilities:   capabilities(),
 		DefaultAPIKey:  defaultAPIKey,
 		DefaultBaseURL: defaultBaseURL,
 		Name:           providerName,
-		RequireAPIKey:  false, // llama.cpp doesn't care
+		RequireAPIKey:  false,
 	}, opts...)
 	if err != nil {
 		return nil, err
@@ -51,9 +55,9 @@ func New(opts ...config.Option) (*Provider, error) {
 	return &Provider{CompatibleProvider: base}, nil
 }
 
-// llamacppCapabilities returns the feature set that a typical recent llama.cpp
+// capabilities returns the feature set that a typical recent llama.cpp
 // server actually implements reliably through its /v1 endpoint.
-func llamacppCapabilities() providers.Capabilities {
+func capabilities() providers.Capabilities {
 	return providers.Capabilities{
 		Completion:          true,
 		CompletionStreaming: true,

--- a/providers/llamacpp/llamacpp_test.go
+++ b/providers/llamacpp/llamacpp_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 const (
-	// testModel is the name typically returned by /v1/models when only one model is loaded
+	// testModel is the name typically returned by /v1/models when only one model is loaded.
 	testModel = "llama.cpp"
 
-	// testLlamacppAvailabilityTimeout is how long we wait to check if the server is alive
+	// testLlamacppAvailabilityTimeout is how long we wait to check if the server is alive.
 	testLlamacppAvailabilityTimeout = 5 * time.Second
 )
 
@@ -73,12 +73,16 @@ func TestIntegration(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("ListModels returns at least one model", func(t *testing.T) {
+		t.Parallel()
+
 		models, err := p.ListModels(ctx)
 		require.NoError(t, err)
-		require.NotEmpty(t, models.Data, "should return at least one loaded model")
+		require.NotEmpty(t, models.Data)
 	})
 
 	t.Run("Completion generates text", func(t *testing.T) {
+		t.Parallel()
+
 		resp, err := p.Completion(ctx, anyllm.CompletionParams{
 			Model:    testModel,
 			Messages: testutil.MessagesWithSystem(),
@@ -89,12 +93,14 @@ func TestIntegration(t *testing.T) {
 	})
 
 	t.Run("Embedding generates vectors", func(t *testing.T) {
+		t.Parallel()
+
 		resp, err := p.Embedding(ctx, anyllm.EmbeddingParams{
 			Model: testModel,
 			Input: []string{"test"},
 		})
 		require.NoError(t, err)
-		require.NotEmpty(t, resp.Data, "should return at least one embedding")
+		require.NotEmpty(t, resp.Data)
 	})
 }
 


### PR DESCRIPTION
## Summary
- Reorder constants alphabetically with doc comments
- Remove inline comments from CompatibleConfig fields
- Rename `llamacppCapabilities` to `capabilities` (no need to repeat the package name)
- Add fullstops to test constant comments
- Add `t.Parallel()` to integration subtests
- Remove `msgAndArgs` from `require` calls

## Test plan
- [x] `golangci-lint run --fix -v ./providers/llamacpp/...` passes clean
- [x] Unit tests pass: `go test ./providers/llamacpp/...`