### PR TITLE
fix(openai): non-compatible providers send correct max_tokens field

### DIFF
--- a/internal/testutil/fakeserver.go
+++ b/internal/testutil/fakeserver.go
@@ -1,0 +1,134 @@
+// Package testutil provides testing utilities and fixtures for any-llm.
+package testutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+// FakeCompletionServer creates an httptest server that captures the raw JSON
+// request body and returns a minimal valid OpenAI-compatible chat completion
+// response. The captured body is returned so callers can assert on the exact
+// JSON field names sent over the wire.
+//
+// The handler uses t.Errorf for error reporting, which is safe because the
+// blocking HTTP client call in the test goroutine synchronises the handler
+// goroutine — the handler always completes before the test returns.
+func FakeCompletionServer(t *testing.T) (serverURL string, capturedBody func() map[string]any) {
+	t.Helper()
+
+	var (
+		mu   sync.Mutex
+		body map[string]any
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading request body: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Errorf("unmarshalling request body: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		// Minimal valid chat completion response.
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-test",
+			"object": "chat.completion",
+			"created": 1700000000,
+			"model": "test-model",
+			"choices": [{
+				"index": 0,
+				"message": {"role": "assistant", "content": "hello"},
+				"finish_reason": "stop"
+			}],
+			"usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
+		}`))
+	}))
+
+	t.Cleanup(srv.Close)
+
+	return srv.URL, func() map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+
+		cp := make(map[string]any, len(body))
+		maps.Copy(cp, body)
+
+		return cp
+	}
+}
+
+// FakeStreamingServer creates an httptest server that captures the raw JSON
+// request body and returns a minimal valid OpenAI-compatible streaming (SSE)
+// response. The captured body is returned so callers can assert on the exact
+// JSON field names sent over the wire.
+//
+// The handler uses t.Errorf for error reporting, which is safe because the
+// blocking HTTP client call in the test goroutine synchronises the handler
+// goroutine — the handler always completes before the test returns.
+func FakeStreamingServer(t *testing.T) (serverURL string, capturedBody func() map[string]any) {
+	t.Helper()
+
+	var (
+		mu   sync.Mutex
+		body map[string]any
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading request body: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Errorf("unmarshalling request body: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+
+		// Minimal valid SSE streaming response.
+		chunk := `{"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"hello"},"finish_reason":null}]}`
+		done := `{"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`
+
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", chunk)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", done)
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+
+	t.Cleanup(srv.Close)
+
+	return srv.URL, func() map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+
+		cp := make(map[string]any, len(body))
+		maps.Copy(cp, body)
+
+		return cp
+	}
+}

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -8,6 +8,9 @@ import (
 	"fmt"
 	"slices"
 
+	oaisdk "github.com/openai/openai-go"
+	"github.com/openai/openai-go/packages/param"
+
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
 	"github.com/mozilla-ai/any-llm-go/providers/openai"
@@ -50,13 +53,14 @@ type Provider struct {
 // New creates a new DeepSeek provider.
 func New(opts ...config.Option) (*Provider, error) {
 	base, err := openai.NewCompatible(openai.CompatibleConfig{
-		APIKeyEnvVar:   envAPIKey,
-		BaseURLEnvVar:  "",
-		Capabilities:   capabilities(),
-		DefaultAPIKey:  "",
-		DefaultBaseURL: defaultBaseURL,
-		Name:           providerName,
-		RequireAPIKey:  true,
+		APIKeyEnvVar:                   envAPIKey,
+		BaseURLEnvVar:                  "",
+		Capabilities:                   capabilities(),
+		ChatCompletionRequestTransform: transformRequest,
+		DefaultAPIKey:                  "",
+		DefaultBaseURL:                 defaultBaseURL,
+		Name:                           providerName,
+		RequireAPIKey:                  true,
 	}, opts...)
 	if err != nil {
 		return nil, err
@@ -154,6 +158,20 @@ func preprocessParams(params providers.CompletionParams) providers.CompletionPar
 		User:            params.User,
 		Extra:           params.Extra,
 	}
+}
+
+// transformRequest adjusts the OpenAI SDK request for DeepSeek's API.
+// DeepSeek uses max_tokens, not max_completion_tokens.
+// If both are set, MaxCompletionTokens takes precedence over MaxTokens.
+// See: https://api-docs.deepseek.com/api/create-chat-completion
+func transformRequest(req *oaisdk.ChatCompletionNewParams) {
+	if req.MaxCompletionTokens.Valid() {
+		// Set max_tokens using max_completion_tokens value.
+		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
+	}
+
+	// Clear unsupported fields from the request.
+	req.MaxCompletionTokens = param.Opt[int64]{}
 }
 
 // preprocessMessagesForJSONSchema injects the JSON schema into the last user message.

--- a/providers/deepseek/deepseek_test.go
+++ b/providers/deepseek/deepseek_test.go
@@ -354,6 +354,73 @@ func TestPreprocessMessagesForJSONSchema(t *testing.T) {
 	})
 }
 
