### PR TITLE
feat(provider): add Z.ai provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ for _, model := range models.Data {
 |  Mistral   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
 |   Ollama   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
 |   OpenAI   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
+|    z.ai    |      ✅      |      ✅      |      ✅ |      ✅      |      ❌       |
 
 More providers coming soon! See [docs/providers.md](docs/providers.md) for the full list.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -15,6 +15,7 @@ any-llm-go supports multiple LLM providers through a unified interface. Each pro
 | [Mistral](#mistral)     | `mistral`   |     ✅      |     ✅     |   ✅   |     ✅     |     ✅      |      ✅      |
 | [Ollama](#ollama)       | `ollama`    |     ✅      |     ✅     |   ✅   |     ✅     |     ✅      |      ✅      |
 | [OpenAI](#openai)       | `openai`    |     ✅      |     ✅     |   ✅   |     ✅     |     ✅      |      ✅      |
+| [z.ai](#zai)            | `zai`       |     ✅      |     ✅     |   ✅   |     ✅     |     ❌      |      ✅      |
 
 ### Legend
 
@@ -458,6 +459,44 @@ provider, err := openai.New(
 **Embedding Models:**
 - `text-embedding-3-small` - Cost-effective embeddings
 - `text-embedding-3-large` - Higher quality embeddings
+
+### z.ai
+
+z.ai provides access to the GLM model family through an OpenAI-compatible API.
+
+```go
+import (
+    anyllm "github.com/mozilla-ai/any-llm-go"
+    "github.com/mozilla-ai/any-llm-go/providers/zai"
+)
+
+// Using environment variable (ZAI_API_KEY).
+provider, err := zai.New()
+
+// Or with explicit API key.
+provider, err := zai.New(anyllm.WithAPIKey("your-key"))
+```
+
+**Environment Variable:** `ZAI_API_KEY`
+
+**Popular Models:**
+- `glm-4.5-air` - Fast and cost-effective
+- `glm-4.5` - Capable general model
+- `glm-4.6` - Vision-capable model
+- `glm-4.7` - Advanced model
+- `glm-5` - Most capable model
+
+**Completion:**
+
+```go
+provider, _ := zai.New()
+resp, err := provider.Completion(ctx, anyllm.CompletionParams{
+    Model: "glm-4.6",
+    Messages: []anyllm.Message{
+        {Role: anyllm.RoleUser, Content: "Hello!"},
+    },
+})
+```
 
 ## Coming Soon
 

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -29,7 +29,7 @@ var ProviderModelMap = map[string]string{
 	"cerebras":   "llama3.1-8b",
 	"openrouter": "meta-llama/llama-3.1-8b-instruct",
 	"llamacpp":   "Qwen2.5-7B-Instruct",
-	"zai":        "glm-4-32b-0414-128k",
+	"zai":        "glm-4.7-flash",
 }
 
 // ProviderReasoningModelMap maps providers to reasoning-capable models.
@@ -40,7 +40,7 @@ var ProviderReasoningModelMap = map[string]string{
 	"mistral":   "magistral-small-latest",
 	"deepseek":  "deepseek-reasoner",
 	"ollama":    "deepseek-r1",
-	"zai":       "glm-4.5",
+	"zai":       "glm-4.7-flash",
 }
 
 // ProviderImageModelMap maps providers to vision-capable models.
@@ -50,7 +50,7 @@ var ProviderImageModelMap = map[string]string{
 	"mistral":   "pixtral-small-latest",
 	"ollama":    "llava",
 	"openai":    "gpt-4o-mini",
-	"zai":       "glm-4.5v",
+	"zai":       "glm-4.6v-flash",
 }
 
 // EmbeddingProviderModelMap maps providers to embedding models.

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -29,6 +29,7 @@ var ProviderModelMap = map[string]string{
 	"cerebras":   "llama3.1-8b",
 	"openrouter": "meta-llama/llama-3.1-8b-instruct",
 	"llamacpp":   "Qwen2.5-7B-Instruct",
+	"zai":        "glm-4-32b-0414-128k",
 }
 
 // ProviderReasoningModelMap maps providers to reasoning-capable models.
@@ -39,6 +40,7 @@ var ProviderReasoningModelMap = map[string]string{
 	"mistral":   "magistral-small-latest",
 	"deepseek":  "deepseek-reasoner",
 	"ollama":    "deepseek-r1",
+	"zai":       "glm-4.5",
 }
 
 // ProviderImageModelMap maps providers to vision-capable models.
@@ -48,6 +50,7 @@ var ProviderImageModelMap = map[string]string{
 	"mistral":   "pixtral-small-latest",
 	"ollama":    "llava",
 	"openai":    "gpt-4o-mini",
+	"zai":       "glm-4.5v",
 }
 
 // EmbeddingProviderModelMap maps providers to embedding models.
@@ -90,6 +93,7 @@ var providerEnvKeys = map[string]string{
 	"perplexity": "PERPLEXITY_API_KEY",
 	"together":   "TOGETHER_API_KEY",
 	"xai":        "XAI_API_KEY",
+	"zai":        "ZAI_API_KEY",
 }
 
 // SimpleMessages returns a simple test message.

--- a/providers/zai/zai.go
+++ b/providers/zai/zai.go
@@ -1,0 +1,510 @@
+// Package zai provides a z.ai provider implementation for any-llm.
+package zai
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	"github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+// Provider configuration constants.
+const (
+	defaultBaseURL = "https://api.z.ai/api/paas/v4/"
+	envAPIKey      = "ZAI_API_KEY"
+	providerName   = "zai"
+)
+
+// Object type constants.
+const (
+	objectChatCompletion      = "chat.completion"
+	objectChatCompletionChunk = "chat.completion.chunk"
+	objectList                = "list"
+)
+
+// Ensure Provider implements the required interfaces.
+var (
+	_ providers.CapabilityProvider = (*Provider)(nil)
+	_ providers.ErrorConverter     = (*Provider)(nil)
+	_ providers.ModelLister        = (*Provider)(nil)
+	_ providers.Provider           = (*Provider)(nil)
+)
+
+// Provider implements the providers.Provider interface for z.ai.
+type Provider struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// New creates a new z.ai provider.
+func New(opts ...config.Option) (*Provider, error) {
+	cfg, err := config.New(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("invalid options: %w", err)
+	}
+
+	apiKey := cfg.ResolveAPIKey(envAPIKey)
+	if apiKey == "" {
+		return nil, errors.NewMissingAPIKeyError(providerName, envAPIKey)
+	}
+
+	baseURL := defaultBaseURL
+	if cfg.BaseURL != "" {
+		baseURL = cfg.BaseURL
+	}
+
+	return &Provider{
+		apiKey:     apiKey,
+		baseURL:    baseURL,
+		httpClient: cfg.HTTPClient(),
+	}, nil
+}
+
+// Capabilities returns the provider's capabilities.
+func (p *Provider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{
+		Completion:          true,
+		CompletionImage:     false,
+		CompletionPDF:       false,
+		CompletionReasoning: true,
+		CompletionStreaming: true,
+		CompletionTools:     true,
+		Embedding:           false,
+		ListModels:          true,
+	}
+}
+
+// Completion performs a chat completion request.
+func (p *Provider) Completion(
+	ctx context.Context,
+	params providers.CompletionParams,
+) (*providers.ChatCompletion, error) {
+	reqBody, err := p.createRequest(params, false)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := p.doRequest(ctx, "POST", "chat/completions", reqBody)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("zai: failed to close response body: %v", err)
+		}
+	}()
+
+	var zaiResult zaiChatCompletion
+	if err := json.NewDecoder(resp.Body).Decode(&zaiResult); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return zaiResult.toProviderCompletion(), nil
+}
+
+// CompletionStream performs a streaming chat completion request.
+func (p *Provider) CompletionStream(
+	ctx context.Context,
+	params providers.CompletionParams,
+) (<-chan providers.ChatCompletionChunk, <-chan error) {
+	chunks := make(chan providers.ChatCompletionChunk)
+	errs := make(chan error, 1)
+
+	go func() {
+		defer close(chunks)
+		defer close(errs)
+
+		reqBody, err := p.createRequest(params, true)
+		if err != nil {
+			select {
+			case errs <- err:
+			case <-ctx.Done():
+			}
+			return
+		}
+
+		resp, err := p.doRequest(ctx, "POST", "chat/completions", reqBody)
+		if err != nil {
+			select {
+			case errs <- err:
+			case <-ctx.Done():
+			}
+			return
+		}
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				log.Printf("zai: failed to close response body: %v", err)
+			}
+		}()
+
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if len(line) == 0 {
+				continue
+			}
+
+			if !bytes.HasPrefix(line, []byte("data: ")) {
+				continue
+			}
+
+			data := bytes.TrimPrefix(line, []byte("data: "))
+			if string(data) == "[DONE]" {
+				return
+			}
+
+			var zaiChunk zaiChatCompletionChunk
+			if err := json.Unmarshal(data, &zaiChunk); err != nil {
+				continue
+			}
+
+			select {
+			case chunks <- zaiChunk.toProviderChunk():
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			select {
+			case errs <- fmt.Errorf("reading stream: %w", err):
+			case <-ctx.Done():
+			}
+		}
+	}()
+
+	return chunks, errs
+}
+
+// ConvertError converts z.ai errors to unified error types.
+// Implements providers.ErrorConverter.
+func (p *Provider) ConvertError(err error) error {
+	return errors.NewProviderError(providerName, err)
+}
+
+// ListModels returns a list of available models.
+func (p *Provider) ListModels(ctx context.Context) (*providers.ModelsResponse, error) {
+	resp, err := p.doRequest(ctx, "GET", "models", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("zai: failed to close response body: %v", err)
+		}
+	}()
+
+	var apiResp struct {
+		Object string `json:"object"`
+		Data   []struct {
+			ID      string `json:"id"`
+			Object  string `json:"object"`
+			Created int64  `json:"created"`
+			OwnedBy string `json:"owned_by"`
+		} `json:"data"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return nil, fmt.Errorf("decoding list models: %w", err)
+	}
+
+	models := make([]providers.Model, len(apiResp.Data))
+	for i, m := range apiResp.Data {
+		models[i] = providers.Model{
+			ID:      m.ID,
+			Object:  m.Object,
+			Created: m.Created,
+			OwnedBy: m.OwnedBy,
+		}
+	}
+
+	return &providers.ModelsResponse{
+		Object: apiResp.Object,
+		Data:   models,
+	}, nil
+}
+
+// Name returns the provider name.
+func (p *Provider) Name() string {
+	return providerName
+}
+
+// createRequest converts providers.CompletionParams to a z.ai chat request.
+func (p *Provider) createRequest(params providers.CompletionParams, stream bool) (*chatRequest, error) {
+	req := &chatRequest{
+		Model:       params.Model,
+		Stream:      stream,
+		Tools:       params.Tools,
+		ToolChoice:  params.ToolChoice,
+		Temperature: params.Temperature,
+		TopP:        params.TopP,
+		MaxTokens:   params.MaxTokens,
+		Stop:        params.Stop,
+		UserID:      params.User,
+	}
+
+	if params.ReasoningEffort != "" && params.ReasoningEffort != providers.ReasoningEffortNone {
+		req.Thinking = &thinkingParam{Type: "enabled"}
+	}
+
+	msgs := make([]messageParam, len(params.Messages))
+	for i, m := range params.Messages {
+		mp := messageParam{
+			Message: providers.Message{
+				Role:       m.Role,
+				Name:       m.Name,
+				ToolCalls:  m.ToolCalls,
+				ToolCallID: m.ToolCallID,
+				Content:    m.Content,
+			},
+		}
+
+		if m.Reasoning != nil {
+			mp.ReasoningContent = m.Reasoning.Content
+		}
+
+		if parts, ok := m.Content.([]providers.ContentPart); ok {
+			newParts := make([]contentPart, len(parts))
+			for j, part := range parts {
+				newParts[j] = contentPart{
+					Type: part.Type,
+					Text: part.Text,
+				}
+				if part.ImageURL != nil {
+					// Strip Data URI prefix for z.ai image format.
+					url := part.ImageURL.URL
+					if strings.HasPrefix(url, "data:image/") {
+						if idx := strings.Index(url, "base64,"); idx != -1 {
+							url = url[idx+7:]
+						}
+					}
+					newParts[j].ImageURL = map[string]string{
+						"url": url,
+					}
+				}
+			}
+			mp.Content = newParts
+		}
+		msgs[i] = mp
+	}
+	req.Messages = msgs
+
+	return req, nil
+}
+
+// doRequest sends an HTTP request to the z.ai API.
+func (p *Provider) doRequest(ctx context.Context, method, endpoint string, body any) (*http.Response, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling request: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	fullURL, err := url.JoinPath(p.baseURL, endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("joining url path: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Accept-Language", "en-US,en")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, p.ConvertError(err)
+	}
+
+	if resp.StatusCode >= 400 {
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				log.Printf("zai: failed to close response body: %v", err)
+			}
+		}()
+		return nil, p.handleErrorResponse(resp)
+	}
+
+	return resp, nil
+}
+
+// handleErrorResponse parses an error response from the z.ai API.
+func (p *Provider) handleErrorResponse(resp *http.Response) error {
+	body, _ := io.ReadAll(resp.Body)
+	msg := fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(body))
+
+	type errorResp struct {
+		Error struct {
+			Message string `json:"message"`
+			Code    any    `json:"code"`
+		} `json:"error"`
+	}
+	var e errorResp
+	if json.Unmarshal(body, &e) == nil && e.Error.Message != "" {
+		msg = fmt.Sprintf("z.ai error: %s (code: %v)", e.Error.Message, e.Error.Code)
+	}
+
+	switch resp.StatusCode {
+	case 401:
+		return errors.NewAuthenticationError(providerName, fmt.Errorf("%s", msg))
+	case 429:
+		return errors.NewRateLimitError(providerName, fmt.Errorf("%s", msg))
+	case 404:
+		return errors.NewModelNotFoundError(providerName, fmt.Errorf("%s", msg))
+	case 400:
+		return errors.NewInvalidRequestError(providerName, fmt.Errorf("%s", msg))
+	default:
+		return errors.NewProviderError(providerName, fmt.Errorf("%s", msg))
+	}
+}
+
+// z.ai response types.
+
+// zaiChatCompletion represents a z.ai chat completion response.
+type zaiChatCompletion struct {
+	ID      string           `json:"id"`
+	Object  string           `json:"object"`
+	Created int64            `json:"created"`
+	Model   string           `json:"model"`
+	Choices []zaiChoice      `json:"choices"`
+	Usage   *providers.Usage `json:"usage,omitempty"`
+}
+
+// zaiChoice represents a choice in a z.ai chat completion response.
+type zaiChoice struct {
+	Index        int        `json:"index"`
+	Message      zaiMessage `json:"message"`
+	FinishReason string     `json:"finish_reason,omitempty"`
+}
+
+// zaiMessage represents a message in a z.ai chat completion response.
+type zaiMessage struct {
+	providers.Message
+	ReasoningContent string `json:"reasoning_content,omitempty"`
+}
+
+// toProviderCompletion converts a z.ai response to the unified ChatCompletion format.
+func (z *zaiChatCompletion) toProviderCompletion() *providers.ChatCompletion {
+	choices := make([]providers.Choice, len(z.Choices))
+	for i, c := range z.Choices {
+		msg := c.Message.Message
+		if c.Message.ReasoningContent != "" {
+			msg.Reasoning = &providers.Reasoning{
+				Content: c.Message.ReasoningContent,
+			}
+		}
+		choices[i] = providers.Choice{
+			Index:        c.Index,
+			Message:      msg,
+			FinishReason: c.FinishReason,
+		}
+	}
+	return &providers.ChatCompletion{
+		ID:      z.ID,
+		Object:  z.Object,
+		Created: z.Created,
+		Model:   z.Model,
+		Choices: choices,
+		Usage:   z.Usage,
+	}
+}
+
+// zaiChatCompletionChunk represents a z.ai streaming chunk.
+type zaiChatCompletionChunk struct {
+	ID      string           `json:"id"`
+	Object  string           `json:"object"`
+	Created int64            `json:"created"`
+	Model   string           `json:"model"`
+	Choices []zaiChunkChoice `json:"choices"`
+	Usage   *providers.Usage `json:"usage,omitempty"`
+}
+
+// zaiChunkChoice represents a choice in a z.ai streaming chunk.
+type zaiChunkChoice struct {
+	Index        int           `json:"index"`
+	Delta        zaiChunkDelta `json:"delta"`
+	FinishReason string        `json:"finish_reason,omitempty"`
+}
+
+// zaiChunkDelta represents delta content in a z.ai streaming chunk.
+type zaiChunkDelta struct {
+	providers.ChunkDelta
+	ReasoningContent string `json:"reasoning_content,omitempty"`
+}
+
+// toProviderChunk converts a z.ai streaming chunk to the unified ChatCompletionChunk format.
+func (z *zaiChatCompletionChunk) toProviderChunk() providers.ChatCompletionChunk {
+	choices := make([]providers.ChunkChoice, len(z.Choices))
+	for i, c := range z.Choices {
+		delta := c.Delta.ChunkDelta
+		if c.Delta.ReasoningContent != "" {
+			delta.Reasoning = &providers.Reasoning{
+				Content: c.Delta.ReasoningContent,
+			}
+		}
+		choices[i] = providers.ChunkChoice{
+			Index:        c.Index,
+			Delta:        delta,
+			FinishReason: c.FinishReason,
+		}
+	}
+	return providers.ChatCompletionChunk{
+		ID:      z.ID,
+		Object:  z.Object,
+		Created: z.Created,
+		Model:   z.Model,
+		Choices: choices,
+		Usage:   z.Usage,
+	}
+}
+
+// z.ai request types.
+
+// chatRequest represents a z.ai chat completion request body.
+type chatRequest struct {
+	Model       string           `json:"model"`
+	Messages    []messageParam   `json:"messages"`
+	Stream      bool             `json:"stream,omitempty"`
+	Thinking    *thinkingParam   `json:"thinking,omitempty"`
+	Tools       []providers.Tool `json:"tools,omitempty"`
+	ToolChoice  any              `json:"tool_choice,omitempty"`
+	Temperature *float64         `json:"temperature,omitempty"`
+	TopP        *float64         `json:"top_p,omitempty"`
+	MaxTokens   *int             `json:"max_tokens,omitempty"`
+	Stop        []string         `json:"stop,omitempty"`
+	UserID      string           `json:"user_id,omitempty"`
+}
+
+// thinkingParam represents the thinking configuration for z.ai.
+type thinkingParam struct {
+	Type string `json:"type"`
+}
+
+// messageParam represents a message in a z.ai chat request.
+type messageParam struct {
+	providers.Message
+	ReasoningContent string `json:"reasoning_content,omitempty"`
+}
+
+// contentPart represents a multimodal content part in a z.ai message.
+type contentPart struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	ImageURL any    `json:"image_url,omitempty"`
+}

--- a/providers/zai/zai.go
+++ b/providers/zai/zai.go
@@ -23,6 +23,8 @@ const (
 	defaultBaseURL = "https://api.z.ai/api/paas/v4/"
 	envAPIKey      = "ZAI_API_KEY"
 	providerName   = "zai"
+	dataURIPrefix  = "data:image/"
+	base64Prefix   = "base64,"
 )
 
 // Object type constants.
@@ -284,9 +286,9 @@ func (p *Provider) createRequest(params providers.CompletionParams, stream bool)
 				if part.ImageURL != nil {
 					// Strip Data URI prefix for z.ai image format.
 					url := part.ImageURL.URL
-					if strings.HasPrefix(url, "data:image/") {
-						if idx := strings.Index(url, "base64,"); idx != -1 {
-							url = url[idx+7:]
+					if strings.HasPrefix(url, dataURIPrefix) {
+						if idx := strings.Index(url, base64Prefix); idx != -1 {
+							url = url[idx+len(base64Prefix):]
 						}
 					}
 					newParts[j].ImageURL = map[string]string{

--- a/providers/zai/zai_test.go
+++ b/providers/zai/zai_test.go
@@ -1,0 +1,1093 @@
+package zai
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	"github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/internal/testutil"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+func TestNew(t *testing.T) {
+	// Note: Not using t.Parallel() here because child test uses t.Setenv.
+
+	t.Run("creates provider with API key", func(t *testing.T) {
+		t.Parallel()
+
+		provider, err := New(config.WithAPIKey("test-key"))
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+		require.Equal(t, providerName, provider.Name())
+	})
+
+	t.Run("returns error when API key is missing", func(t *testing.T) {
+		t.Setenv(envAPIKey, "")
+
+		provider, err := New()
+		require.Nil(t, provider)
+		require.Error(t, err)
+
+		var missingKeyErr *errors.MissingAPIKeyError
+		require.ErrorAs(t, err, &missingKeyErr)
+		require.Equal(t, providerName, missingKeyErr.Provider)
+		require.Equal(t, envAPIKey, missingKeyErr.EnvVar)
+	})
+
+	t.Run("creates provider with custom base URL", func(t *testing.T) {
+		t.Parallel()
+
+		provider, err := New(
+			config.WithAPIKey("test-key"),
+			config.WithBaseURL("https://custom.z.ai/v1"),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+	})
+}
+
+func TestCapabilities(t *testing.T) {
+	t.Parallel()
+
+	provider, err := New(config.WithAPIKey("test-key"))
+	require.NoError(t, err)
+
+	caps := provider.Capabilities()
+
+	require.True(t, caps.Completion)
+	require.False(t, caps.CompletionImage)
+	require.False(t, caps.CompletionPDF)
+	require.True(t, caps.CompletionReasoning)
+	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.CompletionTools)
+	require.False(t, caps.Embedding)
+	require.True(t, caps.ListModels)
+}
+
+func TestProviderName(t *testing.T) {
+	t.Parallel()
+
+	provider, err := New(config.WithAPIKey("test-key"))
+	require.NoError(t, err)
+	require.Equal(t, providerName, provider.Name())
+}
+
+func TestHandleErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		statusCode   int
+		body         string
+		wantSentinel error
+		wantContains string
+	}{
+		{
+			name:         "401 becomes AuthenticationError",
+			statusCode:   401,
+			body:         `{"error":{"message":"invalid api key","code":1001}}`,
+			wantSentinel: errors.ErrAuthentication,
+			wantContains: "invalid api key",
+		},
+		{
+			name:         "429 becomes RateLimitError",
+			statusCode:   429,
+			body:         `{"error":{"message":"rate limit exceeded","code":1002}}`,
+			wantSentinel: errors.ErrRateLimit,
+			wantContains: "rate limit exceeded",
+		},
+		{
+			name:         "404 becomes ModelNotFoundError",
+			statusCode:   404,
+			body:         `{"error":{"message":"model not found","code":1211}}`,
+			wantSentinel: errors.ErrModelNotFound,
+			wantContains: "model not found",
+		},
+		{
+			name:         "400 becomes InvalidRequestError",
+			statusCode:   400,
+			body:         `{"error":{"message":"invalid request","code":1210}}`,
+			wantSentinel: errors.ErrInvalidRequest,
+			wantContains: "invalid request",
+		},
+		{
+			name:         "500 becomes ProviderError",
+			statusCode:   500,
+			body:         `{"error":{"message":"internal error","code":1500}}`,
+			wantSentinel: errors.ErrProvider,
+			wantContains: "internal error",
+		},
+		{
+			name:         "unparseable body falls back to raw message",
+			statusCode:   502,
+			body:         "bad gateway",
+			wantSentinel: errors.ErrProvider,
+			wantContains: "bad gateway",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Provider{}
+			resp := &http.Response{
+				StatusCode: tc.statusCode,
+				Body:       io.NopCloser(strings.NewReader(tc.body)),
+			}
+
+			err := p.handleErrorResponse(resp)
+			require.Error(t, err)
+			require.True(t, stderrors.Is(err, tc.wantSentinel),
+				"expected error to match %v, got %v", tc.wantSentinel, err)
+			require.Contains(t, err.Error(), tc.wantContains)
+		})
+	}
+}
+
+func TestCreateRequest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("converts basic parameters", func(t *testing.T) {
+		t.Parallel()
+
+		p := &Provider{}
+		temp := 0.7
+		topP := 0.9
+		maxTokens := 100
+
+		model := testutil.TestModel(providerName)
+		params := providers.CompletionParams{
+			Model: model,
+			Messages: []providers.Message{
+				{Role: providers.RoleUser, Content: "Hello"},
+			},
+			Temperature: &temp,
+			TopP:        &topP,
+			MaxTokens:   &maxTokens,
+			Stop:        []string{"END"},
+			User:        "test-user-123",
+		}
+
+		req, err := p.createRequest(params, false)
+		require.NoError(t, err)
+
+		require.Equal(t, model, req.Model)
+		require.False(t, req.Stream)
+		require.Equal(t, &temp, req.Temperature)
+		require.Equal(t, &topP, req.TopP)
+		require.Equal(t, &maxTokens, req.MaxTokens)
+		require.Equal(t, []string{"END"}, req.Stop)
+		require.Equal(t, "test-user-123", req.UserID)
+		require.Nil(t, req.Thinking)
+		require.Len(t, req.Messages, 1)
+		require.Equal(t, providers.RoleUser, req.Messages[0].Role)
+	})
+
+	t.Run("enables stream", func(t *testing.T) {
+		t.Parallel()
+
+		p := &Provider{}
+		params := providers.CompletionParams{
+			Model: testutil.TestModel(providerName),
+			Messages: []providers.Message{
+				{Role: providers.RoleUser, Content: "Hello"},
+			},
+		}
+
+		req, err := p.createRequest(params, true)
+		require.NoError(t, err)
+		require.True(t, req.Stream)
+	})
+
+	t.Run("enables thinking when reasoning effort is set", func(t *testing.T) {
+		t.Parallel()
+
+		p := &Provider{}
+		params := providers.CompletionParams{
+			Model: testutil.ReasoningModel(providerName),
+			Messages: []providers.Message{
+				{Role: providers.RoleUser, Content: "Think about this"},
+			},
+			ReasoningEffort: providers.ReasoningEffortHigh,
+		}
+
+		req, err := p.createRequest(params, false)
+		require.NoError(t, err)
+		require.NotNil(t, req.Thinking)
+		require.Equal(t, "enabled", req.Thinking.Type)
+	})
+
+	t.Run("does not enable thinking for ReasoningEffortNone", func(t *testing.T) {
+		t.Parallel()
+
+		p := &Provider{}
+		params := providers.CompletionParams{
+			Model: testutil.TestModel(providerName),
+			Messages: []providers.Message{
+				{Role: providers.RoleUser, Content: "Hello"},
+			},
+			ReasoningEffort: providers.ReasoningEffortNone,
+		}
+
+		req, err := p.createRequest(params, false)
+		require.NoError(t, err)
+		require.Nil(t, req.Thinking)
+	})
+
+	t.Run("preserves reasoning_content from history", func(t *testing.T) {
+		t.Parallel()
+
+		p := &Provider{}
+		params := providers.CompletionParams{
+			Model: testutil.ReasoningModel(providerName),
+			Messages: []providers.Message{
+				{Role: providers.RoleUser, Content: "Think about this"},
+				{
+					Role:    providers.RoleAssistant,
+					Content: "Here is my answer",
+					Reasoning: &providers.Reasoning{
+						Content: "Let me think step by step...",
+					},
+				},
+				{Role: providers.RoleUser, Content: "Follow up question"},
+			},
+		}
+
+		req, err := p.createRequest(params, false)
+		require.NoError(t, err)
+		require.Len(t, req.Messages, 3)
+
+		// The assistant message should carry reasoning_content.
+		require.Equal(t, "Let me think step by step...", req.Messages[1].ReasoningContent)
+
+		// User messages should not have reasoning_content.
+		require.Empty(t, req.Messages[0].ReasoningContent)
+		require.Empty(t, req.Messages[2].ReasoningContent)
+	})
+
+	t.Run("converts tool calls and tool results", func(t *testing.T) {
+		t.Parallel()
+
+		p := &Provider{}
+		params := providers.CompletionParams{
+			Model: testutil.TestModel(providerName),
+			Messages: []providers.Message{
+				{Role: providers.RoleUser, Content: "What is the weather?"},
+				{
+					Role:    providers.RoleAssistant,
+					Content: "",
+					ToolCalls: []providers.ToolCall{
+						{
+							ID:   "call_abc",
+							Type: "function",
+							Function: providers.FunctionCall{
+								Name:      "get_weather",
+								Arguments: `{"location":"Paris"}`,
+							},
+						},
+					},
+				},
+				{
+					Role:       providers.RoleTool,
+					Content:    `{"temp":22}`,
+					ToolCallID: "call_abc",
+				},
+			},
+			Tools:      []providers.Tool{testutil.WeatherTool()},
+			ToolChoice: "auto",
+		}
+
+		req, err := p.createRequest(params, false)
+		require.NoError(t, err)
+		require.Len(t, req.Messages, 3)
+
+		// Assistant message should have tool calls.
+		require.Len(t, req.Messages[1].ToolCalls, 1)
+		require.Equal(t, "get_weather", req.Messages[1].ToolCalls[0].Function.Name)
+
+		// Tool message should have tool_call_id.
+		require.Equal(t, "call_abc", req.Messages[2].ToolCallID)
+
+		// Request-level tools and tool_choice should be set.
+		require.Len(t, req.Tools, 1)
+		require.Equal(t, "auto", req.ToolChoice)
+	})
+
+	t.Run("converts multimodal content parts", func(t *testing.T) {
+		t.Parallel()
+
+		p := &Provider{}
+		params := providers.CompletionParams{
+			Model: testutil.ProviderImageModelMap[providerName],
+			Messages: []providers.Message{
+				{
+					Role: providers.RoleUser,
+					Content: []providers.ContentPart{
+						{Type: "text", Text: "What is in this image?"},
+						{
+							Type:     "image_url",
+							ImageURL: &providers.ImageURL{URL: "https://example.com/img.jpg"},
+						},
+					},
+				},
+			},
+		}
+
+		req, err := p.createRequest(params, false)
+		require.NoError(t, err)
+		require.Len(t, req.Messages, 1)
+
+		// Content should be an array of content parts.
+		parts, ok := req.Messages[0].Content.([]contentPart)
+		require.True(t, ok, "expected content to be []contentPart")
+		require.Len(t, parts, 2)
+
+		require.Equal(t, "text", parts[0].Type)
+		require.Equal(t, "What is in this image?", parts[0].Text)
+
+		require.Equal(t, "image_url", parts[1].Type)
+		imgURL, ok := parts[1].ImageURL.(map[string]string)
+		require.True(t, ok)
+		require.Equal(t, "https://example.com/img.jpg", imgURL["url"])
+	})
+
+	t.Run("strips data URI prefix from base64 images", func(t *testing.T) {
+		t.Parallel()
+
+		p := &Provider{}
+		params := providers.CompletionParams{
+			Model: testutil.ProviderImageModelMap[providerName],
+			Messages: []providers.Message{
+				{
+					Role: providers.RoleUser,
+					Content: []providers.ContentPart{
+						{
+							Type:     "image_url",
+							ImageURL: &providers.ImageURL{URL: "data:image/png;base64,iVBOR..."},
+						},
+					},
+				},
+			},
+		}
+
+		req, err := p.createRequest(params, false)
+		require.NoError(t, err)
+
+		parts, ok := req.Messages[0].Content.([]contentPart)
+		require.True(t, ok)
+		require.Len(t, parts, 1)
+
+		imgURL, ok := parts[0].ImageURL.(map[string]string)
+		require.True(t, ok)
+		require.Equal(t, "iVBOR...", imgURL["url"])
+	})
+
+	t.Run("serializes user_id correctly in JSON", func(t *testing.T) {
+		t.Parallel()
+
+		p := &Provider{}
+		params := providers.CompletionParams{
+			Model: testutil.TestModel(providerName),
+			Messages: []providers.Message{
+				{Role: providers.RoleUser, Content: "Hello"},
+			},
+			User: "usr-12345678",
+		}
+
+		req, err := p.createRequest(params, false)
+		require.NoError(t, err)
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		// Verify it uses "user_id" not "user" as the JSON key.
+		require.Contains(t, string(data), `"user_id"`)
+		require.NotContains(t, string(data), `"user":`)
+	})
+}
+
+func TestToProviderCompletion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("converts basic response", func(t *testing.T) {
+		t.Parallel()
+
+		model := testutil.TestModel(providerName)
+		zaiResp := &zaiChatCompletion{
+			ID:      "chatcmpl-123",
+			Object:  objectChatCompletion,
+			Created: 1234567890,
+			Model:   model,
+			Choices: []zaiChoice{
+				{
+					Index: 0,
+					Message: zaiMessage{
+						Message: providers.Message{
+							Role:    providers.RoleAssistant,
+							Content: "Hello World",
+						},
+					},
+					FinishReason: "stop",
+				},
+			},
+			Usage: &providers.Usage{
+				PromptTokens:     10,
+				CompletionTokens: 5,
+				TotalTokens:      15,
+			},
+		}
+
+		result := zaiResp.toProviderCompletion()
+
+		require.Equal(t, "chatcmpl-123", result.ID)
+		require.Equal(t, objectChatCompletion, result.Object)
+		require.Equal(t, int64(1234567890), result.Created)
+		require.Equal(t, model, result.Model)
+		require.Len(t, result.Choices, 1)
+		require.Equal(t, providers.RoleAssistant, result.Choices[0].Message.Role)
+		require.Equal(t, "Hello World", result.Choices[0].Message.Content)
+		require.Equal(t, "stop", result.Choices[0].FinishReason)
+		require.NotNil(t, result.Usage)
+		require.Equal(t, 15, result.Usage.TotalTokens)
+	})
+
+	t.Run("converts response with reasoning_content", func(t *testing.T) {
+		t.Parallel()
+
+		zaiResp := &zaiChatCompletion{
+			ID:      "chatcmpl-456",
+			Object:  objectChatCompletion,
+			Created: 1234567890,
+			Model:   testutil.ReasoningModel(providerName),
+			Choices: []zaiChoice{
+				{
+					Index: 0,
+					Message: zaiMessage{
+						Message: providers.Message{
+							Role:    providers.RoleAssistant,
+							Content: "The answer is 42.",
+						},
+						ReasoningContent: "Let me think step by step...",
+					},
+					FinishReason: "stop",
+				},
+			},
+		}
+
+		result := zaiResp.toProviderCompletion()
+
+		require.Len(t, result.Choices, 1)
+		require.Equal(t, "The answer is 42.", result.Choices[0].Message.Content)
+		require.NotNil(t, result.Choices[0].Message.Reasoning)
+		require.Equal(t, "Let me think step by step...", result.Choices[0].Message.Reasoning.Content)
+	})
+
+	t.Run("converts response without reasoning_content", func(t *testing.T) {
+		t.Parallel()
+
+		zaiResp := &zaiChatCompletion{
+			ID:     "chatcmpl-789",
+			Object: objectChatCompletion,
+			Model:  testutil.TestModel(providerName),
+			Choices: []zaiChoice{
+				{
+					Index: 0,
+					Message: zaiMessage{
+						Message: providers.Message{
+							Role:    providers.RoleAssistant,
+							Content: "Hello",
+						},
+					},
+					FinishReason: "stop",
+				},
+			},
+		}
+
+		result := zaiResp.toProviderCompletion()
+
+		require.Nil(t, result.Choices[0].Message.Reasoning)
+	})
+
+	t.Run("converts response with tool_calls", func(t *testing.T) {
+		t.Parallel()
+
+		zaiResp := &zaiChatCompletion{
+			ID:     "chatcmpl-tool",
+			Object: objectChatCompletion,
+			Model:  testutil.TestModel(providerName),
+			Choices: []zaiChoice{
+				{
+					Index: 0,
+					Message: zaiMessage{
+						Message: providers.Message{
+							Role: providers.RoleAssistant,
+							ToolCalls: []providers.ToolCall{
+								{
+									ID:   "call_001",
+									Type: "function",
+									Function: providers.FunctionCall{
+										Name:      "get_weather",
+										Arguments: `{"location":"Paris"}`,
+									},
+								},
+							},
+						},
+					},
+					FinishReason: "tool_calls",
+				},
+			},
+		}
+
+		result := zaiResp.toProviderCompletion()
+
+		require.Len(t, result.Choices, 1)
+		require.Len(t, result.Choices[0].Message.ToolCalls, 1)
+		require.Equal(t, "get_weather", result.Choices[0].Message.ToolCalls[0].Function.Name)
+		require.Equal(t, "tool_calls", result.Choices[0].FinishReason)
+	})
+}
+
+func TestToProviderChunk(t *testing.T) {
+	t.Parallel()
+
+	t.Run("converts basic streaming chunk", func(t *testing.T) {
+		t.Parallel()
+
+		model := testutil.TestModel(providerName)
+		zaiChunk := &zaiChatCompletionChunk{
+			ID:      "chatcmpl-stream-1",
+			Object:  objectChatCompletionChunk,
+			Created: 1234567890,
+			Model:   model,
+			Choices: []zaiChunkChoice{
+				{
+					Index: 0,
+					Delta: zaiChunkDelta{
+						ChunkDelta: providers.ChunkDelta{
+							Role:    providers.RoleAssistant,
+							Content: "Hello",
+						},
+					},
+				},
+			},
+		}
+
+		result := zaiChunk.toProviderChunk()
+
+		require.Equal(t, "chatcmpl-stream-1", result.ID)
+		require.Equal(t, objectChatCompletionChunk, result.Object)
+		require.Equal(t, model, result.Model)
+		require.Len(t, result.Choices, 1)
+		require.Equal(t, providers.RoleAssistant, result.Choices[0].Delta.Role)
+		require.Equal(t, "Hello", result.Choices[0].Delta.Content)
+		require.Nil(t, result.Choices[0].Delta.Reasoning)
+	})
+
+	t.Run("converts chunk with reasoning_content", func(t *testing.T) {
+		t.Parallel()
+
+		zaiChunk := &zaiChatCompletionChunk{
+			ID:     "chatcmpl-stream-2",
+			Object: objectChatCompletionChunk,
+			Model:  testutil.ReasoningModel(providerName),
+			Choices: []zaiChunkChoice{
+				{
+					Index: 0,
+					Delta: zaiChunkDelta{
+						ReasoningContent: "Thinking...",
+					},
+				},
+			},
+		}
+
+		result := zaiChunk.toProviderChunk()
+
+		require.Len(t, result.Choices, 1)
+		require.NotNil(t, result.Choices[0].Delta.Reasoning)
+		require.Equal(t, "Thinking...", result.Choices[0].Delta.Reasoning.Content)
+		require.Empty(t, result.Choices[0].Delta.Content)
+	})
+
+	t.Run("converts final chunk with finish reason and usage", func(t *testing.T) {
+		t.Parallel()
+
+		zaiChunk := &zaiChatCompletionChunk{
+			ID:     "chatcmpl-stream-3",
+			Object: objectChatCompletionChunk,
+			Model:  testutil.TestModel(providerName),
+			Choices: []zaiChunkChoice{
+				{
+					Index:        0,
+					Delta:        zaiChunkDelta{},
+					FinishReason: "stop",
+				},
+			},
+			Usage: &providers.Usage{
+				PromptTokens:     10,
+				CompletionTokens: 20,
+				TotalTokens:      30,
+			},
+		}
+
+		result := zaiChunk.toProviderChunk()
+
+		require.Equal(t, "stop", result.Choices[0].FinishReason)
+		require.NotNil(t, result.Usage)
+		require.Equal(t, 30, result.Usage.TotalTokens)
+	})
+
+	t.Run("converts chunk with tool calls", func(t *testing.T) {
+		t.Parallel()
+
+		zaiChunk := &zaiChatCompletionChunk{
+			ID:     "chatcmpl-stream-4",
+			Object: objectChatCompletionChunk,
+			Model:  testutil.TestModel(providerName),
+			Choices: []zaiChunkChoice{
+				{
+					Index: 0,
+					Delta: zaiChunkDelta{
+						ChunkDelta: providers.ChunkDelta{
+							ToolCalls: []providers.ToolCall{
+								{
+									ID:   "call_001",
+									Type: "function",
+									Function: providers.FunctionCall{
+										Name:      "get_weather",
+										Arguments: `{"loc`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		result := zaiChunk.toProviderChunk()
+
+		require.Len(t, result.Choices[0].Delta.ToolCalls, 1)
+		require.Equal(t, "get_weather", result.Choices[0].Delta.ToolCalls[0].Function.Name)
+	})
+}
+
+func TestConvertError(t *testing.T) {
+	t.Parallel()
+
+	p := &Provider{}
+
+	t.Run("wraps error as ProviderError", func(t *testing.T) {
+		t.Parallel()
+
+		err := p.ConvertError(stderrors.New("network timeout"))
+		require.Error(t, err)
+		require.True(t, stderrors.Is(err, errors.ErrProvider))
+		require.Contains(t, err.Error(), "["+providerName+"]")
+	})
+}
+
+// Integration tests - only run if z.ai API key is available.
+
+func TestIntegrationCompletion(t *testing.T) {
+	t.Parallel()
+
+	if testutil.SkipIfNoAPIKey(providerName) {
+		t.Skip("ZAI_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	params := providers.CompletionParams{
+		Model:    testutil.TestModel(providerName),
+		Messages: testutil.SimpleMessages(),
+	}
+
+	resp, err := provider.Completion(ctx, params)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, resp.ID)
+	require.Equal(t, objectChatCompletion, resp.Object)
+	require.Len(t, resp.Choices, 1)
+	require.NotEmpty(t, resp.Choices[0].Message.Content)
+	require.Equal(t, providers.RoleAssistant, resp.Choices[0].Message.Role)
+}
+
+func TestIntegrationCompletionWithSystemMessage(t *testing.T) {
+	t.Parallel()
+
+	if testutil.SkipIfNoAPIKey(providerName) {
+		t.Skip("ZAI_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	params := providers.CompletionParams{
+		Model:    testutil.TestModel(providerName),
+		Messages: testutil.MessagesWithSystem(),
+	}
+
+	resp, err := provider.Completion(ctx, params)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, resp.ID)
+	require.Len(t, resp.Choices, 1)
+	require.NotEmpty(t, resp.Choices[0].Message.Content)
+}
+
+func TestIntegrationCompletionStream(t *testing.T) {
+	t.Parallel()
+
+	if testutil.SkipIfNoAPIKey(providerName) {
+		t.Skip("ZAI_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	params := providers.CompletionParams{
+		Model:    testutil.TestModel(providerName),
+		Messages: testutil.SimpleMessages(),
+		Stream:   true,
+	}
+
+	chunks, errs := provider.CompletionStream(ctx, params)
+
+	var content strings.Builder
+	chunkCount := 0
+
+	for chunk := range chunks {
+		chunkCount++
+		require.Equal(t, objectChatCompletionChunk, chunk.Object)
+		if len(chunk.Choices) > 0 {
+			content.WriteString(chunk.Choices[0].Delta.Content)
+		}
+	}
+
+	err = <-errs
+	require.NoError(t, err)
+
+	require.Greater(t, chunkCount, 0)
+	require.NotEmpty(t, content.String())
+}
+
+func TestIntegrationListModels(t *testing.T) {
+	t.Parallel()
+
+	if testutil.SkipIfNoAPIKey(providerName) {
+		t.Skip("ZAI_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	resp, err := provider.ListModels(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, objectList, resp.Object)
+	require.NotEmpty(t, resp.Data)
+}
+
+func TestIntegrationCompletionConversation(t *testing.T) {
+	t.Parallel()
+
+	if testutil.SkipIfNoAPIKey(providerName) {
+		t.Skip("ZAI_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	params := providers.CompletionParams{
+		Model:    testutil.TestModel(providerName),
+		Messages: testutil.ConversationMessages(),
+	}
+
+	resp, err := provider.Completion(ctx, params)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, resp.ID)
+	require.Len(t, resp.Choices, 1)
+
+	// The model should remember the name "Alice".
+	require.Contains(t, strings.ToLower(resp.Choices[0].Message.ContentString()), "alice")
+}
+
+func TestIntegrationCompletionWithTools(t *testing.T) {
+	t.Parallel()
+
+	if testutil.SkipIfNoAPIKey(providerName) {
+		t.Skip("ZAI_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	params := providers.CompletionParams{
+		Model:      testutil.TestModel(providerName),
+		Messages:   testutil.ToolCallMessages(),
+		Tools:      []providers.Tool{testutil.WeatherTool()},
+		ToolChoice: "auto",
+	}
+
+	resp, err := provider.Completion(ctx, params)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, resp.ID)
+	require.Len(t, resp.Choices, 1)
+
+	// Should either have tool calls or content.
+	choice := resp.Choices[0]
+	hasToolCalls := len(choice.Message.ToolCalls) > 0
+	hasContent := choice.Message.ContentString() != ""
+	require.True(t, hasToolCalls || hasContent, "Expected tool calls or content")
+
+	if hasToolCalls {
+		require.Equal(t, "get_weather", choice.Message.ToolCalls[0].Function.Name)
+	}
+}
+
+func TestIntegrationAgentLoop(t *testing.T) {
+	t.Parallel()
+
+	if testutil.SkipIfNoAPIKey(providerName) {
+		t.Skip("ZAI_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tools := []providers.Tool{testutil.WeatherTool()}
+
+	// Step 1: Send initial message asking about weather.
+	messages := []providers.Message{
+		{Role: providers.RoleUser, Content: "What is the weather in Paris? Use the get_weather tool."},
+	}
+
+	resp, err := provider.Completion(ctx, providers.CompletionParams{
+		Model:      testutil.TestModel(providerName),
+		Messages:   messages,
+		Tools:      tools,
+		ToolChoice: "auto",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+
+	// Step 2: Verify the model called the tool.
+	require.NotEmpty(t, resp.Choices[0].Message.ToolCalls, "expected model to call get_weather tool")
+	require.Equal(t, providers.FinishReasonToolCalls, resp.Choices[0].FinishReason)
+
+	tc := resp.Choices[0].Message.ToolCalls[0]
+	require.Equal(t, "get_weather", tc.Function.Name)
+	require.NotEmpty(t, tc.ID)
+
+	// Step 3: Parse the arguments.
+	var args struct {
+		Location string `json:"location"`
+	}
+	err = json.Unmarshal([]byte(tc.Function.Arguments), &args)
+	require.NoError(t, err, "tool arguments should be valid JSON")
+	require.NotEmpty(t, args.Location, "location argument should be present")
+	require.Contains(t, strings.ToLower(args.Location), "paris")
+
+	// Step 4: Add assistant message with tool call and tool result.
+	messages = append(messages, resp.Choices[0].Message)
+	messages = append(messages, providers.Message{
+		Role:       providers.RoleTool,
+		Content:    testutil.MockWeatherResult(t, args.Location),
+		ToolCallID: tc.ID,
+	})
+
+	// Step 5: Continue conversation with tool result.
+	resp, err = provider.Completion(ctx, providers.CompletionParams{
+		Model:    testutil.TestModel(providerName),
+		Messages: messages,
+		Tools:    tools,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+
+	// Step 6: Verify the model produced a final response.
+	require.Equal(t, providers.FinishReasonStop, resp.Choices[0].FinishReason)
+	require.NotEmpty(t, resp.Choices[0].Message.ContentString())
+}
+
+func TestIntegrationAgentLoopMultipleParams(t *testing.T) {
+	t.Parallel()
+
+	if testutil.SkipIfNoAPIKey(providerName) {
+		t.Skip("ZAI_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tools := []providers.Tool{testutil.NewTestCalculatorTool(t)}
+
+	// Ask the model to use the calculator with specific values.
+	messages := []providers.Message{
+		{Role: providers.RoleUser, Content: "Use the calculate tool to add 15 and 27 together."},
+	}
+
+	resp, err := provider.Completion(ctx, providers.CompletionParams{
+		Model:      testutil.TestModel(providerName),
+		Messages:   messages,
+		Tools:      tools,
+		ToolChoice: "auto",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+
+	// Verify the model called the tool with correct parameters.
+	require.NotEmpty(t, resp.Choices[0].Message.ToolCalls, "expected model to call calculate tool")
+
+	tc := resp.Choices[0].Message.ToolCalls[0]
+	require.Equal(t, "calculate", tc.Function.Name)
+
+	// Parse and verify all required parameters are present.
+	var args struct {
+		A         float64 `json:"a"`
+		B         float64 `json:"b"`
+		Operation string  `json:"operation"`
+	}
+	err = json.Unmarshal([]byte(tc.Function.Arguments), &args)
+	require.NoError(t, err, "tool arguments should be valid JSON")
+
+	// Verify the parameters.
+	require.Equal(t, 15.0, args.A, "first operand should be 15")
+	require.Equal(t, 27.0, args.B, "second operand should be 27")
+	require.Equal(t, "add", args.Operation, "operation should be 'add'")
+
+	// Complete the agent loop with tool result.
+	messages = append(messages, resp.Choices[0].Message)
+	messages = append(messages, providers.Message{
+		Role:       providers.RoleTool,
+		Content:    testutil.MockCalculatorResult(t, args.A, args.B, args.Operation),
+		ToolCallID: tc.ID,
+	})
+
+	resp, err = provider.Completion(ctx, providers.CompletionParams{
+		Model:    testutil.TestModel(providerName),
+		Messages: messages,
+		Tools:    tools,
+	})
+	require.NoError(t, err)
+
+	// Verify final response mentions the result.
+	require.Contains(t, resp.Choices[0].Message.ContentString(), "42")
+}
+
+func TestIntegrationCompletionReasoning(t *testing.T) {
+	t.Parallel()
+
+	if testutil.SkipIfNoAPIKey(providerName) {
+		t.Skip("ZAI_API_KEY not set")
+	}
+
+	model := testutil.ReasoningModel(providerName)
+	if model == "" {
+		t.Skip("No reasoning model configured for zai")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	params := providers.CompletionParams{
+		Model: model,
+		Messages: []providers.Message{
+			{Role: providers.RoleUser, Content: "Please say hello! Think very briefly before you respond."},
+		},
+		ReasoningEffort: providers.ReasoningEffortLow,
+	}
+
+	resp, err := provider.Completion(ctx, params)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, resp.ID)
+	require.Len(t, resp.Choices, 1)
+	require.NotEmpty(t, resp.Choices[0].Message.Content)
+
+	// With reasoning effort, we should get reasoning content.
+	if resp.Choices[0].Message.Reasoning != nil {
+		require.NotEmpty(t, resp.Choices[0].Message.Reasoning.Content)
+	}
+}
+
+func TestIntegrationAuthenticationError(t *testing.T) {
+	t.Parallel()
+
+	provider, err := New(config.WithAPIKey("invalid-api-key"))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	params := providers.CompletionParams{
+		Model:    testutil.TestModel(providerName),
+		Messages: testutil.SimpleMessages(),
+	}
+
+	_, err = provider.Completion(ctx, params)
+	require.Error(t, err)
+
+	// Check that it's converted to an authentication error.
+	var authErr *errors.AuthenticationError
+	require.ErrorAs(t, err, &authErr)
+}
+
+func TestIntegrationAgentLoopContinuation(t *testing.T) {
+	t.Parallel()
+
+	if testutil.SkipIfNoAPIKey(providerName) {
+		t.Skip("ZAI_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Start with the agent loop messages (user asks, assistant calls tool, tool returns).
+	messages := testutil.AgentLoopMessages()
+
+	params := providers.CompletionParams{
+		Model:    testutil.TestModel(providerName),
+		Messages: messages,
+		Tools:    []providers.Tool{testutil.WeatherTool()},
+	}
+
+	// The model should respond with the weather information.
+	resp, err := provider.Completion(ctx, params)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, resp.ID)
+	require.Len(t, resp.Choices, 1)
+
+	// Should have a content response (not another tool call).
+	if contentStr := resp.Choices[0].Message.ContentString(); contentStr != "" {
+		content := strings.ToLower(contentStr)
+		// Should mention the weather or sunny.
+		require.True(
+			t,
+			strings.Contains(content, "sunny") || strings.Contains(content, "weather") ||
+				strings.Contains(content, "salvaterra"),
+		)
+	}
+}

--- a/providers/zai/zai_test.go
+++ b/providers/zai/zai_test.go
@@ -698,8 +698,6 @@ func TestConvertError(t *testing.T) {
 // Integration tests - only run if z.ai API key is available.
 
 func TestIntegrationCompletion(t *testing.T) {
-	t.Parallel()
-
 	if testutil.SkipIfNoAPIKey(providerName) {
 		t.Skip("ZAI_API_KEY not set")
 	}
@@ -724,8 +722,6 @@ func TestIntegrationCompletion(t *testing.T) {
 }
 
 func TestIntegrationCompletionWithSystemMessage(t *testing.T) {
-	t.Parallel()
-
 	if testutil.SkipIfNoAPIKey(providerName) {
 		t.Skip("ZAI_API_KEY not set")
 	}
@@ -748,8 +744,6 @@ func TestIntegrationCompletionWithSystemMessage(t *testing.T) {
 }
 
 func TestIntegrationCompletionStream(t *testing.T) {
-	t.Parallel()
-
 	if testutil.SkipIfNoAPIKey(providerName) {
 		t.Skip("ZAI_API_KEY not set")
 	}
@@ -785,8 +779,6 @@ func TestIntegrationCompletionStream(t *testing.T) {
 }
 
 func TestIntegrationListModels(t *testing.T) {
-	t.Parallel()
-
 	if testutil.SkipIfNoAPIKey(providerName) {
 		t.Skip("ZAI_API_KEY not set")
 	}
@@ -803,8 +795,6 @@ func TestIntegrationListModels(t *testing.T) {
 }
 
 func TestIntegrationCompletionConversation(t *testing.T) {
-	t.Parallel()
-
 	if testutil.SkipIfNoAPIKey(providerName) {
 		t.Skip("ZAI_API_KEY not set")
 	}
@@ -829,8 +819,6 @@ func TestIntegrationCompletionConversation(t *testing.T) {
 }
 
 func TestIntegrationCompletionWithTools(t *testing.T) {
-	t.Parallel()
-
 	if testutil.SkipIfNoAPIKey(providerName) {
 		t.Skip("ZAI_API_KEY not set")
 	}
@@ -864,8 +852,6 @@ func TestIntegrationCompletionWithTools(t *testing.T) {
 }
 
 func TestIntegrationAgentLoop(t *testing.T) {
-	t.Parallel()
-
 	if testutil.SkipIfNoAPIKey(providerName) {
 		t.Skip("ZAI_API_KEY not set")
 	}
@@ -930,8 +916,6 @@ func TestIntegrationAgentLoop(t *testing.T) {
 }
 
 func TestIntegrationAgentLoopMultipleParams(t *testing.T) {
-	t.Parallel()
-
 	if testutil.SkipIfNoAPIKey(providerName) {
 		t.Skip("ZAI_API_KEY not set")
 	}
@@ -996,8 +980,6 @@ func TestIntegrationAgentLoopMultipleParams(t *testing.T) {
 }
 
 func TestIntegrationCompletionReasoning(t *testing.T) {
-	t.Parallel()
-
 	if testutil.SkipIfNoAPIKey(providerName) {
 		t.Skip("ZAI_API_KEY not set")
 	}
@@ -1033,8 +1015,6 @@ func TestIntegrationCompletionReasoning(t *testing.T) {
 }
 
 func TestIntegrationAuthenticationError(t *testing.T) {
-	t.Parallel()
-
 	provider, err := New(config.WithAPIKey("invalid-api-key"))
 	require.NoError(t, err)
 
@@ -1053,8 +1033,6 @@ func TestIntegrationAuthenticationError(t *testing.T) {
 }
 
 func TestIntegrationAgentLoopContinuation(t *testing.T) {
-	t.Parallel()
-
 	if testutil.SkipIfNoAPIKey(providerName) {
 		t.Skip("ZAI_API_KEY not set")
 	}


### PR DESCRIPTION
## Summary

Add Z.ai (Zhipu AI) provider implementation based on the OpenAI-compatible one.

## Changes

- Add `providers/zai/zai.go` — provider implementation using `net/http`
- Add `providers/zai/zai_test.go` — comprehensive unit and integration tests
- Update `internal/testutil/fixtures.go`
- Update `docs/providers.md`
- Update `README.md`

## Interfaces Implemented

- `Provider`
- `CapabilityProvider`
- `ModelLister`
- `ErrorConverter`

## Testing

```
$ make test                                                           

golangci-lint run --fix ./...
0 issues.

go test -race ./...
ok      github.com/mozilla-ai/any-llm-go/providers/zai  6.728s
```
```
$ go test -short ./...
ok      github.com/mozilla-ai/any-llm-go/providers/zai  7.698s
```
```
$ go tool cover -func=coverage.out                                                    
github.com/mozilla-ai/any-llm-go/providers/zai/zai.go:51:       New                     90.0%
github.com/mozilla-ai/any-llm-go/providers/zai/zai.go:75:       Capabilities            100.0%
github.com/mozilla-ai/any-llm-go/providers/zai/zai.go:89:       Completion              76.9%
github.com/mozilla-ai/any-llm-go/providers/zai/zai.go:117:      CompletionStream        70.6%
github.com/mozilla-ai/any-llm-go/providers/zai/zai.go:192:      ConvertError            100.0%
github.com/mozilla-ai/any-llm-go/providers/zai/zai.go:197:      ListModels              76.9%
github.com/mozilla-ai/any-llm-go/providers/zai/zai.go:239:      Name                    100.0%
github.com/mozilla-ai/any-llm-go/providers/zai/zai.go:244:      createRequest           100.0%
github.com/mozilla-ai/any-llm-go/providers/zai/zai.go:307:      doRequest               79.2%
github.com/mozilla-ai/any-llm-go/providers/zai/zai.go:348:      handleErrorResponse     100.0%
github.com/mozilla-ai/any-llm-go/providers/zai/zai.go:403:      toProviderCompletion    100.0%
github.com/mozilla-ai/any-llm-go/providers/zai/zai.go:452:      toProviderChunk         100.0%
total:                                                          (statements)            84.8%
```
## Checklist

- [x] Tests pass locally (`go test -short ./...`)
- [x] Linting passes (`golangci-lint run ./...`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)
