### PR TITLE
feat(config): add WithHeader option for custom HTTP headers

### DIFF
--- a/anyllm.go
+++ b/anyllm.go
@@ -156,6 +156,7 @@ var (
 	WithAPIKey     = config.WithAPIKey
 	WithBaseURL    = config.WithBaseURL
 	WithExtra      = config.WithExtra
+	WithHeader     = config.WithHeader
 	WithHTTPClient = config.WithHTTPClient
 	WithTimeout    = config.WithTimeout
 )

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,11 @@ type Config struct {
 	// BaseURL is the base URL for the API. If empty, the provider's default is used.
 	BaseURL string
 
+	// Headers holds extra HTTP headers to include on every request.
+	// Useful for proxy authentication (e.g., Cloudflare AI Gateway's
+	// cf-aig-authorization header).
+	Headers map[string]string
+
 	// Extra holds provider-specific configuration options.
 	Extra map[string]any
 
@@ -90,6 +95,26 @@ func WithBaseURL(baseURL string) Option {
 	}
 }
 
+
+// WithHeader adds an HTTP header that will be included on every request.
+// Useful for proxy/gateway authentication (e.g., cf-aig-authorization for
+// Cloudflare AI Gateway). Can be called multiple times to add multiple headers.
+func WithHeader(key, value string) Option {
+	return func(c *Config) error {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return fmt.Errorf("header key cannot be empty")
+		}
+
+		if c.Headers == nil {
+			c.Headers = make(map[string]string)
+		}
+
+		c.Headers[key] = value
+		return nil
+	}
+}
+
 // WithExtra sets extra provider-specific configuration.
 // Whitespace is automatically trimmed from the key.
 func WithExtra(key string, value any) Option {
@@ -155,9 +180,41 @@ func (c *Config) HTTPClient() *http.Client {
 		if c.httpClient == nil {
 			c.httpClient = &http.Client{Timeout: c.Timeout}
 		}
+
+		// Wrap the transport to inject custom headers on every request.
+		if len(c.Headers) > 0 {
+			c.httpClient = &http.Client{
+				Transport: &headerTransport{
+					base:    c.httpClient.Transport,
+					headers: c.Headers,
+				},
+				Timeout:       c.httpClient.Timeout,
+				CheckRedirect: c.httpClient.CheckRedirect,
+				Jar:           c.httpClient.Jar,
+			}
+		}
 	})
 
 	return c.httpClient
+}
+
+// headerTransport is an http.RoundTripper that injects headers on every request.
+type headerTransport struct {
+	base    http.RoundTripper
+	headers map[string]string
+}
+
+func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	for key, value := range t.headers {
+		req.Header.Set(key, value)
+	}
+
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	return base.RoundTrip(req)
 }
 
 // ResolveAPIKey returns the API key from config if set, otherwise falls back

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	// Headers holds extra HTTP headers to include on every request.
 	// Useful for proxy authentication (e.g., Cloudflare AI Gateway's
 	// cf-aig-authorization header).
-	Headers map[string]string
+	Headers http.Header
 
 	// Extra holds provider-specific configuration options.
 	Extra map[string]any
@@ -37,6 +37,33 @@ type Config struct {
 
 // Option is a function that modifies the Config.
 type Option func(*Config) error
+
+// headerTransport is an http.RoundTripper that injects a fixed set of headers
+// onto every request it forwards.
+type headerTransport struct {
+	base    http.RoundTripper
+	headers http.Header
+}
+
+// RoundTrip injects the configured headers and forwards the request.
+// It operates on a clone so the caller's *http.Request is left unmodified,
+// per the http.RoundTripper contract.
+func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	for key, values := range t.headers {
+		clone.Header.Del(key)
+		for _, value := range values {
+			clone.Header.Add(key, value)
+		}
+	}
+
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	return base.RoundTrip(clone)
+}
 
 // New creates a Config with the given options applied.
 // Note: HTTPClient is not created here by default; it is lazily created via the HTTPClient()
@@ -95,26 +122,6 @@ func WithBaseURL(baseURL string) Option {
 	}
 }
 
