### PR TITLE
refactor(platform): file organization and config resolution

### DIFF
--- a/providers/platform/platform.go
+++ b/providers/platform/platform.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -25,23 +24,27 @@ import (
 	"github.com/mozilla-ai/any-llm-go/sdk"
 )
 
+// Provider configuration constants.
 const (
-	providerName       = "platform"
+	defaultPlatformURL = "https://platform-api.any-llm.ai/api/v1"
 	envAPIKey          = "ANY_LLM_KEY"
 	envPlatformURL     = "ANY_LLM_PLATFORM_URL"
-	defaultPlatformURL = "https://platform-api.any-llm.ai/api/v1"
+	providerName       = "platform"
 )
 
-// newProviderFunc creates a provider with the given options.
-type newProviderFunc func(opts ...config.Option) (providers.Provider, error)
+// Ensure Provider implements the required interfaces.
+var (
+	_ providers.CapabilityProvider = (*Provider)(nil)
+	_ providers.Provider           = (*Provider)(nil)
+)
 
 // supportedProviders maps provider names to their constructors.
 var supportedProviders = map[string]newProviderFunc{
-	"openai": func(opts ...config.Option) (providers.Provider, error) {
-		return openai.New(opts...)
-	},
 	"anthropic": func(opts ...config.Option) (providers.Provider, error) {
 		return anthropic.New(opts...)
+	},
+	"openai": func(opts ...config.Option) (providers.Provider, error) {
+		return openai.New(opts...)
 	},
 }
 
@@ -49,26 +52,41 @@ var supportedProviders = map[string]newProviderFunc{
 // It proxies requests to underlying providers (OpenAI, Anthropic, etc.) after
 // authenticating with the platform to get decrypted API keys.
 type Provider struct {
-	config         *config.Config
-	platformClient *anyllmplatform.Client
-	httpClient     *http.Client
-	anyLLMKey      string
-	clientName     string
-
-	// Cached provider information.
-	providerKeyID string
-	projectID     string
-
-	// The underlying provider that handles actual LLM calls.
-	underlyingProvider providers.Provider
+	anyLLMKey          string
+	clientName         string
+	config             *config.Config
+	httpClient         *http.Client
+	platformClient     *anyllmplatform.Client
+	platformURL        string
+	projectID          string
+	providerKeyID      string
 	underlyingName     string
+	underlyingProvider providers.Provider
 }
 
-// Ensure Provider implements the required interfaces.
-var (
-	_ providers.Provider           = (*Provider)(nil)
-	_ providers.CapabilityProvider = (*Provider)(nil)
-)
+// newProviderFunc creates a provider with the given options.
+type newProviderFunc func(opts ...config.Option) (providers.Provider, error)
+
+// streamingMetrics holds performance metrics for streaming requests.
+type streamingMetrics struct {
+	avgChunkSize                *float64
+	chunksReceived              int
+	interChunkLatencyVarianceMs *float64
+	timeToFirstTokenMs          *float64
+	timeToLastTokenMs           *float64
+	tokensPerSecond             *float64
+	totalDurationMs             float64
+}
+
+// usageEventPayload represents the payload for usage events.
+type usageEventPayload struct {
+	ClientName    string         `json:"client_name,omitempty"`
+	Data          map[string]any `json:"data"`
+	ID            string         `json:"id"`
+	Model         string         `json:"model"`
+	Provider      string         `json:"provider"`
+	ProviderKeyID string         `json:"provider_key_id"`
+}
 
 // New creates a new platform provider.
 func New(opts ...config.Option) (*Provider, error) {
@@ -82,7 +100,7 @@ func New(opts ...config.Option) (*Provider, error) {
 		return nil, errors.NewMissingAPIKeyError(providerName, envAPIKey)
 	}
 
-	platformURL := os.Getenv(envPlatformURL)
+	platformURL := cfg.ResolveEnv(envPlatformURL)
 	if platformURL == "" {
 		platformURL = defaultPlatformURL
 	}
@@ -98,22 +116,18 @@ func New(opts ...config.Option) (*Provider, error) {
 	}
 
 	return &Provider{
-		config:         cfg,
-		platformClient: platformClient,
-		httpClient:     &http.Client{Timeout: 30 * time.Second},
 		anyLLMKey:      anyLLMKey,
 		clientName:     clientName,
+		config:         cfg,
+		httpClient:     &http.Client{Timeout: 30 * time.Second},
+		platformClient: platformClient,
+		platformURL:    platformURL,
 	}, nil
 }
 
 // WithClientName sets a client name for per-client usage tracking.
 func WithClientName(name string) config.Option {
 	return config.WithExtra("client_name", strings.TrimSpace(name))
-}
-
-// Name returns the provider name.
-func (p *Provider) Name() string {
-	return providerName
 }
 
 // Capabilities returns the provider's capabilities.
@@ -132,13 +146,175 @@ func (p *Provider) Capabilities() providers.Capabilities {
 	}
 }
 