+func TestCompletionSendsMaxTokensOnWire(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeCompletionServer(t)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	maxTokens := 512
+	params := providers.CompletionParams{
+		Model:     "deepseek-chat",
+		Messages:  testutil.SimpleMessages(),
+		MaxTokens: &maxTokens,
+	}
+
+	_, err = provider.Completion(context.Background(), params)
+	require.NoError(t, err)
+
+	body := capturedBody()
+
+	// DeepSeek is not fully OpenAI-compatible.
+	// The wire request must use max_tokens (not max_completion_tokens)
+	// because that is what the DeepSeek API accepts.
+	// See: https://api-docs.deepseek.com/api/create-chat-completion
+	require.Contains(t, body, "max_tokens")
+	require.NotContains(t, body, "max_completion_tokens")
+	require.Equal(t, float64(512), body["max_tokens"])
+}
+
+func TestCompletionStreamSendsMaxTokensOnWire(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeStreamingServer(t)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	maxTokens := 512
+	params := providers.CompletionParams{
+		Model:     "deepseek-chat",
+		Messages:  testutil.SimpleMessages(),
+		MaxTokens: &maxTokens,
+		Stream:    true,
+	}
+
+	chunks, errs := provider.CompletionStream(context.Background(), params)
+	for range chunks {
+		// Drain the channel.
+	}
+	require.NoError(t, <-errs)
+
+	body := capturedBody()
+
+	// DeepSeek is not fully OpenAI-compatible.
+	// The streaming wire request must also use max_tokens (not max_completion_tokens).
+	// See: https://api-docs.deepseek.com/api/create-chat-completion
+	require.Contains(t, body, "max_tokens")
+	require.NotContains(t, body, "max_completion_tokens")
+	require.Equal(t, float64(512), body["max_tokens"])
+}
+
 // Integration tests - only run if DeepSeek API key is available.
 
 func TestIntegrationCompletion(t *testing.T) {

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"slices"
 
+	oaisdk "github.com/openai/openai-go"
+	"github.com/openai/openai-go/packages/param"
+
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
 	"github.com/mozilla-ai/any-llm-go/providers/openai"
@@ -48,13 +51,14 @@ type Provider struct {
 // New creates a new Mistral provider.
 func New(opts ...config.Option) (*Provider, error) {
 	base, err := openai.NewCompatible(openai.CompatibleConfig{
-		APIKeyEnvVar:   envAPIKey,
-		BaseURLEnvVar:  "",
-		Capabilities:   capabilities(),
-		DefaultAPIKey:  "",
-		DefaultBaseURL: defaultBaseURL,
-		Name:           providerName,
-		RequireAPIKey:  true,
+		APIKeyEnvVar:                   envAPIKey,
+		BaseURLEnvVar:                  "",
+		Capabilities:                   capabilities(),
+		ChatCompletionRequestTransform: transformRequest,
+		DefaultAPIKey:                  "",
+		DefaultBaseURL:                 defaultBaseURL,
+		Name:                           providerName,
+		RequireAPIKey:                  true,
 	}, opts...)
 	if err != nil {
 		return nil, err
@@ -69,7 +73,7 @@ func (p *Provider) Completion(
 	ctx context.Context,
 	params providers.CompletionParams,
 ) (*providers.ChatCompletion, error) {
-	params = preprocessParams(params)
+	params = patchMessageParams(params)
 	return p.CompatibleProvider.Completion(ctx, params)
 }
 
@@ -79,7 +83,7 @@ func (p *Provider) CompletionStream(
 	ctx context.Context,
 	params providers.CompletionParams,
 ) (<-chan providers.ChatCompletionChunk, <-chan error) {
-	params = preprocessParams(params)
+	params = patchMessageParams(params)
 	return p.CompatibleProvider.CompletionStream(ctx, params)
 }
 
@@ -130,12 +134,25 @@ func patchMessages(messages []providers.Message) []providers.Message {
 	return result
 }
 
-// preprocessParams handles Mistral's API requirements.
-// Mistral doesn't accept the "user" or "reasoning_effort" fields and requires
-// an assistant message between tool results and user messages.
-func preprocessParams(params providers.CompletionParams) providers.CompletionParams {
+// patchMessageParams handles Mistral's message-level requirements.
+// Mistral requires an assistant message between tool results and user messages.
+func patchMessageParams(params providers.CompletionParams) providers.CompletionParams {
 	params.Messages = patchMessages(slices.Clone(params.Messages))
-	params.ReasoningEffort = "" // Mistral doesn't support reasoning_effort; Magistral models reason automatically.
-	params.User = ""            // Mistral doesn't support the user field.
 	return params
+}
+
+// transformRequest adjusts the OpenAI SDK request for Mistral's API.
+// Mistral uses max_tokens (not max_completion_tokens) and does not accept user or reasoning_effort fields.
+// If both are set, MaxCompletionTokens takes precedence over MaxTokens.
+// See: https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post
+func transformRequest(req *oaisdk.ChatCompletionNewParams) {
+	if req.MaxCompletionTokens.Valid() {
+		// Set max_tokens using max_completion_tokens value.
+		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
+	}
+
+	// Clear unsupported fields from the request.
+	req.MaxCompletionTokens = param.Opt[int64]{}
+	req.User = param.Opt[string]{}
+	req.ReasoningEffort = ""
 }

--- a/providers/mistral/mistral_test.go
+++ b/providers/mistral/mistral_test.go
@@ -77,53 +77,8 @@ func TestProviderName(t *testing.T) {
 	require.Equal(t, providerName, provider.Name())
 }
 
-func TestPreprocessParams(t *testing.T) {
+func TestPatchMessageParams(t *testing.T) {
 	t.Parallel()
-
-	t.Run("strips user field from params", func(t *testing.T) {
-		t.Parallel()
-
-		params := providers.CompletionParams{
-			Model:    "mistral-small-latest",
-			Messages: testutil.SimpleMessages(),
-			User:     "test-user",
-		}
-
-		result := preprocessParams(params)
-
-		require.Equal(t, params.Model, result.Model)
-		require.Empty(t, result.User)
-	})
-
-	t.Run("strips reasoning effort from params", func(t *testing.T) {
-		t.Parallel()
-
-		params := providers.CompletionParams{
-			Model:           "magistral-small-latest",
-			Messages:        testutil.SimpleMessages(),
-			ReasoningEffort: providers.ReasoningEffortLow,
-		}
-
-		result := preprocessParams(params)
-
-		require.Equal(t, params.Model, result.Model)
-		require.Empty(t, result.ReasoningEffort)
-	})
-
-	t.Run("passes through params without user field", func(t *testing.T) {
-		t.Parallel()
-
-		params := providers.CompletionParams{
-			Model:    "mistral-small-latest",
-			Messages: testutil.SimpleMessages(),
-		}
-
-		result := preprocessParams(params)
-
-		require.Equal(t, params.Model, result.Model)
-		require.Equal(t, len(params.Messages), len(result.Messages))
-		require.Empty(t, result.User)
-	})
 
 	t.Run("patches messages with tool-to-user sequence", func(t *testing.T) {
 		t.Parallel()
@@ -136,7 +91,7 @@ func TestPreprocessParams(t *testing.T) {
 			},
 		}
 
-		result := preprocessParams(params)
+		result := patchMessageParams(params)
 
 		require.Len(t, result.Messages, 3)
 		require.Equal(t, providers.RoleTool, result.Messages[0].Role)
@@ -157,7 +112,7 @@ func TestPreprocessParams(t *testing.T) {
 			MaxTokens:   &maxTokens,
 		}
 
-		result := preprocessParams(params)
+		result := patchMessageParams(params)
 
 		require.Equal(t, params.Model, result.Model)
 		require.Equal(t, params.Temperature, result.Temperature)
@@ -274,6 +229,125 @@ func TestPatchMessages(t *testing.T) {
 
 		require.Equal(t, original, messages)
 	})
+}
+
+func TestCompletionSendsMaxTokensOnWire(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeCompletionServer(t)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	maxTokens := 256
+	params := providers.CompletionParams{
+		Model:     "mistral-small-latest",
+		Messages:  testutil.SimpleMessages(),
+		MaxTokens: &maxTokens,
+	}
+
+	_, err = provider.Completion(context.Background(), params)
+	require.NoError(t, err)
+
+	body := capturedBody()
+
+	// Mistral is not fully OpenAI-compatible.
+	// The wire request must use max_tokens (not max_completion_tokens)
+	// because that is what the Mistral API accepts.
+	// See: https://docs.mistral.ai/api?property=operation-chat_completion_v1_chat_completions_post_request_max_tokens
+	require.Contains(t, body, "max_tokens")
+	require.NotContains(t, body, "max_completion_tokens")
+	require.Equal(t, float64(256), body["max_tokens"])
+}
+
+func TestCompletionStripsUserField(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeCompletionServer(t)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	params := providers.CompletionParams{
+		Model:    "mistral-small-latest",
+		Messages: testutil.SimpleMessages(),
+		User:     "test-user",
+	}
+
+	_, err = provider.Completion(context.Background(), params)
+	require.NoError(t, err)
+
+	body := capturedBody()
+
+	// Mistral doesn't support the user field; it must not appear on the wire.
+	require.NotContains(t, body, "user")
+}
+
+func TestCompletionStripsReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeCompletionServer(t)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	params := providers.CompletionParams{
+		Model:           "magistral-small-latest",
+		Messages:        testutil.SimpleMessages(),
+		ReasoningEffort: providers.ReasoningEffortHigh,
+	}
+
+	_, err = provider.Completion(context.Background(), params)
+	require.NoError(t, err)
+
+	body := capturedBody()
+
+	// Mistral doesn't support reasoning_effort; it must not appear on the wire.
+	require.NotContains(t, body, "reasoning_effort")
+}
+
+func TestCompletionStreamSendsMaxTokensOnWire(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeStreamingServer(t)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	maxTokens := 256
+	params := providers.CompletionParams{
+		Model:     "mistral-small-latest",
+		Messages:  testutil.SimpleMessages(),
+		MaxTokens: &maxTokens,
+		Stream:    true,
+	}
+
+	chunks, errs := provider.CompletionStream(context.Background(), params)
+	for range chunks {
+		// Drain the channel.
+	}
+	require.NoError(t, <-errs)
+
+	body := capturedBody()
+
+	// Mistral is not fully OpenAI-compatible.
+	// The streaming wire request must also use max_tokens (not max_completion_tokens).
+	// See: https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post
+	require.Contains(t, body, "max_tokens")
+	require.NotContains(t, body, "max_completion_tokens")
+	require.Equal(t, float64(256), body["max_tokens"])
 }
 
 // Integration tests - only run if Mistral API key is available.

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -68,6 +68,14 @@ type CompatibleConfig struct {
 	// Name is the provider name used in error messages.
 	Name string
 
+	// ChatCompletionRequestTransform is an optional function that modifies the chat
+	// completion request after convertParams() builds it and before it is serialized
+	// to the wire. Providers that are not fully OpenAI-compatible use this to adjust
+	// wire-level fields (e.g. swapping max_completion_tokens back to max_tokens).
+	// The pointer refers to a locally-constructed value owned by the caller; the
+	// function must not retain it beyond the call. Nil means no transformation.
+	ChatCompletionRequestTransform func(*openai.ChatCompletionNewParams)
+
 	// RequireAPIKey indicates whether an API key is required.
 	RequireAPIKey bool
 }
@@ -143,6 +151,9 @@ func (p *CompatibleProvider) Completion(
 	}
 
 	req := convertParams(params)
+	if p.compatibleConfig.ChatCompletionRequestTransform != nil {
+		p.compatibleConfig.ChatCompletionRequestTransform(&req)
+	}
 
 	resp, err := p.client.Chat.Completions.New(ctx, req)
 	if err != nil {
@@ -170,6 +181,9 @@ func (p *CompatibleProvider) CompletionStream(
 		}
 
 		req := convertParams(params)
+		if p.compatibleConfig.ChatCompletionRequestTransform != nil {
+			p.compatibleConfig.ChatCompletionRequestTransform(&req)
+		}
 		stream := p.client.Chat.Completions.NewStreaming(ctx, req)
 
 		for stream.Next() {

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -441,6 +441,68 @@ func TestConvertTools(t *testing.T) {
 	})
 }
 
+func TestCompletionSendsMaxCompletionTokensOnWire(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeCompletionServer(t)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	maxTokens := 1024
+	params := providers.CompletionParams{
+		Model:     "gpt-4",
+		Messages:  testutil.SimpleMessages(),
+		MaxTokens: &maxTokens,
+	}
+
+	_, err = provider.Completion(context.Background(), params)
+	require.NoError(t, err)
+
+	body := capturedBody()
+
+	// OpenAI requires max_completion_tokens (not max_tokens) for current models.
+	require.Contains(t, body, "max_completion_tokens")
+	require.NotContains(t, body, "max_tokens")
+	require.Equal(t, float64(1024), body["max_completion_tokens"])
+}
+
+func TestCompletionStreamSendsMaxCompletionTokensOnWire(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeStreamingServer(t)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	maxTokens := 1024
+	params := providers.CompletionParams{
+		Model:     "gpt-4",
+		Messages:  testutil.SimpleMessages(),
+		MaxTokens: &maxTokens,
+		Stream:    true,
+	}
+
+	chunks, errs := provider.CompletionStream(context.Background(), params)
+	for range chunks {
+		// Drain the channel.
+	}
+	require.NoError(t, <-errs)
+
+	body := capturedBody()
+
+	// OpenAI requires max_completion_tokens (not max_tokens) for current models.
+	require.Contains(t, body, "max_completion_tokens")
+	require.NotContains(t, body, "max_tokens")
+	require.Equal(t, float64(1024), body["max_completion_tokens"])
+}
+
 // Integration tests - only run if API key is available.
 
 func TestIntegrationCompletion(t *testing.T) {


### PR DESCRIPTION
## Summary

- DeepSeek and Mistral delegate to `CompatibleProvider.Completion()` which maps `MaxTokens` → `max_completion_tokens` on the wire. Both APIs actually expect `max_tokens`, meaning the token limit was silently dropped.
- Adds `ChatCompletionRequestTransform` hook to `CompatibleConfig` (Strategy pattern) so providers can adjust the SDK request after `convertParams` builds it.
- DeepSeek and Mistral supply transforms that swap `max_completion_tokens` → `max_tokens` and clear unsupported fields.
- Moves Mistral's `user`/`reasoning_effort` stripping from `preprocessParams` to `transformRequest` where it operates on the actual wire request.

## Context

Inspired by [any-llm#865](https://github.com/mozilla-ai/any-llm/pull/865) which addressed the same `max_tokens` vs `max_completion_tokens` issue in the Python port. The Go approach differs: rather than changing the base compatible provider, we keep `max_completion_tokens` as the correct default (per OpenAI spec) and let non-compatible providers opt into transforming their requests.

## Test plan

- [x] Wire-level tests using `httptest.NewServer` capture actual JSON bodies and assert field names
- [x] OpenAI sends `max_completion_tokens` (not `max_tokens`)
- [x] DeepSeek sends `max_tokens` (not `max_completion_tokens`)
- [x] Mistral sends `max_tokens` (not `max_completion_tokens`)
- [x] Mistral strips `user` and `reasoning_effort` from wire requests
- [x] Full test suite passes with `-race`