### PR TITLE
fix(ollama): use ResolveEnv for base URL resolution

### DIFF
--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -116,7 +116,7 @@ func New(opts ...config.Option) (*Provider, error) {
 
 	baseURL := cfg.BaseURL
 	if baseURL == "" {
-		baseURL = cfg.ResolveAPIKey(envBaseURL) // OLLAMA_HOST env var
+		baseURL = cfg.ResolveEnv(envBaseURL)
 	}
 	if baseURL == "" {
 		baseURL = defaultBaseURL


### PR DESCRIPTION
## Summary

Replace `cfg.ResolveAPIKey` with `cfg.ResolveEnv` for resolving the `OLLAMA_HOST` environment variable. Using an API key resolver for a base URL is semantically wrong.

## Changes

- Replace `cfg.ResolveAPIKey(envBaseURL)` with `cfg.ResolveEnv(envBaseURL)` in `New()`

## Testing

Ran `make lint` and `make test` locally.

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass locally (`make test`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)