### PR TITLE
align naming for unexported capabilities methods

### DIFF
--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -52,7 +52,7 @@ func New(opts ...config.Option) (*Provider, error) {
 	base, err := openai.NewCompatible(openai.CompatibleConfig{
 		APIKeyEnvVar:   envAPIKey,
 		BaseURLEnvVar:  "",
-		Capabilities:   deepseekCapabilities(),
+		Capabilities:   capabilities(),
 		DefaultAPIKey:  "",
 		DefaultBaseURL: defaultBaseURL,
 		Name:           providerName,
@@ -85,8 +85,8 @@ func (p *Provider) CompletionStream(
 	return p.CompatibleProvider.CompletionStream(ctx, params)
 }
 
-// deepseekCapabilities returns the capabilities for the DeepSeek provider.
-func deepseekCapabilities() providers.Capabilities {
+// capabilities returns the capabilities for the DeepSeek provider.
+func capabilities() providers.Capabilities {
 	return providers.Capabilities{
 		Completion:          true,
 		CompletionImage:     false, // DeepSeek doesn't support images.

--- a/providers/groq/groq.go
+++ b/providers/groq/groq.go
@@ -41,7 +41,7 @@ func New(opts ...config.Option) (*Provider, error) {
 	base, err := openai.NewCompatible(openai.CompatibleConfig{
 		APIKeyEnvVar:   envAPIKey,
 		BaseURLEnvVar:  "",
-		Capabilities:   groqCapabilities(),
+		Capabilities:   capabilities(),
 		DefaultAPIKey:  "",
 		DefaultBaseURL: defaultBaseURL,
 		Name:           providerName,
@@ -54,8 +54,8 @@ func New(opts ...config.Option) (*Provider, error) {
 	return &Provider{CompatibleProvider: base}, nil
 }
 
-// groqCapabilities returns the capabilities for the Groq provider.
-func groqCapabilities() providers.Capabilities {
+// capabilities returns the capabilities for the Groq provider.
+func capabilities() providers.Capabilities {
 	return providers.Capabilities{
 		Completion:          true,
 		CompletionImage:     false, // Groq doesn't support image inputs.

--- a/providers/llamafile/llamafile.go
+++ b/providers/llamafile/llamafile.go
@@ -37,7 +37,7 @@ func New(opts ...config.Option) (*Provider, error) {
 	base, err := openai.NewCompatible(openai.CompatibleConfig{
 		APIKeyEnvVar:   "", // Llamafile doesn't use an API key env var.
 		BaseURLEnvVar:  envBaseURL,
-		Capabilities:   llamafileCapabilities(),
+		Capabilities:   capabilities(),
 		DefaultAPIKey:  defaultAPIKey,
 		DefaultBaseURL: defaultBaseURL,
 		Name:           providerName,
@@ -50,8 +50,8 @@ func New(opts ...config.Option) (*Provider, error) {
 	return &Provider{CompatibleProvider: base}, nil
 }
 
-// llamafileCapabilities returns the capabilities for the Llamafile provider.
-func llamafileCapabilities() providers.Capabilities {
+// capabilities returns the capabilities for the Llamafile provider.
+func capabilities() providers.Capabilities {
 	return providers.Capabilities{
 		Completion:          true,
 		CompletionImage:     true, // Depends on the model loaded.

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -50,7 +50,7 @@ func New(opts ...config.Option) (*Provider, error) {
 	base, err := openai.NewCompatible(openai.CompatibleConfig{
 		APIKeyEnvVar:   envAPIKey,
 		BaseURLEnvVar:  "",
-		Capabilities:   mistralCapabilities(),
+		Capabilities:   capabilities(),
 		DefaultAPIKey:  "",
 		DefaultBaseURL: defaultBaseURL,
 		Name:           providerName,
@@ -83,8 +83,8 @@ func (p *Provider) CompletionStream(
 	return p.CompatibleProvider.CompletionStream(ctx, params)
 }
 
-// mistralCapabilities returns the capabilities for the Mistral provider.
-func mistralCapabilities() providers.Capabilities {
+// capabilities returns the capabilities for the Mistral provider.
+func capabilities() providers.Capabilities {
 	return providers.Capabilities{
 		Completion:          true,
 		CompletionImage:     true, // Pixtral models support vision.

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -31,7 +31,7 @@ type Provider struct {
 func New(opts ...config.Option) (*Provider, error) {
 	base, err := NewCompatible(CompatibleConfig{
 		APIKeyEnvVar:   envAPIKey,
-		Capabilities:   openAICapabilities(),
+		Capabilities:   capabilities(),
 		DefaultBaseURL: defaultBaseURL,
 		Name:           providerName,
 		RequireAPIKey:  true,
@@ -43,8 +43,8 @@ func New(opts ...config.Option) (*Provider, error) {
 	return &Provider{CompatibleProvider: base}, nil
 }
 
-// openAICapabilities returns the capabilities for the OpenAI provider.
-func openAICapabilities() providers.Capabilities {
+// capabilities returns the capabilities for the OpenAI provider.
+func capabilities() providers.Capabilities {
 	return providers.Capabilities{
 		Completion:          true,
 		CompletionImage:     true,


### PR DESCRIPTION
## Summary

Align the unexported method name, that returns the supported capabilities of each provider.

## Changes

<!-- List the changes made -->
- `xxxCapabilities() => capabilities()` in related providers.

## Checklist

- [x] Tests pass locally (`make test`)
- [x] Linting passes (`make lint`)
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or documented in summary)
