### PR TITLE
feat(providers): add CompletionTools field to Capabilities struct

### DIFF
--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -122,6 +122,7 @@ func NewMockProvider() *MockProvider {
 			return providers.Capabilities{
 				Completion:          true,
 				CompletionStreaming: true,
+				CompletionTools:     true,
 				Embedding:           true,
 				ListModels:          true,
 			}

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -124,10 +124,11 @@ func New(opts ...config.Option) (*Provider, error) {
 func (p *Provider) Capabilities() providers.Capabilities {
 	return providers.Capabilities{
 		Completion:          true,
-		CompletionStreaming: true,
-		CompletionReasoning: true,
 		CompletionImage:     true,
 		CompletionPDF:       true,
+		CompletionReasoning: true,
+		CompletionStreaming: true,
+		CompletionTools:     true,
 		Embedding:           false,
 		ListModels:          false,
 	}

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -57,10 +57,11 @@ func TestCapabilities(t *testing.T) {
 	caps := provider.Capabilities()
 
 	require.True(t, caps.Completion)
-	require.True(t, caps.CompletionStreaming)
-	require.True(t, caps.CompletionReasoning)
 	require.True(t, caps.CompletionImage)
 	require.True(t, caps.CompletionPDF)
+	require.True(t, caps.CompletionReasoning)
+	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.CompletionTools)
 	require.False(t, caps.Embedding) // Anthropic doesn't support embeddings.
 	require.False(t, caps.ListModels)
 }

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -93,6 +93,7 @@ func capabilities() providers.Capabilities {
 		CompletionPDF:       false,
 		CompletionReasoning: true, // DeepSeek R1 supports reasoning.
 		CompletionStreaming: true,
+		CompletionTools:     true,
 		Embedding:           false, // DeepSeek doesn't host embedding models.
 		ListModels:          true,
 	}

--- a/providers/deepseek/deepseek_test.go
+++ b/providers/deepseek/deepseek_test.go
@@ -60,10 +60,11 @@ func TestCapabilities(t *testing.T) {
 	caps := provider.Capabilities()
 
 	require.True(t, caps.Completion)
-	require.True(t, caps.CompletionStreaming)
-	require.True(t, caps.CompletionReasoning)
 	require.False(t, caps.CompletionImage)
 	require.False(t, caps.CompletionPDF)
+	require.True(t, caps.CompletionReasoning)
+	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.CompletionTools)
 	require.False(t, caps.Embedding)
 	require.True(t, caps.ListModels)
 }

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -147,6 +147,7 @@ func (p *Provider) Capabilities() providers.Capabilities {
 		CompletionPDF:       false,
 		CompletionReasoning: true,
 		CompletionStreaming: true,
+		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
 	}

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -64,10 +64,11 @@ func TestCapabilities(t *testing.T) {
 	caps := provider.Capabilities()
 
 	require.True(t, caps.Completion)
-	require.True(t, caps.CompletionStreaming)
-	require.True(t, caps.CompletionReasoning)
 	require.True(t, caps.CompletionImage)
 	require.False(t, caps.CompletionPDF)
+	require.True(t, caps.CompletionReasoning)
+	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.CompletionTools)
 	require.True(t, caps.Embedding)
 	require.True(t, caps.ListModels)
 }

--- a/providers/groq/groq.go
+++ b/providers/groq/groq.go
@@ -62,6 +62,7 @@ func capabilities() providers.Capabilities {
 		CompletionPDF:       false,
 		CompletionReasoning: false, // Groq doesn't support reasoning parameters.
 		CompletionStreaming: true,
+		CompletionTools:     true,
 		Embedding:           false, // Groq doesn't host embedding models.
 		ListModels:          true,
 	}

--- a/providers/groq/groq_test.go
+++ b/providers/groq/groq_test.go
@@ -60,10 +60,11 @@ func TestCapabilities(t *testing.T) {
 	caps := provider.Capabilities()
 
 	require.True(t, caps.Completion)
-	require.True(t, caps.CompletionStreaming)
-	require.False(t, caps.CompletionReasoning)
 	require.False(t, caps.CompletionImage)
 	require.False(t, caps.CompletionPDF)
+	require.False(t, caps.CompletionReasoning)
+	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.CompletionTools)
 	require.False(t, caps.Embedding)
 	require.True(t, caps.ListModels)
 }

--- a/providers/llamacpp/llamacpp.go
+++ b/providers/llamacpp/llamacpp.go
@@ -61,6 +61,7 @@ func capabilities() providers.Capabilities {
 	return providers.Capabilities{
 		Completion:          true,
 		CompletionStreaming: true,
+		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
 	}

--- a/providers/llamacpp/llamacpp_test.go
+++ b/providers/llamacpp/llamacpp_test.go
@@ -55,6 +55,7 @@ func TestCapabilities(t *testing.T) {
 	caps := p.Capabilities()
 	require.True(t, caps.Completion)
 	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.CompletionTools)
 	require.True(t, caps.Embedding)
 	require.True(t, caps.ListModels)
 }

--- a/providers/llamafile/llamafile.go
+++ b/providers/llamafile/llamafile.go
@@ -58,6 +58,7 @@ func capabilities() providers.Capabilities {
 		CompletionPDF:       false,
 		CompletionReasoning: false, // Llamafile doesn't support reasoning natively.
 		CompletionStreaming: true,
+		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
 	}

