### PR TITLE
chore(sdk): bump version to v0.8.0

### DIFF
--- a/sdk/version.go
+++ b/sdk/version.go
@@ -2,4 +2,4 @@
 package sdk
 
 // Version is the library version string.
-const Version = "v0.7.0"
+const Version = "v0.8.0"


### PR DESCRIPTION
## Summary

Bump `sdk.Version` to `v0.8.0` in preparation for the v0.8.0 release.

## Changes

- Update `Version` const in `sdk/version.go` from `v0.7.0` to `v0.8.0`

## Testing

No logic changes — version const update only.

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass locally (`make test`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)