### PR TITLE
chore: tidy Makefile and PR template checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@
 
 ## Checklist
 
-- [ ] Tests pass locally (`go test -short ./...`)
-- [ ] Linting passes (`golangci-lint run ./...`)
+- [ ] Linting passes (`make lint`)
+- [ ] Tests pass locally (`make test`)
 - [ ] Documentation updated (if needed)
 - [ ] No breaking changes (or documented in summary)

--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,54 @@
-.PHONY: lint test build clean fmt
+# Show available targets
+.PHONY: help
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  all        Run lint, test, and build"
+	@echo "  build      Verify compilation"
+	@echo "  clean      Clean test cache"
+	@echo "  help       Show this help"
+	@echo "  lint       Run linting with auto-fix"
+	@echo "  test       Run linting then all tests"
+	@echo "  test-only  Run all tests without linting"
+	@echo "  test-unit  Run unit tests only (skip integration)"
+	@echo "  tidy       Tidy go.mod dependencies"
+
+# Run all checks (lint + test + build)
+.PHONY: all
+all: test build
+
+# Build and verify compilation
+.PHONY: build
+build:
+	go build ./...
+
+# Clean test cache
+.PHONY: clean
+clean:
+	go clean -testcache
 
 # Run linting with auto-fix
+.PHONY: lint
 lint:
 	golangci-lint run --fix ./...
 
 # Run all tests
+.PHONY: test
 test: lint
 	go test -race ./...
 
 # Run tests without linting (faster)
+.PHONY: test-only
 test-only:
 	go test -v -race ./...
 
 # Run unit tests only (skip integration tests)
+.PHONY: test-unit
 test-unit:
 	go test -v -race -short ./...
 
-# Build and verify compilation
-build:
-	go build ./...
-
-# Format code
-fmt:
-	gofmt -s -w .
-	goimports -w .
-
-# Clean test cache
-clean:
-	go clean -testcache
-
 # Tidy dependencies
+.PHONY: tidy
 tidy:
 	go mod tidy
-
-# Run all checks (lint + test + build)
-all: lint test build


### PR DESCRIPTION
## Summary

- Tidy Makefile: remove redundant `fmt` target, add `help` target, sort targets alphabetically, fix `.PHONY` declarations
- Update PR template checklist to use `make lint` / `make test` instead of raw commands

## Testing

- `make help` outputs correct target list
- `make lint` and `make test` work as before