### PR TITLE
feat(gemini): ThoughtSignature capture and replay for thinking models

### DIFF
--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -79,6 +79,10 @@ const (
 // Default MIME type for image URLs when type cannot be determined.
 const defaultImageMIMEType = "image/jpeg"
 
+// Bypass value for tool calls that lack a real ThoughtSignature.
+// See https://ai.google.dev/gemini-api/docs/thought-signatures#faqs
+const thoughtSignatureBypass = "skip_thought_signature_validator"
+
 // Error message patterns for 400 error classification.
 // The Gemini SDK doesn't expose typed errors for these conditions,
 // so we rely on message matching as a pragmatic fallback.
@@ -523,7 +527,31 @@ func convertAssistantMessage(msg providers.Message) *genai.Content {
 	for _, tc := range msg.ToolCalls {
 		var args map[string]any
 		_ = json.Unmarshal([]byte(tc.Function.Arguments), &args)
-		parts = append(parts, genai.NewPartFromFunctionCall(tc.Function.Name, args))
+
+		part := genai.NewPartFromFunctionCall(tc.Function.Name, args)
+
+		// Replay the thought signature that Gemini returned on the original turn.
+		// Thinking models (2.5+) require this on every function call part when
+		// replaying conversation history; omitting it causes a 400 error.
+		// If no real signature was captured, use the documented bypass value.
+		//
+		// NOTE: The Go SDK declares Part.ThoughtSignature as []byte, and Go's
+		// encoding/json automatically base64-encodes []byte fields — so the
+		// bypass reaches the API as "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+		// rather than the literal string. In testing the API appears to accept
+		// the base64-encoded form transparently, but this behaviour is
+		// undocumented and the wire format differs from what the docs describe.
+		// The Python SDK uses str, avoiding this entirely.
+		//
+		// Upstream issue: https://github.com/googleapis/go-genai/issues/711
+		// See also: https://github.com/langchain-ai/langchain-google/issues/1570
+		if sig := thoughtSignatureFromExtra(tc.Extra); sig != nil {
+			part.ThoughtSignature = sig
+		} else {
+			part.ThoughtSignature = []byte(thoughtSignatureBypass)
+		}
+
+		parts = append(parts, part)
 	}
 
 	if len(parts) == 0 {
@@ -881,6 +909,31 @@ func setProviderExtra(tc *providers.ToolCall, provider string, key string, value
 		tc.Extra[provider] = make(providers.ProviderData)
 	}
 	tc.Extra[provider][key] = value
+}
+
+// thoughtSignatureFromExtra extracts and base64-decodes a ThoughtSignature
+// from ToolCall Extra data. Returns nil if not present or invalid.
+func thoughtSignatureFromExtra(extra map[string]providers.ProviderData) []byte {
+	if extra == nil {
+		return nil
+	}
+
+	googleData, ok := extra[extraKeyProvider]
+	if !ok {
+		return nil
+	}
+
+	sigStr, ok := googleData[extraKeyThoughtSignature].(string)
+	if !ok {
+		return nil
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(sigStr)
+	if err != nil {
+		return nil
+	}
+
+	return sig
 }
 
 // thinkingBudget returns the token budget for the given reasoning effort.

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -70,6 +70,12 @@ const (
 	idPrefixToolCall   = "call_"
 )
 
+// Provider-specific Extra keys for round-tripping metadata in ToolCall.Extra.
+const (
+	extraKeyProvider         = "google"
+	extraKeyThoughtSignature = "thought_signature"
+)
+
 // Default MIME type for image URLs when type cannot be determined.
 const defaultImageMIMEType = "image/jpeg"
 
@@ -455,6 +461,12 @@ func (s *streamState) processResponse(resp *genai.GenerateContentResponse) ([]pr
 			if err != nil {
 				return nil, err
 			}
+
+			// Preserve the thought signature so callers can echo it back on the next turn.
+			if len(part.ThoughtSignature) > 0 {
+				setProviderExtra(&toolCall, extraKeyProvider, extraKeyThoughtSignature,
+					base64.StdEncoding.EncodeToString(part.ThoughtSignature))
+			}
 			s.toolCalls = append(s.toolCalls, toolCall)
 			result = append(result, s.chunk(providers.ChunkDelta{
 				ToolCalls: []providers.ToolCall{toolCall},
@@ -675,6 +687,12 @@ func extractResponseContent(
 			if err != nil {
 				return "", nil, nil, "", err
 			}
+
+			// Preserve the thought signature so callers can echo it back on the next turn.
+			if len(part.ThoughtSignature) > 0 {
+				setProviderExtra(&toolCall, extraKeyProvider, extraKeyThoughtSignature,
+					base64.StdEncoding.EncodeToString(part.ThoughtSignature))
+			}
 			toolCalls = append(toolCalls, toolCall)
 		case part.Thought:
 			reasoningBuilder.WriteString(part.Text)
@@ -850,6 +868,19 @@ func generateID(prefix string) (string, error) {
 		return "", fmt.Errorf("generating ID: %w", err)
 	}
 	return prefix + hex.EncodeToString(b), nil
+}
+
+// setProviderExtra safely sets a key in a ToolCall's provider-specific Extra data.
+// Initialises the maps if nil, and preserves existing keys.
+// NOTE: This lives in the gemini package for now; lift to providers if other providers need it.
+func setProviderExtra(tc *providers.ToolCall, provider string, key string, value any) {
+	if tc.Extra == nil {
+		tc.Extra = make(map[string]providers.ProviderData)
+	}
+	if tc.Extra[provider] == nil {
+		tc.Extra[provider] = make(providers.ProviderData)
+	}
+	tc.Extra[provider][key] = value
 }
 
 // thinkingBudget returns the token budget for the given reasoning effort.

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -532,6 +532,11 @@ func convertAssistantMessage(msg providers.Message) *genai.Content {
 		// replaying conversation history; omitting it causes a 400 error.
 		// If no real signature was captured, use the documented bypass value.
 		//
+		// This applies unconditionally to all models, including non-thinking
+		// ones. In testing, non-thinking models accept the field without issue.
+		// The Python any-llm library follows the same pattern, so we mirror it
+		// here. Revisit if this causes problems with specific models.
+		//
 		// NOTE: The Go SDK declares Part.ThoughtSignature as []byte, and Go's
 		// encoding/json automatically base64-encodes []byte fields — so the
 		// bypass reaches the API as "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -70,11 +70,8 @@ const (
 	idPrefixToolCall   = "call_"
 )
 
-// Provider-specific Extra keys for round-tripping metadata in ToolCall.Extra.
-const (
-	extraKeyProvider         = "google"
-	extraKeyThoughtSignature = "thought_signature"
-)
+// Extra key for round-tripping ThoughtSignature metadata in ToolCall.Extra.
+const extraKeyThoughtSignature = "thought_signature"
 
 // Default MIME type for image URLs when type cannot be determined.
 const defaultImageMIMEType = "image/jpeg"
@@ -468,7 +465,7 @@ func (s *streamState) processResponse(resp *genai.GenerateContentResponse) ([]pr
 
 			// Preserve the thought signature so callers can echo it back on the next turn.
 			if len(part.ThoughtSignature) > 0 {
-				setProviderExtra(&toolCall, extraKeyProvider, extraKeyThoughtSignature,
+				setProviderExtra(&toolCall, providerName, extraKeyThoughtSignature,
 					base64.StdEncoding.EncodeToString(part.ThoughtSignature))
 			}
 			s.toolCalls = append(s.toolCalls, toolCall)
@@ -718,7 +715,7 @@ func extractResponseContent(
 
 			// Preserve the thought signature so callers can echo it back on the next turn.
 			if len(part.ThoughtSignature) > 0 {
-				setProviderExtra(&toolCall, extraKeyProvider, extraKeyThoughtSignature,
+				setProviderExtra(&toolCall, providerName, extraKeyThoughtSignature,
 					base64.StdEncoding.EncodeToString(part.ThoughtSignature))
 			}
 			toolCalls = append(toolCalls, toolCall)
@@ -918,12 +915,12 @@ func thoughtSignatureFromExtra(extra map[string]providers.ProviderData) []byte {
 		return nil
 	}
 
-	googleData, ok := extra[extraKeyProvider]
+	geminiData, ok := extra[providerName]
 	if !ok {
 		return nil
 	}
 
-	sigStr, ok := googleData[extraKeyThoughtSignature].(string)
+	sigStr, ok := geminiData[extraKeyThoughtSignature].(string)
 	if !ok {
 		return nil
 	}

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -245,7 +245,7 @@ func TestConvertMessages(t *testing.T) {
 							Arguments: `{"location": "Paris"}`,
 						},
 						Extra: map[string]providers.ProviderData{
-							extraKeyProvider: {extraKeyThoughtSignature: sig},
+							providerName: {extraKeyThoughtSignature: sig},
 						},
 					},
 				},
@@ -811,28 +811,28 @@ func TestThoughtSignatureFromExtra(t *testing.T) {
 		{
 			name: "missing key returns nil",
 			extra: map[string]providers.ProviderData{
-				extraKeyProvider: {"other_key": "value"},
+				providerName: {"other_key": "value"},
 			},
 			expected: nil,
 		},
 		{
 			name: "wrong type returns nil",
 			extra: map[string]providers.ProviderData{
-				extraKeyProvider: {extraKeyThoughtSignature: 12345},
+				providerName: {extraKeyThoughtSignature: 12345},
 			},
 			expected: nil,
 		},
 		{
 			name: "invalid base64 returns nil",
 			extra: map[string]providers.ProviderData{
-				extraKeyProvider: {extraKeyThoughtSignature: "not-valid-base64!!!"},
+				providerName: {extraKeyThoughtSignature: "not-valid-base64!!!"},
 			},
 			expected: nil,
 		},
 		{
 			name: "valid signature decodes correctly",
 			extra: map[string]providers.ProviderData{
-				extraKeyProvider: {
+				providerName: {
 					extraKeyThoughtSignature: base64.StdEncoding.EncodeToString([]byte("test-sig")),
 				},
 			},
@@ -1014,10 +1014,10 @@ func TestStreamStateProcessResponse(t *testing.T) {
 
 		tc := chunks[0].Choices[0].Delta.ToolCalls[0]
 		require.NotNil(t, tc.Extra)
-		googleData, ok := tc.Extra[extraKeyProvider]
+		geminiData, ok := tc.Extra[providerName]
 		require.True(t, ok, "expected google provider data in Extra")
 
-		sig, ok := googleData[extraKeyThoughtSignature].(string)
+		sig, ok := geminiData[extraKeyThoughtSignature].(string)
 		require.True(t, ok, "expected thought_signature to be a string")
 
 		// Value should be base64-encoded.
@@ -1198,8 +1198,8 @@ func TestConvertResponse(t *testing.T) {
 
 		tc := result.Choices[0].Message.ToolCalls[0]
 		require.NotNil(t, tc.Extra)
-		googleData := tc.Extra[extraKeyProvider]
-		sig, ok := googleData[extraKeyThoughtSignature].(string)
+		geminiData := tc.Extra[providerName]
+		sig, ok := geminiData[extraKeyThoughtSignature].(string)
 		require.True(t, ok)
 
 		decoded, err := base64.StdEncoding.DecodeString(sig)

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -3,6 +3,7 @@ package gemini
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	stderrors "errors"
 	"strings"
 	"testing"
@@ -893,6 +894,82 @@ func TestThoughtSignatureRoundTrip(t *testing.T) {
 
 	// Verify the signature round-tripped identically.
 	require.Equal(t, originalSig, content.Parts[0].ThoughtSignature)
+}
+
+func TestThoughtSignatureWireFormat(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bypass value is base64-encoded by json.Marshal", func(t *testing.T) {
+		t.Parallel()
+
+		// Build a message with no Extra — should get the bypass.
+		msg := providers.Message{
+			Role: providers.RoleAssistant,
+			ToolCalls: []providers.ToolCall{{
+				ID:   "call_1",
+				Type: "function",
+				Function: providers.FunctionCall{
+					Name:      "search",
+					Arguments: `{"q":"test"}`,
+				},
+			}},
+		}
+
+		content := convertAssistantMessage(msg)
+		require.Len(t, content.Parts, 1)
+
+		// Marshal the Part as the SDK would before sending.
+		raw, err := json.Marshal(content.Parts[0])
+		require.NoError(t, err)
+
+		wireJSON := string(raw)
+
+		// The literal bypass must NOT appear — json.Marshal base64-encodes []byte.
+		require.NotContains(t, wireJSON, thoughtSignatureBypass)
+
+		// The base64-encoded form must appear instead.
+		encoded := base64.StdEncoding.EncodeToString([]byte(thoughtSignatureBypass))
+		require.Contains(t, wireJSON, encoded)
+	})
+
+	t.Run("real signature is base64-encoded by json.Marshal", func(t *testing.T) {
+		t.Parallel()
+
+		realSig := []byte("opaque-gemini-signature-abc123")
+		storedB64 := base64.StdEncoding.EncodeToString(realSig)
+
+		msg := providers.Message{
+			Role: providers.RoleAssistant,
+			ToolCalls: []providers.ToolCall{{
+				ID:   "call_1",
+				Type: "function",
+				Function: providers.FunctionCall{
+					Name:      "search",
+					Arguments: `{"q":"test"}`,
+				},
+				Extra: map[string]providers.ProviderData{
+					providerName: {extraKeyThoughtSignature: storedB64},
+				},
+			}},
+		}
+
+		content := convertAssistantMessage(msg)
+		require.Len(t, content.Parts, 1)
+
+		// The Part should have the raw bytes.
+		require.Equal(t, realSig, content.Parts[0].ThoughtSignature)
+
+		// When marshaled, json.Marshal base64-encodes the raw bytes — which
+		// produces a double-encoded value on the wire. This is the expected
+		// (if unfortunate) behaviour until the upstream SDK changes
+		// ThoughtSignature from []byte to string.
+		raw, err := json.Marshal(content.Parts[0])
+		require.NoError(t, err)
+
+		wireJSON := string(raw)
+		doubleEncoded := base64.StdEncoding.EncodeToString(realSig)
+		require.Contains(t, wireJSON, doubleEncoded)
+	})
 }
 
 func TestStreamStateProcessResponse(t *testing.T) {

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -720,33 +720,33 @@ func TestSetProviderExtra(t *testing.T) {
 		{
 			name:     "nil Extra initialises both maps",
 			initial:  nil,
-			provider: "google",
+			provider: providerName,
 			key:      "thought_signature",
 			value:    "abc123",
 			expected: map[string]providers.ProviderData{
-				"google": {"thought_signature": "abc123"},
+				providerName: {"thought_signature": "abc123"},
 			},
 		},
 		{
 			name:     "nil provider map initialises inner map",
 			initial:  map[string]providers.ProviderData{},
-			provider: "google",
+			provider: providerName,
 			key:      "thought_signature",
 			value:    "abc123",
 			expected: map[string]providers.ProviderData{
-				"google": {"thought_signature": "abc123"},
+				providerName: {"thought_signature": "abc123"},
 			},
 		},
 		{
 			name: "preserves existing provider keys",
 			initial: map[string]providers.ProviderData{
-				"google": {"existing_key": "existing_value"},
+				providerName: {"existing_key": "existing_value"},
 			},
-			provider: "google",
+			provider: providerName,
 			key:      "thought_signature",
 			value:    "abc123",
 			expected: map[string]providers.ProviderData{
-				"google": {
+				providerName: {
 					"existing_key":      "existing_value",
 					"thought_signature": "abc123",
 				},
@@ -757,24 +757,24 @@ func TestSetProviderExtra(t *testing.T) {
 			initial: map[string]providers.ProviderData{
 				"other": {"key": "value"},
 			},
-			provider: "google",
+			provider: providerName,
 			key:      "thought_signature",
 			value:    "abc123",
 			expected: map[string]providers.ProviderData{
-				"other":  {"key": "value"},
-				"google": {"thought_signature": "abc123"},
+				"other":      {"key": "value"},
+				providerName: {"thought_signature": "abc123"},
 			},
 		},
 		{
 			name: "overwrites existing key",
 			initial: map[string]providers.ProviderData{
-				"google": {"thought_signature": "old"},
+				providerName: {"thought_signature": "old"},
 			},
-			provider: "google",
+			provider: providerName,
 			key:      "thought_signature",
 			value:    "new",
 			expected: map[string]providers.ProviderData{
-				"google": {"thought_signature": "new"},
+				providerName: {"thought_signature": "new"},
 			},
 		},
 	}

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -2,6 +2,7 @@ package gemini
 
 import (
 	"context"
+	"encoding/base64"
 	stderrors "errors"
 	"strings"
 	"testing"
@@ -644,6 +645,90 @@ func TestNewStreamState(t *testing.T) {
 	require.Nil(t, state.usage)
 }
 
+func TestSetProviderExtra(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		initial  map[string]providers.ProviderData
+		provider string
+		key      string
+		value    any
+		expected map[string]providers.ProviderData
+	}{
+		{
+			name:     "nil Extra initialises both maps",
+			initial:  nil,
+			provider: "google",
+			key:      "thought_signature",
+			value:    "abc123",
+			expected: map[string]providers.ProviderData{
+				"google": {"thought_signature": "abc123"},
+			},
+		},
+		{
+			name:     "nil provider map initialises inner map",
+			initial:  map[string]providers.ProviderData{},
+			provider: "google",
+			key:      "thought_signature",
+			value:    "abc123",
+			expected: map[string]providers.ProviderData{
+				"google": {"thought_signature": "abc123"},
+			},
+		},
+		{
+			name: "preserves existing provider keys",
+			initial: map[string]providers.ProviderData{
+				"google": {"existing_key": "existing_value"},
+			},
+			provider: "google",
+			key:      "thought_signature",
+			value:    "abc123",
+			expected: map[string]providers.ProviderData{
+				"google": {
+					"existing_key":      "existing_value",
+					"thought_signature": "abc123",
+				},
+			},
+		},
+		{
+			name: "preserves other providers",
+			initial: map[string]providers.ProviderData{
+				"other": {"key": "value"},
+			},
+			provider: "google",
+			key:      "thought_signature",
+			value:    "abc123",
+			expected: map[string]providers.ProviderData{
+				"other":  {"key": "value"},
+				"google": {"thought_signature": "abc123"},
+			},
+		},
+		{
+			name: "overwrites existing key",
+			initial: map[string]providers.ProviderData{
+				"google": {"thought_signature": "old"},
+			},
+			provider: "google",
+			key:      "thought_signature",
+			value:    "new",
+			expected: map[string]providers.ProviderData{
+				"google": {"thought_signature": "new"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			toolCall := providers.ToolCall{Extra: tc.initial}
+			setProviderExtra(&toolCall, tc.provider, tc.key, tc.value)
+			require.Equal(t, tc.expected, toolCall.Extra)
+		})
+	}
+}
+
 func TestStreamStateProcessResponse(t *testing.T) {
 	t.Parallel()
 
@@ -736,6 +821,69 @@ func TestStreamStateProcessResponse(t *testing.T) {
 		require.Equal(t, 10, state.usage.PromptTokens)
 		require.Equal(t, 5, state.usage.CompletionTokens)
 		require.Equal(t, 15, state.usage.TotalTokens)
+	})
+
+	t.Run("captures thought signature on function call", func(t *testing.T) {
+		t.Parallel()
+
+		state, err := newStreamState("test-model")
+		require.NoError(t, err)
+		resp := &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{
+				Content: &genai.Content{
+					Parts: []*genai.Part{{
+						FunctionCall: &genai.FunctionCall{
+							Name: "get_weather",
+							Args: map[string]any{"location": "Paris"},
+						},
+						ThoughtSignature: []byte("test-signature-bytes"),
+					}},
+				},
+			}},
+		}
+
+		chunks, err := state.processResponse(resp)
+		require.NoError(t, err)
+		require.Len(t, chunks, 1)
+
+		tc := chunks[0].Choices[0].Delta.ToolCalls[0]
+		require.NotNil(t, tc.Extra)
+		googleData, ok := tc.Extra[extraKeyProvider]
+		require.True(t, ok, "expected google provider data in Extra")
+
+		sig, ok := googleData[extraKeyThoughtSignature].(string)
+		require.True(t, ok, "expected thought_signature to be a string")
+
+		// Value should be base64-encoded.
+		decoded, err := base64.StdEncoding.DecodeString(sig)
+		require.NoError(t, err)
+		require.Equal(t, []byte("test-signature-bytes"), decoded)
+	})
+
+	t.Run("no thought signature leaves Extra nil", func(t *testing.T) {
+		t.Parallel()
+
+		state, err := newStreamState("test-model")
+		require.NoError(t, err)
+		resp := &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{
+				Content: &genai.Content{
+					Parts: []*genai.Part{{
+						FunctionCall: &genai.FunctionCall{
+							Name: "get_weather",
+							Args: map[string]any{"location": "Paris"},
+						},
+					}},
+				},
+			}},
+		}
+
+		chunks, err := state.processResponse(resp)
+		require.NoError(t, err)
+		require.Len(t, chunks, 1)
+
+		tc := chunks[0].Choices[0].Delta.ToolCalls[0]
+		require.Nil(t, tc.Extra)
 	})
 
 	t.Run("returns empty slice for empty candidates", func(t *testing.T) {
@@ -858,6 +1006,39 @@ func TestConvertResponse(t *testing.T) {
 		require.Len(t, result.Choices[0].Message.ToolCalls, 1)
 		require.Equal(t, "get_weather", result.Choices[0].Message.ToolCalls[0].Function.Name)
 		require.Equal(t, providers.FinishReasonToolCalls, result.Choices[0].FinishReason)
+	})
+
+	t.Run("captures thought signature on function call", func(t *testing.T) {
+		t.Parallel()
+
+		resp := &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{
+				Content: &genai.Content{
+					Parts: []*genai.Part{{
+						FunctionCall: &genai.FunctionCall{
+							Name: "get_weather",
+							Args: map[string]any{"location": "Paris"},
+						},
+						ThoughtSignature: []byte("non-stream-sig"),
+					}},
+				},
+				FinishReason: genai.FinishReasonStop,
+			}},
+		}
+
+		result, err := convertResponse(resp, "gemini-2.5-pro")
+		require.NoError(t, err)
+		require.Len(t, result.Choices[0].Message.ToolCalls, 1)
+
+		tc := result.Choices[0].Message.ToolCalls[0]
+		require.NotNil(t, tc.Extra)
+		googleData := tc.Extra[extraKeyProvider]
+		sig, ok := googleData[extraKeyThoughtSignature].(string)
+		require.True(t, ok)
+
+		decoded, err := base64.StdEncoding.DecodeString(sig)
+		require.NoError(t, err)
+		require.Equal(t, []byte("non-stream-sig"), decoded)
 	})
 
 	t.Run("converts thinking response", func(t *testing.T) {

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -227,6 +227,67 @@ func TestConvertMessages(t *testing.T) {
 		require.Nil(t, system)
 	})
 
+	t.Run("replays thought signature from Extra", func(t *testing.T) {
+		t.Parallel()
+
+		sig := base64.StdEncoding.EncodeToString([]byte("real-signature"))
+		messages := []providers.Message{
+			{Role: providers.RoleUser, Content: "What's the weather?"},
+			{
+				Role:    providers.RoleAssistant,
+				Content: "",
+				ToolCalls: []providers.ToolCall{
+					{
+						ID:   "call_123",
+						Type: "function",
+						Function: providers.FunctionCall{
+							Name:      "get_weather",
+							Arguments: `{"location": "Paris"}`,
+						},
+						Extra: map[string]providers.ProviderData{
+							extraKeyProvider: {extraKeyThoughtSignature: sig},
+						},
+					},
+				},
+			},
+		}
+
+		result, _ := convertMessages(messages)
+
+		require.Len(t, result, 2)
+		require.Equal(t, roleModel, result[1].Role)
+		require.NotNil(t, result[1].Parts[0].FunctionCall)
+		require.Equal(t, []byte("real-signature"), result[1].Parts[0].ThoughtSignature)
+	})
+
+	t.Run("tool call without signature uses bypass value", func(t *testing.T) {
+		t.Parallel()
+
+		messages := []providers.Message{
+			{Role: providers.RoleUser, Content: "What's the weather?"},
+			{
+				Role:    providers.RoleAssistant,
+				Content: "",
+				ToolCalls: []providers.ToolCall{
+					{
+						ID:   "call_123",
+						Type: "function",
+						Function: providers.FunctionCall{
+							Name:      "get_weather",
+							Arguments: `{"location": "Paris"}`,
+						},
+					},
+				},
+			},
+		}
+
+		result, _ := convertMessages(messages)
+
+		require.Len(t, result, 2)
+		require.NotNil(t, result[1].Parts[0].FunctionCall)
+		require.Equal(t, []byte(thoughtSignatureBypass), result[1].Parts[0].ThoughtSignature)
+	})
+
 	t.Run("unknown role returns nil", func(t *testing.T) {
 		t.Parallel()
 
@@ -727,6 +788,111 @@ func TestSetProviderExtra(t *testing.T) {
 			require.Equal(t, tc.expected, toolCall.Extra)
 		})
 	}
+}
+
+func TestThoughtSignatureFromExtra(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		extra    map[string]providers.ProviderData
+		expected []byte
+	}{
+		{
+			name:     "nil extra returns nil",
+			extra:    nil,
+			expected: nil,
+		},
+		{
+			name:     "missing provider returns nil",
+			extra:    map[string]providers.ProviderData{"other": {"key": "value"}},
+			expected: nil,
+		},
+		{
+			name: "missing key returns nil",
+			extra: map[string]providers.ProviderData{
+				extraKeyProvider: {"other_key": "value"},
+			},
+			expected: nil,
+		},
+		{
+			name: "wrong type returns nil",
+			extra: map[string]providers.ProviderData{
+				extraKeyProvider: {extraKeyThoughtSignature: 12345},
+			},
+			expected: nil,
+		},
+		{
+			name: "invalid base64 returns nil",
+			extra: map[string]providers.ProviderData{
+				extraKeyProvider: {extraKeyThoughtSignature: "not-valid-base64!!!"},
+			},
+			expected: nil,
+		},
+		{
+			name: "valid signature decodes correctly",
+			extra: map[string]providers.ProviderData{
+				extraKeyProvider: {
+					extraKeyThoughtSignature: base64.StdEncoding.EncodeToString([]byte("test-sig")),
+				},
+			},
+			expected: []byte("test-sig"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := thoughtSignatureFromExtra(tc.extra)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestThoughtSignatureRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// Simulate an API response with a ThoughtSignature on a function call.
+	originalSig := []byte("opaque-signature-from-gemini-api-xyz123")
+
+	resp := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{{
+			Content: &genai.Content{
+				Parts: []*genai.Part{{
+					FunctionCall: &genai.FunctionCall{
+						Name: "search",
+						Args: map[string]any{"query": "test"},
+					},
+					ThoughtSignature: originalSig,
+				}},
+			},
+			FinishReason: genai.FinishReasonStop,
+		}},
+	}
+
+	// Capture via non-streaming path.
+	result, err := convertResponse(resp, "gemini-2.5-pro")
+	require.NoError(t, err)
+	require.Len(t, result.Choices[0].Message.ToolCalls, 1)
+
+	capturedTC := result.Choices[0].Message.ToolCalls[0]
+	require.NotNil(t, capturedTC.Extra)
+
+	// Build a message with the captured tool call (as a caller would).
+	assistantMsg := providers.Message{
+		Role:      providers.RoleAssistant,
+		Content:   "",
+		ToolCalls: []providers.ToolCall{capturedTC},
+	}
+
+	// Replay via convertAssistantMessage.
+	content := convertAssistantMessage(assistantMsg)
+	require.NotNil(t, content)
+	require.Len(t, content.Parts, 1)
+
+	// Verify the signature round-tripped identically.
+	require.Equal(t, originalSig, content.Parts[0].ThoughtSignature)
 }
 
 func TestStreamStateProcessResponse(t *testing.T) {

--- a/providers/types.go
+++ b/providers/types.go
@@ -69,6 +69,9 @@ type Provider interface {
 	CompletionStream(ctx context.Context, params CompletionParams) (<-chan ChatCompletionChunk, <-chan error)
 }
 
+// ProviderData holds provider-specific metadata keyed by field name.
+type ProviderData map[string]any
+
 // ReasoningEffort levels for extended thinking.
 type ReasoningEffort string
 
@@ -260,9 +263,13 @@ type Tool struct {
 
 // ToolCall represents a tool call made by the assistant.
 type ToolCall struct {
-	ID       string       `json:"id"`
-	Type     string       `json:"type"`
-	Function FunctionCall `json:"function"`
+	// Extra holds provider-specific metadata for round-tripping across
+	// multi-turn conversations. Keyed by provider name (e.g. "google").
+	// Excluded from JSON; callers preserve this through their own storage.
+	Extra    map[string]ProviderData `json:"-"`
+	Function FunctionCall            `json:"function"`
+	ID       string                  `json:"id"`
+	Type     string                  `json:"type"`
 }
 
 // ToolChoice represents a specific tool choice.

--- a/providers/types.go
+++ b/providers/types.go
@@ -264,7 +264,7 @@ type Tool struct {
 // ToolCall represents a tool call made by the assistant.
 type ToolCall struct {
 	// Extra holds provider-specific metadata for round-tripping across
-	// multi-turn conversations. Keyed by provider name (e.g. "google").
+	// multi-turn conversations. Keyed by provider name (e.g. "gemini").
 	// Excluded from JSON; callers preserve this through their own storage.
 	Extra    map[string]ProviderData `json:"-"`
 	Function FunctionCall            `json:"function"`

--- a/providers/types_test.go
+++ b/providers/types_test.go
@@ -1,0 +1,39 @@
+package providers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolCallExtraExcludedFromJSON(t *testing.T) {
+	t.Parallel()
+
+	tc := ToolCall{
+		ID:   "call_123",
+		Type: "function",
+		Function: FunctionCall{
+			Name:      "get_weather",
+			Arguments: `{"location": "Paris"}`,
+		},
+		Extra: map[string]ProviderData{
+			"google": {"thought_signature": "abc123"},
+		},
+	}
+
+	b, err := json.Marshal(tc)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	err = json.Unmarshal(b, &decoded)
+	require.NoError(t, err)
+
+	// Extra must not appear in JSON output.
+	_, hasExtra := decoded["extra"]
+	require.False(t, hasExtra, "Extra field must be excluded from JSON serialization")
+
+	// Standard fields must be present.
+	require.Equal(t, "call_123", decoded["id"])
+	require.Equal(t, "function", decoded["type"])
+}


### PR DESCRIPTION
## Summary

- Add `ProviderData` type and `Extra` field to `ToolCall` for round-tripping provider-specific metadata (excluded from JSON serialization, keyed by `Provider.Name()`)
- Capture `ThoughtSignature` from Gemini 2.5+ function call responses in both streaming and non-streaming paths, stored as base64 in `ToolCall.Extra["gemini"]["thought_signature"]`
- Replay captured signatures on outgoing function call parts; fall back to the documented bypass value for tool calls without a real signature
- Filed upstream issue on Go SDK for `Part.ThoughtSignature` `[]byte` base64 encoding: https://github.com/googleapis/go-genai/issues/711

Inspired by #60 — thank you @mrbeandev for identifying the need and informing the approach.

Closes #60

## Test plan

- [x] `TestToolCallExtraExcludedFromJSON` — Extra field not in JSON output
- [x] `TestSetProviderExtra` — safe map initialisation (5 cases)
- [x] `TestStreamStateProcessResponse/captures_thought_signature_on_function_call` — streaming capture
- [x] `TestStreamStateProcessResponse/no_thought_signature_leaves_Extra_nil` — streaming without signature
- [x] `TestConvertResponse/captures_thought_signature_on_function_call` — non-streaming capture
- [x] `TestConvertMessages/replays_thought_signature_from_Extra` — replay real signature
- [x] `TestConvertMessages/tool_call_without_signature_uses_bypass_value` — bypass fallback
- [x] `TestThoughtSignatureFromExtra` — helper edge cases (6 cases)
- [x] `TestThoughtSignatureRoundTrip` — end-to-end capture→replay