-
-// WithHeader adds an HTTP header that will be included on every request.
-// Useful for proxy/gateway authentication (e.g., cf-aig-authorization for
-// Cloudflare AI Gateway). Can be called multiple times to add multiple headers.
-func WithHeader(key, value string) Option {
-	return func(c *Config) error {
-		key = strings.TrimSpace(key)
-		if key == "" {
-			return fmt.Errorf("header key cannot be empty")
-		}
-
-		if c.Headers == nil {
-			c.Headers = make(map[string]string)
-		}
-
-		c.Headers[key] = value
-		return nil
-	}
-}
-
 // WithExtra sets extra provider-specific configuration.
 // Whitespace is automatically trimmed from the key.
 func WithExtra(key string, value any) Option {
@@ -129,6 +136,26 @@ func WithExtra(key string, value any) Option {
 		}
 
 		c.Extra[key] = value
+		return nil
+	}
+}
+
+// WithHeader adds an HTTP header sent on every request. Whitespace is trimmed
+// from the key, and repeated calls with the same key overwrite the previous value.
+// Useful for proxy/gateway authentication (e.g., cf-aig-authorization for
+// Cloudflare AI Gateway).
+func WithHeader(key string, value string) Option {
+	return func(c *Config) error {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return fmt.Errorf("header key cannot be empty")
+		}
+
+		if c.Headers == nil {
+			c.Headers = make(http.Header)
+		}
+
+		c.Headers.Set(key, value)
 		return nil
 	}
 }
@@ -170,23 +197,24 @@ func (c *Config) ExtraValue(key string) (any, bool) {
 	return v, ok
 }
 
-// HTTPClient returns the configured HTTP client, or lazily creates one using
-// the configured Timeout if no custom client was provided via WithHTTPClient.
-// The lazily-created client is cached and reused on subsequent calls.
+// HTTPClient returns the HTTP client used for requests, creating and caching one on first use.
+// When Headers are configured, the returned client wraps the base transport to inject those
+// headers on every request; the base is the client from WithHTTPClient, or a lazily-created
+// client using the configured Timeout.
 //
-// Note: If a custom client was provided via WithHTTPClient, that pointer is returned.
+// Note: with Headers set, the returned *http.Client is a distinct value from any client passed
+// to WithHTTPClient — its Timeout, CheckRedirect, and Jar are copied, but the pointer differs.
 func (c *Config) HTTPClient() *http.Client {
 	c.httpClientOnce.Do(func() {
 		if c.httpClient == nil {
 			c.httpClient = &http.Client{Timeout: c.Timeout}
 		}
 
-		// Wrap the transport to inject custom headers on every request.
 		if len(c.Headers) > 0 {
 			c.httpClient = &http.Client{
 				Transport: &headerTransport{
 					base:    c.httpClient.Transport,
-					headers: c.Headers,
+					headers: c.Headers.Clone(),
 				},
 				Timeout:       c.httpClient.Timeout,
 				CheckRedirect: c.httpClient.CheckRedirect,
@@ -196,25 +224,6 @@ func (c *Config) HTTPClient() *http.Client {
 	})
 
 	return c.httpClient
-}
-
-// headerTransport is an http.RoundTripper that injects headers on every request.
-type headerTransport struct {
-	base    http.RoundTripper
-	headers map[string]string
-}
-
-func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	for key, value := range t.headers {
-		req.Header.Set(key, value)
-	}
-
-	base := t.base
-	if base == nil {
-		base = http.DefaultTransport
-	}
-
-	return base.RoundTrip(req)
 }
 
 // ResolveAPIKey returns the API key from config if set, otherwise falls back

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -580,18 +581,21 @@ func TestWithHeader(t *testing.T) {
 		name    string
 		key     string
 		value   string
+		wantKey string
 		wantErr bool
 	}{
 		{
 			name:    "valid header",
 			key:     "cf-aig-authorization",
 			value:   "Bearer token123",
+			wantKey: "cf-aig-authorization",
 			wantErr: false,
 		},
 		{
 			name:    "key with whitespace trimmed",
 			key:     "  X-Custom-Header  ",
 			value:   "value",
+			wantKey: "X-Custom-Header",
 			wantErr: false,
 		},
 		{
@@ -610,6 +614,7 @@ func TestWithHeader(t *testing.T) {
 			name:    "empty value is allowed",
 			key:     "X-Header",
 			value:   "",
+			wantKey: "X-Header",
 			wantErr: false,
 		},
 	}
@@ -626,6 +631,7 @@ func TestWithHeader(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotNil(t, cfg.Headers)
+			require.Equal(t, tc.value, cfg.Headers.Get(tc.wantKey))
 		})
 	}
 }
