### PR TITLE
feat(gemini): ThoughtSignature round-trip + fix 5xx transient error retry

### DIFF
--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -73,6 +73,16 @@ const (
 // Default MIME type for image URLs when type cannot be determined.
 const defaultImageMIMEType = "image/jpeg"
 
+// geminiThoughtSignatureBypass is a sentinel value that can be used as a
+// ThoughtSignature when no real signature is available. Gemini 2.5+ thinking
+// models require a ThoughtSignature on every tool-call part when replaying
+// conversation history. If a call was recorded without a signature (e.g. from
+// an earlier session or a non-thinking model), supplying this bypass value
+// tells the API to skip signature validation for that part.
+//
+// Reference: https://ai.google.dev/gemini-api/docs/thinking#thought-signatures
+const geminiThoughtSignatureBypass = "context_engineering_is_the_way_to_go"
+
 // Error message patterns for 400 error classification.
 // The Gemini SDK doesn't expose typed errors for these conditions,
 // so we rely on message matching as a pragmatic fallback.
@@ -246,6 +256,11 @@ func (p *Provider) ConvertError(err error) error {
 	case 404:
 		return errors.NewModelNotFoundError(providerName, err)
 	case 429:
+		return errors.NewRateLimitError(providerName, err)
+	case 500, 502, 503, 529:
+		// Transient server-side errors: internal error, bad gateway, service
+		// unavailable, and overloaded (529). Return as RateLimitError so callers
+		// with retry logic (checking the "rate_limit" code) can back off and retry.
 		return errors.NewRateLimitError(providerName, err)
 	case 400:
 		// The Gemini SDK doesn't expose typed errors for context length or content
@@ -455,6 +470,10 @@ func (s *streamState) processResponse(resp *genai.GenerateContentResponse) ([]pr
 			if err != nil {
 				return nil, err
 			}
+			// Capture the thought signature so callers can echo it back on the next turn.
+			if len(part.ThoughtSignature) > 0 {
+				toolCall.ThoughtSignature = part.ThoughtSignature
+			}
 			s.toolCalls = append(s.toolCalls, toolCall)
 			result = append(result, s.chunk(providers.ChunkDelta{
 				ToolCalls: []providers.ToolCall{toolCall},
@@ -511,7 +530,18 @@ func convertAssistantMessage(msg providers.Message) *genai.Content {
 	for _, tc := range msg.ToolCalls {
 		var args map[string]any
 		_ = json.Unmarshal([]byte(tc.Function.Arguments), &args)
-		parts = append(parts, genai.NewPartFromFunctionCall(tc.Function.Name, args))
+		part := genai.NewPartFromFunctionCall(tc.Function.Name, args)
+		// Echo the ThoughtSignature that Gemini returned on the original turn.
+		// Thinking models (Gemini 2.5+) require this to be present; if absent
+		// the API returns a 400. Fall back to the bypass sentinel when no real
+		// signature is stored so that older entries replayed from history remain
+		// compatible.
+		if len(tc.ThoughtSignature) > 0 {
+			part.ThoughtSignature = tc.ThoughtSignature
+		} else {
+			part.ThoughtSignature = []byte(geminiThoughtSignatureBypass)
+		}
+		parts = append(parts, part)
 	}
 
 	if len(parts) == 0 {
@@ -674,6 +704,10 @@ func extractResponseContent(
 			toolCall, err := convertFunctionCallToToolCall(part.FunctionCall)
 			if err != nil {
 				return "", nil, nil, "", err
+			}
+			// Capture the thought signature so callers can echo it back on the next turn.
+			if len(part.ThoughtSignature) > 0 {
+				toolCall.ThoughtSignature = part.ThoughtSignature
 			}
 			toolCalls = append(toolCalls, toolCall)
 		case part.Thought:

--- a/providers/types.go
+++ b/providers/types.go
@@ -263,6 +263,13 @@ type ToolCall struct {
 	ID       string       `json:"id"`
 	Type     string       `json:"type"`
 	Function FunctionCall `json:"function"`
+
+	// ThoughtSignature holds the raw Gemini "thought signature" bytes associated
+	// with this tool call. Gemini 2.5+ thinking models attach a per-call signature
+	// that must be echoed back verbatim on the next turn to avoid a 400 error.
+	// This field is excluded from JSON serialization; the caller is responsible for
+	// round-tripping it through whatever storage mechanism is appropriate.
+	ThoughtSignature []byte `json:"-"`
 }
 
 // ToolChoice represents a specific tool choice.


### PR DESCRIPTION
## Summary

Two fixes for the Gemini provider, both discovered while using any-llm-go in a long-running agentic loop with Gemini 2.5 Pro thinking models.

### 1. ThoughtSignature round-trip support

**Problem:** Gemini 2.5+ thinking models attach a `ThoughtSignature` to every `FunctionCall` part in the response. When conversation history is replayed on the next turn, the API requires these signatures to be echoed back verbatim. Without this, the API returns a `400 Bad Request` error on the second tool-call turn and beyond.

**Fix:**
- `providers/types.go`: Added a `ThoughtSignature []byte` field (tagged `json:"-"`) to `ToolCall`. The field is excluded from JSON marshalling so it does not affect the wire format; callers round-trip it through whatever storage mechanism they use.
- `providers/gemini/gemini.go`:
  - **Capture (streaming):** `streamState.processResponse` now copies `part.ThoughtSignature → toolCall.ThoughtSignature` for each function-call part.
  - **Capture (non-streaming):** `extractResponseContent` does the same.
  - **Replay:** `convertAssistantMessage` sets `part.ThoughtSignature` from `ToolCall.ThoughtSignature` when echoing history. Falls back to the `geminiThoughtSignatureBypass` sentinel constant (documented by Google) for older tool calls recorded without a signature, to preserve backward compatibility.

### 2. Transient 5xx error retry

**Problem:** HTTP 500, 502, 503, and 529 responses from the Gemini API fell through `ConvertError` without a matching case and became `ProviderError`. Since callers typically only retry on `RateLimitError`, these transient server-side errors were not retried, causing unnecessary hard failures under load.

**Fix:** Added `case 500, 502, 503, 529` in `ConvertError` mapping to `NewRateLimitError`, consistent with how callers already handle 429.

## Testing

- Manually tested with live Gemini 2.5 Pro (thinking enabled) in a multi-turn agentic loop — no more 400 errors on tool-call replay.
- Manually reproduced and verified the 503 retry fix against a Gemini endpoint under load.
- The changes are also running in production in [only-true-agi](https://github.com/mrbeandev/only-true-agi), an agentic framework built on top of this library.

## Breaking changes

None. `ThoughtSignature` is `json:"-"` so existing serialized `ToolCall` values remain valid. Error classification for 5xx is strictly more permissive (adds retry, no new failures).