### PR TITLE
fix Apache 2 license so pkg.go.dev shows documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -48,7 +48,7 @@
       "Contribution" shall mean any work of authorship, including
       the original version of the Work and any modifications or additions
       to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
+      submitted to Licensor for inclusion in the Work by the copyright owner
       or by an individual or Legal Entity authorized to submit on behalf of
       the copyright owner. For the purposes of this definition, "submitted"
       means any form of electronic, verbal, or written communication sent


### PR DESCRIPTION
## Summary

pkg.go.dev currently refuses to show any-llm-go documentation due to licensing issues with the most recently released tag (v0.8.0). See https://pkg.go.dev/github.com/mozilla-ai/any-llm-go@v0.8.0

But this is confusing - pkg.go.dev says that any-llm-go's license is unknown, but pkg.go.dev definitely supports Apache 2.0 licenses, which any-llm-go is licensed under!

pkg.go.dev uses https://github.com/google/licensecheck under the hood for license detection, and licensecheck is getting confused by a single word deviation in any-llm-go's license from the standard Apache 2.0 text: https://www.apache.org/licenses/LICENSE-2.0.txt

## Changes

this change removes this spurious addition of "the" to the license, so that pkg.go.dev works.

## Testing

no code change

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass locally (`make test`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)