@@ -639,8 +645,24 @@ func TestWithHeader_Multiple(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, cfg.Headers, 2)
-	require.Equal(t, "Bearer token1", cfg.Headers["cf-aig-authorization"])
-	require.Equal(t, "value2", cfg.Headers["X-Custom"])
+	require.Equal(t, "Bearer token1", cfg.Headers.Get("cf-aig-authorization"))
+	require.Equal(t, "value2", cfg.Headers.Get("X-Custom"))
+}
+
+func TestWithHeader_DuplicateKeyOverwrites(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := New(
+		WithHeader("X-Token", "first"),
+		WithHeader("X-Token", "second"),
+	)
+	require.NoError(t, err)
+
+	// WithHeader uses Set semantics: the later value replaces the earlier one
+	// rather than appending a second value.
+	require.Len(t, cfg.Headers, 1)
+	require.Equal(t, "second", cfg.Headers.Get("X-Token"))
+	require.Equal(t, []string{"second"}, cfg.Headers.Values("X-Token"))
 }
 
 func TestHTTPClient_WithHeaders(t *testing.T) {
@@ -658,8 +680,8 @@ func TestHTTPClient_WithHeaders(t *testing.T) {
 	// The transport should be a headerTransport.
 	ht, ok := client.Transport.(*headerTransport)
 	require.True(t, ok, "expected headerTransport, got %T", client.Transport)
-	require.Equal(t, "Bearer mytoken", ht.headers["cf-aig-authorization"])
-	require.Equal(t, "value", ht.headers["X-Custom"])
+	require.Equal(t, "Bearer mytoken", ht.headers.Get("cf-aig-authorization"))
+	require.Equal(t, "value", ht.headers.Get("X-Custom"))
 }
 
 func TestHTTPClient_WithHeaders_CustomClient(t *testing.T) {
@@ -678,7 +700,7 @@ func TestHTTPClient_WithHeaders_CustomClient(t *testing.T) {
 	// Should wrap the custom client's transport.
 	ht, ok := client.Transport.(*headerTransport)
 	require.True(t, ok, "expected headerTransport wrapping custom client")
-	require.Equal(t, "Bearer token", ht.headers["cf-aig-authorization"])
+	require.Equal(t, "Bearer token", ht.headers.Get("cf-aig-authorization"))
 	require.Equal(t, 5*time.Second, client.Timeout)
 }
 
@@ -691,7 +713,38 @@ func TestHTTPClient_NoHeaders_NoWrapping(t *testing.T) {
 	client := cfg.HTTPClient()
 	require.NotNil(t, client)
 
-	// Without headers, transport should NOT be a headerTransport.
-	_, ok := client.Transport.(*headerTransport)
-	require.False(t, ok, "should not wrap transport when no headers are set")
+	// Without headers, the client is left unwrapped and carries no custom transport.
+	require.Nil(t, client.Transport)
+}
+
+func TestHTTPClient_Headers_EndToEnd(t *testing.T) {
+	t.Parallel()
+
+	var got http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg, err := New(
+		WithHeader("cf-aig-authorization", "Bearer e2e-token"),
+		WithHeader("X-Custom", "custom-value"),
+	)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := cfg.HTTPClient().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "Bearer e2e-token", got.Get("cf-aig-authorization"))
+	require.Equal(t, "custom-value", got.Get("X-Custom"))
+
+	// RoundTrip must not mutate the caller's request (net/http contract).
+	require.Empty(t, req.Header.Get("cf-aig-authorization"))
+	require.Empty(t, req.Header.Get("X-Custom"))
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -572,3 +572,126 @@ func TestHTTPClientCaching(t *testing.T) {
 
 	require.Same(t, client1, client2)
 }
+
+func TestWithHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		key     string
+		value   string
+		wantErr bool
+	}{
+		{
+			name:    "valid header",
+			key:     "cf-aig-authorization",
+			value:   "Bearer token123",
+			wantErr: false,
+		},
+		{
+			name:    "key with whitespace trimmed",
+			key:     "  X-Custom-Header  ",
+			value:   "value",
+			wantErr: false,
+		},
+		{
+			name:    "empty key",
+			key:     "",
+			value:   "value",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only key",
+			key:     "   ",
+			value:   "value",
+			wantErr: true,
+		},
+		{
+			name:    "empty value is allowed",
+			key:     "X-Header",
+			value:   "",
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := New(WithHeader(tc.key, tc.value))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, cfg.Headers)
+		})
+	}
+}
+
+func TestWithHeader_Multiple(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := New(
+		WithHeader("cf-aig-authorization", "Bearer token1"),
+		WithHeader("X-Custom", "value2"),
+	)
+	require.NoError(t, err)
+	require.Len(t, cfg.Headers, 2)
+	require.Equal(t, "Bearer token1", cfg.Headers["cf-aig-authorization"])
+	require.Equal(t, "value2", cfg.Headers["X-Custom"])
+}
+
+func TestHTTPClient_WithHeaders(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := New(
+		WithHeader("cf-aig-authorization", "Bearer mytoken"),
+		WithHeader("X-Custom", "value"),
+	)
+	require.NoError(t, err)
+
+	client := cfg.HTTPClient()
+	require.NotNil(t, client)
+
+	// The transport should be a headerTransport.
+	ht, ok := client.Transport.(*headerTransport)
+	require.True(t, ok, "expected headerTransport, got %T", client.Transport)
+	require.Equal(t, "Bearer mytoken", ht.headers["cf-aig-authorization"])
+	require.Equal(t, "value", ht.headers["X-Custom"])
+}
+
+func TestHTTPClient_WithHeaders_CustomClient(t *testing.T) {
+	t.Parallel()
+
+	customClient := &http.Client{Timeout: 5 * time.Second}
+	cfg, err := New(
+		WithHTTPClient(customClient),
+		WithHeader("cf-aig-authorization", "Bearer token"),
+	)
+	require.NoError(t, err)
+
+	client := cfg.HTTPClient()
+	require.NotNil(t, client)
+
+	// Should wrap the custom client's transport.
+	ht, ok := client.Transport.(*headerTransport)
+	require.True(t, ok, "expected headerTransport wrapping custom client")
+	require.Equal(t, "Bearer token", ht.headers["cf-aig-authorization"])
+	require.Equal(t, 5*time.Second, client.Timeout)
+}
+
+func TestHTTPClient_NoHeaders_NoWrapping(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := New()
+	require.NoError(t, err)
+
+	client := cfg.HTTPClient()
+	require.NotNil(t, client)
+
+	// Without headers, transport should NOT be a headerTransport.
+	_, ok := client.Transport.(*headerTransport)
+	require.False(t, ok, "should not wrap transport when no headers are set")
+}

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -118,6 +118,7 @@ func New(opts ...config.Option) (*Provider, error) {
 
 	clientOpts := []option.RequestOption{
 		option.WithAPIKey(apiKey),
+		option.WithHTTPClient(cfg.HTTPClient()),
 	}
 
 	if baseURL != "" {


### PR DESCRIPTION
## Summary

- Add a `WithHeader` config option that injects custom HTTP headers on every provider request.
- Inject headers via a transport wrapper (`headerTransport`) that **clones each request before adding headers**, so the caller's `*http.Request` is never mutated (per the `net/http` `RoundTripper` contract).
- Route the Anthropic provider through `cfg.HTTPClient()` so custom headers (and the configured client) apply to Anthropic too.
- Re-export `WithHeader` from the root `anyllm` package.

`Headers` is stored as the stdlib `http.Header`, and `WithHeader` uses `Set` semantics — repeated calls with the same key overwrite the previous value. The header set is cloned when the client is built, so mutating `cfg.Headers` afterward cannot race an in-flight request.

## Motivation

Proxy/gateway services like [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) require custom authentication headers (e.g., `cf-aig-authorization`) alongside the provider's own API key. Previously there was no way to inject custom headers without supplying a fully custom HTTP client with a hand-rolled round-tripper.

## ⚠️ Behavior change (Anthropic)

Before this PR the Anthropic provider used the `anthropic-sdk-go` default HTTP client, which has **no timeout**. It now uses `cfg.HTTPClient()`, so the configured `cfg.Timeout` (default **120s**) applies to Anthropic requests. Because this is an `http.Client.Timeout`, it bounds the entire request — **including streaming responses**. Callers whose Anthropic calls can exceed 120s should raise it with `WithTimeout`, or supply their own client via `WithHTTPClient`. This aligns Anthropic with every other provider, which already route through `cfg.HTTPClient()`.

## Usage

```go
provider, err := openai.New(
    anyllm.WithAPIKey("sk-..."),
    anyllm.WithBaseURL("https://gateway.ai.cloudflare.com/v1/{account}/{gateway}/openai"),
    anyllm.WithHeader("cf-aig-authorization", "Bearer cf-token"),
)
```

Works with all providers, since they all use `cfg.HTTPClient()` (Anthropic included, via this PR).

## Changes

| File | Change |
|------|--------|
| `config/config.go` | `Headers http.Header` field; `WithHeader` option (Set semantics, trims key); `headerTransport` round-tripper that clones the request before injecting headers; `HTTPClient()` wraps the base transport when headers are set (cloning the header set) while preserving the base client's `Timeout`/`CheckRedirect`/`Jar` |
| `config/config_test.go` | Tests: key/value validation, multiple headers, duplicate-key overwrite, transport wrapping (default + custom client), no-op when no headers set, and an end-to-end `httptest` test asserting inbound headers and that the caller's request is not mutated |
| `providers/anthropic/anthropic.go` | Pass `cfg.HTTPClient()` to the SDK client options |
| `anyllm.go` | Re-export `WithHeader` |

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./config/...` (unit + end-to-end)
- [x] `golangci-lint run` clean
- [x] Rebased onto latest `main`
