### PR TITLE
refactor(anthropic): use ResolveBaseURL for base URL resolution

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -20,6 +20,7 @@ import (
 const (
 	defaultMaxTokens = 4096
 	envAPIKey        = "ANTHROPIC_API_KEY"
+	envBaseURL       = "ANTHROPIC_BASE_URL"
 	providerName     = "anthropic"
 )
 
@@ -104,12 +105,17 @@ func New(opts ...config.Option) (*Provider, error) {
 		return nil, errors.NewMissingAPIKeyError(providerName, envAPIKey)
 	}
 
+	baseURL, err := cfg.ResolveBaseURL(envBaseURL, "")
+	if err != nil {
+		return nil, err
+	}
+
 	clientOpts := []option.RequestOption{
 		option.WithAPIKey(apiKey),
 	}
 
-	if cfg.BaseURL != "" {
-		clientOpts = append(clientOpts, option.WithBaseURL(cfg.BaseURL))
+	if baseURL != "" {
+		clientOpts = append(clientOpts, option.WithBaseURL(baseURL))
 	}
 
 	client := anthropic.NewClient(clientOpts...)


### PR DESCRIPTION
## Summary

Replace direct `cfg.BaseURL` check with `cfg.ResolveBaseURL` for consistency with the config resolution pattern used across other providers.

## Changes

- Add `envBaseURL` constant for the upstream `ANTHROPIC_BASE_URL` env var (supported by the official Anthropic SDKs)
- Use `cfg.ResolveBaseURL(envBaseURL, "")` which follows the standard resolution chain: explicit config → env var → default (empty, letting the SDK use its own default)
- Adds URL validation via `ResolveBaseURL`

## Testing

Ran `make lint` and `make test` locally.

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass locally (`make test`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)