+// Completion performs a chat completion request.
+func (p *Provider) Completion(
+	ctx context.Context,
+	params providers.CompletionParams,
+) (*providers.ChatCompletion, error) {
+	startTime := time.Now()
+
+	// Parse the model to get the provider name.
+	providerName, modelID := parseModelString(params.Model)
+	if providerName == "" {
+		return nil, fmt.Errorf("model must be in format 'provider:model', got %q", params.Model)
+	}
+
+	// Initialize the underlying provider.
+	if err := p.initializeProvider(ctx, providerName); err != nil {
+		return nil, err
+	}
+
+	// Create a copy with the provider-specific model ID.
+	completionParams := params
+	completionParams.Model = modelID
+
+	// Delegate to the underlying provider.
+	completion, err := p.underlyingProvider.Completion(ctx, completionParams)
+	if err != nil {
+		return nil, err
+	}
+
+	// Post usage event.
+	totalDurationMs := float64(time.Since(startTime).Milliseconds())
+	go p.postUsageEvent(context.Background(), completion, nil, totalDurationMs)
+
+	return completion, nil
+}
+
+// CompletionStream performs a streaming chat completion request.
+func (p *Provider) CompletionStream(
+	ctx context.Context,
+	params providers.CompletionParams,
+) (<-chan providers.ChatCompletionChunk, <-chan error) {
+	chunks := make(chan providers.ChatCompletionChunk)
+	errs := make(chan error, 1)
+
+	go func() {
+		defer close(chunks)
+		defer close(errs)
+
+		startTime := time.Now()
+
+		// Parse the model to get the provider name.
+		providerName, modelID := parseModelString(params.Model)
+		if providerName == "" {
+			errs <- fmt.Errorf("model must be in format 'provider:model', got %q", params.Model)
+			return
+		}
+
+		// Initialize the underlying provider.
+		if err := p.initializeProvider(ctx, providerName); err != nil {
+			errs <- err
+			return
+		}
+
+		// Create a copy with updated fields.
+		streamParams := params
+		streamParams.Model = modelID
+		streamParams.Stream = true
+
+		// Ensure we get usage data in the streaming response for tracking.
+		if streamParams.StreamOptions == nil {
+			streamParams.StreamOptions = &providers.StreamOptions{IncludeUsage: true}
+		} else if !streamParams.StreamOptions.IncludeUsage {
+			// Create a copy of StreamOptions to avoid mutating the original.
+			opts := *streamParams.StreamOptions
+			opts.IncludeUsage = true
+			streamParams.StreamOptions = &opts
+		}
+
+		// Get the stream from the underlying provider.
+		upstreamChunks, upstreamErrs := p.underlyingProvider.CompletionStream(ctx, streamParams)
+
+		// Track streaming metrics.
+		var (
+			collectedChunks     []providers.ChatCompletionChunk
+			timeToFirstTokenMs  *float64
+			timeToLastContentMs *float64
+			previousChunkTime   *time.Time
+			chunkLatencies      []float64
+		)
+
+		// Forward chunks and collect for usage tracking.
+		for chunk := range upstreamChunks {
+			currentTime := time.Now()
+
+			// Track time to first token.
+			if timeToFirstTokenMs == nil && len(chunk.Choices) > 0 && chunk.Choices[0].Delta.Content != "" {
+				ms := float64(currentTime.Sub(startTime).Milliseconds())
+				timeToFirstTokenMs = &ms
+			}
+
+			// Track time to last content token.
+			if len(chunk.Choices) > 0 && chunk.Choices[0].Delta.Content != "" {
+				ms := float64(currentTime.Sub(startTime).Milliseconds())
+				timeToLastContentMs = &ms
+			}
+
+			// Track inter-chunk latency.
+			if previousChunkTime != nil {
+				latencyMs := float64(currentTime.Sub(*previousChunkTime).Milliseconds())
+				chunkLatencies = append(chunkLatencies, latencyMs)
+			}
+			previousChunkTime = &currentTime
+
+			collectedChunks = append(collectedChunks, chunk)
+			chunks <- chunk
+		}
+
+		// Check for upstream errors.
+		if err := <-upstreamErrs; err != nil {
+			errs <- err
+			return
+		}
+
+		// Post usage event with streaming metrics.
+		if len(collectedChunks) > 0 {
+			totalDurationMs := float64(time.Since(startTime).Milliseconds())
+			completion := combineChunks(collectedChunks)
+
+			metrics := &streamingMetrics{
+				timeToFirstTokenMs: timeToFirstTokenMs,
+				timeToLastTokenMs:  timeToLastContentMs,
+				totalDurationMs:    totalDurationMs,
+				chunksReceived:     len(collectedChunks),
+			}
+
+			// Calculate tokens per second if we have usage data.
+			if completion.Usage != nil && completion.Usage.CompletionTokens > 0 && timeToLastContentMs != nil &&
+				*timeToLastContentMs > 0 {
+				tps := float64(completion.Usage.CompletionTokens*1000) / *timeToLastContentMs
+				metrics.tokensPerSecond = &tps
+
+				avgChunkSize := float64(completion.Usage.CompletionTokens) / float64(len(collectedChunks))
+				metrics.avgChunkSize = &avgChunkSize
+			}
+
+			// Calculate inter-chunk latency variance if we have enough data points.
+			if len(chunkLatencies) > 1 {
+				variance := calculateVariance(chunkLatencies)
+				metrics.interChunkLatencyVarianceMs = &variance
+			}
+
+			go p.postUsageEvent(context.Background(), completion, metrics, totalDurationMs)
+		}
+	}()
+
+	return chunks, errs
+}
+
+// Name returns the provider name.
+func (p *Provider) Name() string {
+	return providerName
+}
+
 // initializeProvider initializes the underlying provider for the given provider name.
 func (p *Provider) initializeProvider(ctx context.Context, providerName string) error {
 	if p.underlyingProvider != nil && p.underlyingName == providerName {
-		return nil // Already initialized for this provider
+		return nil // Already initialized for this provider.
 	}
 
-	// Get decrypted provider key from the platform
+	// Get decrypted provider key from the platform.
 	result, err := p.platformClient.GetDecryptedProviderKey(ctx, p.anyLLMKey, providerName)
 	if err != nil {
 		return fmt.Errorf("failed to get provider key: %w", err)
@@ -162,181 +338,94 @@ func (p *Provider) initializeProvider(ctx context.Context, providerName string) 
 	return nil
 }
 
-// parseModelString parses a model string in the format "provider:model" or just "model".
-func parseModelString(model string) (providerName, modelID string) {
-	parts := strings.SplitN(model, ":", 2)
-	if len(parts) == 2 {
-		return parts[0], parts[1]
-	}
-	return "", model
-}
-
-// Completion performs a chat completion request.
-func (p *Provider) Completion(
+// postUsageEvent posts a usage event to the platform.
+func (p *Provider) postUsageEvent(
 	ctx context.Context,
-	params providers.CompletionParams,
-) (*providers.ChatCompletion, error) {
-	startTime := time.Now()
-
-	// Parse the model to get the provider name
-	providerName, modelID := parseModelString(params.Model)
-	if providerName == "" {
-		return nil, fmt.Errorf("model must be in format 'provider:model', got %q", params.Model)
+	completion *providers.ChatCompletion,
+	metrics *streamingMetrics,
+	totalDurationMs float64,
+) {
+	if completion == nil || completion.Usage == nil {
+		return
 	}
 
-	// Initialize the underlying provider
-	if err := p.initializeProvider(ctx, providerName); err != nil {
-		return nil, err
-	}
-
-	// Create a copy with the provider-specific model ID.
-	completionParams := params
-	completionParams.Model = modelID
-
-	// Delegate to the underlying provider
-	completion, err := p.underlyingProvider.Completion(ctx, completionParams)
+	// Get access token for Bearer authentication.
+	accessToken, err := p.platformClient.GetAccessToken(ctx, p.anyLLMKey)
 	if err != nil {
-		return nil, err
+		return
 	}
 
-	// Post usage event
-	totalDurationMs := float64(time.Since(startTime).Milliseconds())
-	go p.postUsageEvent(context.Background(), completion, nil, totalDurationMs)
+	// Build data payload.
+	data := map[string]any{
+		"input_tokens":  fmt.Sprintf("%d", completion.Usage.PromptTokens),
+		"output_tokens": fmt.Sprintf("%d", completion.Usage.CompletionTokens),
+	}
 
-	return completion, nil
-}
-
-// CompletionStream performs a streaming chat completion request.
-func (p *Provider) CompletionStream(
-	ctx context.Context,
-	params providers.CompletionParams,
-) (<-chan providers.ChatCompletionChunk, <-chan error) {
-	chunks := make(chan providers.ChatCompletionChunk)
-	errs := make(chan error, 1)
-
-	go func() {
-		defer close(chunks)
-		defer close(errs)
-
-		startTime := time.Now()
-
-		// Parse the model to get the provider name
-		providerName, modelID := parseModelString(params.Model)
-		if providerName == "" {
-			errs <- fmt.Errorf("model must be in format 'provider:model', got %q", params.Model)
-			return
+	// Add performance metrics.
+	performance := map[string]any{}
+	if totalDurationMs > 0 {
+		performance["total_duration_ms"] = totalDurationMs
+	}
+	if metrics != nil {
+		if metrics.timeToFirstTokenMs != nil {
+			performance["time_to_first_token_ms"] = *metrics.timeToFirstTokenMs
 		}
-
-		// Initialize the underlying provider
-		if err := p.initializeProvider(ctx, providerName); err != nil {
-			errs <- err
-			return
+		if metrics.timeToLastTokenMs != nil {
+			performance["time_to_last_token_ms"] = *metrics.timeToLastTokenMs
 		}
-
-		// Create a copy with updated fields.
-		streamParams := params
-		streamParams.Model = modelID
-		streamParams.Stream = true
-
-		// Ensure we get usage data in the streaming response for tracking.
-		if streamParams.StreamOptions == nil {
-			streamParams.StreamOptions = &providers.StreamOptions{IncludeUsage: true}
-		} else if !streamParams.StreamOptions.IncludeUsage {
-			// Create a copy of StreamOptions to avoid mutating the original.
-			opts := *streamParams.StreamOptions
-			opts.IncludeUsage = true
-			streamParams.StreamOptions = &opts
+		if metrics.tokensPerSecond != nil {
+			performance["tokens_per_second"] = *metrics.tokensPerSecond
 		}
-
-		// Get the stream from the underlying provider
-		upstreamChunks, upstreamErrs := p.underlyingProvider.CompletionStream(ctx, streamParams)
-
-		// Track streaming metrics.
-		var (
-			collectedChunks     []providers.ChatCompletionChunk
-			timeToFirstTokenMs  *float64
-			timeToLastContentMs *float64
-			previousChunkTime   *time.Time
-			chunkLatencies      []float64
-		)
-
-		// Forward chunks and collect for usage tracking
-		for chunk := range upstreamChunks {
-			currentTime := time.Now()
-
-			// Track time to first token
-			if timeToFirstTokenMs == nil && len(chunk.Choices) > 0 && chunk.Choices[0].Delta.Content != "" {
-				ms := float64(currentTime.Sub(startTime).Milliseconds())
-				timeToFirstTokenMs = &ms
-			}
-
-			// Track time to last content token
-			if len(chunk.Choices) > 0 && chunk.Choices[0].Delta.Content != "" {
-				ms := float64(currentTime.Sub(startTime).Milliseconds())
-				timeToLastContentMs = &ms
-			}
-
-			// Track inter-chunk latency
-			if previousChunkTime != nil {
-				latencyMs := float64(currentTime.Sub(*previousChunkTime).Milliseconds())
-				chunkLatencies = append(chunkLatencies, latencyMs)
-			}
-			previousChunkTime = &currentTime
-
-			collectedChunks = append(collectedChunks, chunk)
-			chunks <- chunk
+		if metrics.chunksReceived > 0 {
+			performance["chunks_received"] = metrics.chunksReceived
 		}
-
-		// Check for upstream errors
-		if err := <-upstreamErrs; err != nil {
-			errs <- err
-			return
+		if metrics.avgChunkSize != nil {
+			performance["avg_chunk_size"] = *metrics.avgChunkSize
 		}
-
-		// Post usage event with streaming metrics
-		if len(collectedChunks) > 0 {
-			totalDurationMs := float64(time.Since(startTime).Milliseconds())
-			completion := combineChunks(collectedChunks)
-
-			metrics := &streamingMetrics{
-				TimeToFirstTokenMs: timeToFirstTokenMs,
-				TimeToLastTokenMs:  timeToLastContentMs,
-				TotalDurationMs:    totalDurationMs,
-				ChunksReceived:     len(collectedChunks),
-			}
-
-			// Calculate tokens per second if we have usage data
-			if completion.Usage != nil && completion.Usage.CompletionTokens > 0 && timeToLastContentMs != nil &&
-				*timeToLastContentMs > 0 {
-				tps := float64(completion.Usage.CompletionTokens*1000) / *timeToLastContentMs
-				metrics.TokensPerSecond = &tps
-
-				avgChunkSize := float64(completion.Usage.CompletionTokens) / float64(len(collectedChunks))
-				metrics.AvgChunkSize = &avgChunkSize
-			}
-
-			// Calculate inter-chunk latency variance if we have enough data points
-			if len(chunkLatencies) > 1 {
-				variance := calculateVariance(chunkLatencies)
-				metrics.InterChunkLatencyVarianceMs = &variance
-			}
-
-			go p.postUsageEvent(context.Background(), completion, metrics, totalDurationMs)
+		if metrics.interChunkLatencyVarianceMs != nil {
+			performance["inter_chunk_latency_variance_ms"] = *metrics.interChunkLatencyVarianceMs
 		}
-	}()
+	}
+	if len(performance) > 0 {
+		data["performance"] = performance
+	}
 
-	return chunks, errs
-}
+	payload := usageEventPayload{
+		ProviderKeyID: p.providerKeyID,
+		Provider:      p.underlyingName,
+		Model:         completion.Model,
+		Data:          data,
+		ID:            uuid.New().String(),
+		ClientName:    p.clientName,
+	}
 
-// streamingMetrics holds performance metrics for streaming requests.
-type streamingMetrics struct {
-	TimeToFirstTokenMs          *float64
-	TimeToLastTokenMs           *float64
-	TotalDurationMs             float64
-	TokensPerSecond             *float64
-	ChunksReceived              int
-	AvgChunkSize                *float64
-	InterChunkLatencyVarianceMs *float64
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		p.platformURL+"/usage-events/",
+		strings.NewReader(string(jsonPayload)),
+	)
+	if err != nil {
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("User-Agent", userAgent())
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return
+	}
+
+	// Drain and close the response body to allow connection reuse.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
 }
 
 // calculateVariance calculates the sample variance of a slice of float64 values.
@@ -345,21 +434,21 @@ func calculateVariance(values []float64) float64 {
 		return 0
 	}
 
-	// Calculate mean
+	// Calculate mean.
 	var sum float64
 	for _, v := range values {
 		sum += v
 	}
 	mean := sum / float64(len(values))
 
-	// Calculate sum of squared differences
+	// Calculate sum of squared differences.
 	var sumSquaredDiff float64
 	for _, v := range values {
 		diff := v - mean
 		sumSquaredDiff += diff * diff
 	}
 
-	// Return sample variance (n-1)
+	// Return sample variance (n-1).
 	return sumSquaredDiff / float64(len(values)-1)
 }
 
@@ -381,109 +470,13 @@ func combineChunks(chunks []providers.ChatCompletionChunk) *providers.ChatComple
 	}
 }
 
-// usageEventPayload represents the payload for usage events.
-type usageEventPayload struct {
-	ProviderKeyID string         `json:"provider_key_id"`
-	Provider      string         `json:"provider"`
-	Model         string         `json:"model"`
-	Data          map[string]any `json:"data"`
-	ID            string         `json:"id"`
-	ClientName    string         `json:"client_name,omitempty"`
-}
-
-// postUsageEvent posts a usage event to the platform.
-func (p *Provider) postUsageEvent(
-	ctx context.Context,
-	completion *providers.ChatCompletion,
-	metrics *streamingMetrics,
-	totalDurationMs float64,
-) {
-	if completion == nil || completion.Usage == nil {
-		return
+// parseModelString parses a model string in the format "provider:model" or just "model".
+func parseModelString(model string) (providerName string, modelID string) {
+	parts := strings.SplitN(model, ":", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
 	}
-
-	// Get access token for Bearer authentication
-	accessToken, err := p.platformClient.GetAccessToken(ctx, p.anyLLMKey)
-	if err != nil {
-		return
-	}
-
-	// Build data payload
-	data := map[string]any{
-		"input_tokens":  fmt.Sprintf("%d", completion.Usage.PromptTokens),
-		"output_tokens": fmt.Sprintf("%d", completion.Usage.CompletionTokens),
-	}
-
-	// Add performance metrics
-	performance := map[string]any{}
-	if totalDurationMs > 0 {
-		performance["total_duration_ms"] = totalDurationMs
-	}
-	if metrics != nil {
-		if metrics.TimeToFirstTokenMs != nil {
-			performance["time_to_first_token_ms"] = *metrics.TimeToFirstTokenMs
-		}
-		if metrics.TimeToLastTokenMs != nil {
-			performance["time_to_last_token_ms"] = *metrics.TimeToLastTokenMs
-		}
-		if metrics.TokensPerSecond != nil {
-			performance["tokens_per_second"] = *metrics.TokensPerSecond
-		}
-		if metrics.ChunksReceived > 0 {
-			performance["chunks_received"] = metrics.ChunksReceived
-		}
-		if metrics.AvgChunkSize != nil {
-			performance["avg_chunk_size"] = *metrics.AvgChunkSize
-		}
-		if metrics.InterChunkLatencyVarianceMs != nil {
-			performance["inter_chunk_latency_variance_ms"] = *metrics.InterChunkLatencyVarianceMs
-		}
-	}
-	if len(performance) > 0 {
-		data["performance"] = performance
-	}
-
-	payload := usageEventPayload{
-		ProviderKeyID: p.providerKeyID,
-		Provider:      p.underlyingName,
-		Model:         completion.Model,
-		Data:          data,
-		ID:            uuid.New().String(),
-		ClientName:    p.clientName,
-	}
-
-	jsonPayload, err := json.Marshal(payload)
-	if err != nil {
-		return
-	}
-
-	platformURL := os.Getenv(envPlatformURL)
-	if platformURL == "" {
-		platformURL = defaultPlatformURL
-	}
-
-	req, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
-		platformURL+"/usage-events/",
-		strings.NewReader(string(jsonPayload)),
-	)
-	if err != nil {
-		return
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+accessToken)
-	req.Header.Set("User-Agent", userAgent())
-
-	resp, err := p.httpClient.Do(req)
-	if err != nil {
-		return
-	}
-
-	// Drain and close the response body to allow connection reuse
-	_, _ = io.Copy(io.Discard, resp.Body)
-	_ = resp.Body.Close()
+	return "", model
 }
 
 // userAgent returns the formatted User-Agent header value per RFC 9110 section 10.1.5.


### PR DESCRIPTION
## Summary

Reorganize `providers/platform/platform.go` to follow the canonical file layout conventions, and fix config resolution inconsistency.

## Changes

- Reorder file structure: constants → interface assertions → vars → types → constructor → exported methods → unexported methods → package functions
- Sort constants, struct fields, and map entries A-Z
- Move interface assertions before types (matching anthropic reference)
- Group all type declarations together near the top
- Make `streamingMetrics` fields unexported (unexported struct, not serialized)
- Replace raw `os.Getenv` with `cfg.ResolveEnv` for platform URL resolution
- Resolve platform URL once in `New()` and store on struct, removing duplicate resolution in `postUsageEvent`
- Add missing full-stops on single-line comments

## Testing

Ran `make lint` and `make test` locally.

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass locally (`make test`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)