--- a/providers/llamafile/llamafile_test.go
+++ b/providers/llamafile/llamafile_test.go
@@ -61,10 +61,11 @@ func TestCapabilities(t *testing.T) {
 	caps := provider.Capabilities()
 
 	require.True(t, caps.Completion)
-	require.True(t, caps.CompletionStreaming)
-	require.False(t, caps.CompletionReasoning)
 	require.True(t, caps.CompletionImage)
 	require.False(t, caps.CompletionPDF)
+	require.False(t, caps.CompletionReasoning)
+	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.CompletionTools)
 	require.True(t, caps.Embedding)
 	require.True(t, caps.ListModels)
 }

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -91,6 +91,7 @@ func capabilities() providers.Capabilities {
 		CompletionPDF:       false,
 		CompletionReasoning: true, // Magistral models support reasoning.
 		CompletionStreaming: true,
+		CompletionTools:     true,
 		Embedding:           true, // mistral-embed model.
 		ListModels:          true,
 	}

--- a/providers/mistral/mistral_test.go
+++ b/providers/mistral/mistral_test.go
@@ -60,10 +60,11 @@ func TestCapabilities(t *testing.T) {
 	caps := provider.Capabilities()
 
 	require.True(t, caps.Completion)
-	require.True(t, caps.CompletionStreaming)
-	require.True(t, caps.CompletionReasoning)
 	require.True(t, caps.CompletionImage)
 	require.False(t, caps.CompletionPDF)
+	require.True(t, caps.CompletionReasoning)
+	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.CompletionTools)
 	require.True(t, caps.Embedding)
 	require.True(t, caps.ListModels)
 }

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -139,10 +139,11 @@ func New(opts ...config.Option) (*Provider, error) {
 func (p *Provider) Capabilities() providers.Capabilities {
 	return providers.Capabilities{
 		Completion:          true,
-		CompletionStreaming: true,
-		CompletionReasoning: true,
 		CompletionImage:     true,
 		CompletionPDF:       false,
+		CompletionReasoning: true,
+		CompletionStreaming: true,
+		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
 	}

--- a/providers/ollama/ollama_test.go
+++ b/providers/ollama/ollama_test.go
@@ -57,10 +57,11 @@ func TestCapabilities(t *testing.T) {
 	caps := provider.Capabilities()
 
 	require.True(t, caps.Completion)
-	require.True(t, caps.CompletionStreaming)
-	require.True(t, caps.CompletionReasoning)
 	require.True(t, caps.CompletionImage)
 	require.False(t, caps.CompletionPDF)
+	require.True(t, caps.CompletionReasoning)
+	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.CompletionTools)
 	require.True(t, caps.Embedding)
 	require.True(t, caps.ListModels)
 }

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -51,6 +51,7 @@ func capabilities() providers.Capabilities {
 		CompletionPDF:       false,
 		CompletionReasoning: true,
 		CompletionStreaming: true,
+		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
 	}

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -57,9 +57,10 @@ func TestCapabilities(t *testing.T) {
 	caps := provider.Capabilities()
 
 	require.True(t, caps.Completion)
-	require.True(t, caps.CompletionStreaming)
-	require.True(t, caps.CompletionReasoning)
 	require.True(t, caps.CompletionImage)
+	require.True(t, caps.CompletionReasoning)
+	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.CompletionTools)
 	require.True(t, caps.Embedding)
 	require.True(t, caps.ListModels)
 }

--- a/providers/platform/platform.go
+++ b/providers/platform/platform.go
@@ -120,10 +120,11 @@ func (p *Provider) Capabilities() providers.Capabilities {
 	// Return full capabilities since we can proxy to any provider.
 	return providers.Capabilities{
 		Completion:          true,
-		CompletionStreaming: true,
-		CompletionReasoning: true,
 		CompletionImage:     true,
 		CompletionPDF:       true,
+		CompletionReasoning: true,
+		CompletionStreaming: true,
+		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
 	}

--- a/providers/platform/platform_test.go
+++ b/providers/platform/platform_test.go
@@ -63,8 +63,9 @@ func TestProvider_Capabilities(t *testing.T) {
 	caps := provider.Capabilities()
 
 	require.True(t, caps.Completion)
-	require.True(t, caps.CompletionStreaming)
 	require.True(t, caps.CompletionReasoning)
+	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.CompletionTools)
 	require.True(t, caps.Embedding)
 }
 

--- a/providers/types.go
+++ b/providers/types.go
@@ -79,6 +79,7 @@ type Capabilities struct {
 	CompletionPDF       bool
 	CompletionReasoning bool
 	CompletionStreaming bool
+	CompletionTools     bool
 	Embedding           bool
 	ListModels          bool
 }


### PR DESCRIPTION
## Summary

- Adds `CompletionTools bool` field to the `Capabilities` struct so callers can programmatically check tool/function calling support
- Sets `CompletionTools: true` for all providers (matching the existing docs tables)
- Updates all provider tests with capability assertions

Closes #39

## Test plan

- [x] All unit tests pass (`make test-unit`)
- [x] Linting passes (`golangci-lint run --fix -v`)
- [x] Each commit is atomic: one per provider with its test