### PR TITLE
fix(gemini): pass json_schema payload in structured output requests

### DIFF
--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -58,10 +58,11 @@ const (
 
 // Response format and tool type constants.
 const (
-	responseMIMETypeJSON = "application/json"
-	responseFormatJSON   = "json_object"
-	toolCallFallbackName = "function"
-	toolCallType         = "function"
+	responseMIMETypeJSON     = "application/json"
+	responseFormatJSON       = "json_object"
+	responseFormatJSONSchema = "json_schema"
+	toolCallFallbackName     = "function"
+	toolCallType             = "function"
 )
 
 // ID prefix constants for generated identifiers.
@@ -489,8 +490,20 @@ func (s *streamState) processResponse(resp *genai.GenerateContentResponse) ([]pr
 }
 
 // applyResponseFormat configures the response format on the config.
+// For json_schema, Gemini requires both responseMimeType application/json and
+// responseJsonSchema (see https://ai.google.dev/gemini-api/docs/structured-output).
 func applyResponseFormat(cfg *genai.GenerateContentConfig, format *providers.ResponseFormat) {
-	if format.Type == responseFormatJSON {
+	if format == nil {
+		return
+	}
+	switch format.Type {
+	case responseFormatJSONSchema:
+		if format.JSONSchema == nil || format.JSONSchema.Schema == nil {
+			return
+		}
+		cfg.ResponseMIMEType = responseMIMETypeJSON
+		cfg.ResponseJsonSchema = format.JSONSchema.Schema
+	case responseFormatJSON:
 		cfg.ResponseMIMEType = responseMIMETypeJSON
 	}
 }

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -1194,6 +1194,68 @@ func TestStreamStateFinalChunk(t *testing.T) {
 	})
 }
 
+func TestConvertParams(t *testing.T) {
+	t.Parallel()
+
+	provider, err := New(config.WithAPIKey("test-key"))
+	require.NoError(t, err)
+
+	t.Run("json_object sets mime type", func(t *testing.T) {
+		t.Parallel()
+
+		_, cfg := provider.convertParams(providers.CompletionParams{
+			Model:    "gemini-2.0-flash",
+			Messages: []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
+			ResponseFormat: &providers.ResponseFormat{
+				Type: responseFormatJSON,
+			},
+		})
+
+		require.Equal(t, responseMIMETypeJSON, cfg.ResponseMIMEType)
+		require.Nil(t, cfg.ResponseJsonSchema)
+	})
+
+	t.Run("json_schema sets mime type and schema", func(t *testing.T) {
+		t.Parallel()
+
+		schema := map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name":       map[string]any{"type": "string"},
+				"population": map[string]any{"type": "integer"},
+			},
+			"required": []string{"name", "population"},
+		}
+
+		_, cfg := provider.convertParams(providers.CompletionParams{
+			Model:    "gemini-2.0-flash",
+			Messages: []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
+			ResponseFormat: &providers.ResponseFormat{
+				Type: responseFormatJSONSchema,
+				JSONSchema: &providers.JSONSchema{
+					Name:   "city_info",
+					Schema: schema,
+				},
+			},
+		})
+
+		require.Equal(t, responseMIMETypeJSON, cfg.ResponseMIMEType)
+		require.Equal(t, schema, cfg.ResponseJsonSchema)
+	})
+
+	t.Run("nil response format leaves config unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		_, cfg := provider.convertParams(providers.CompletionParams{
+			Model:    "gemini-2.0-flash",
+			Messages: []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
+		})
+
+		require.Empty(t, cfg.ResponseMIMEType)
+		require.Nil(t, cfg.ResponseJsonSchema)
+	})
+}
+
 func TestConvertResponse(t *testing.T) {
 	t.Parallel()
 
@@ -1324,6 +1386,48 @@ func TestApplyResponseFormat(t *testing.T) {
 		cfg := &genai.GenerateContentConfig{}
 		applyResponseFormat(cfg, &providers.ResponseFormat{Type: "text"})
 		require.Empty(t, cfg.ResponseMIMEType)
+	})
+
+	t.Run("json_schema sets mime type and schema", func(t *testing.T) {
+		t.Parallel()
+
+		schema := map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{"type": "string"},
+			},
+		}
+		cfg := &genai.GenerateContentConfig{}
+		applyResponseFormat(cfg, &providers.ResponseFormat{
+			Type: "json_schema",
+			JSONSchema: &providers.JSONSchema{
+				Name:   "test_schema",
+				Schema: schema,
+			},
+		})
+		require.Equal(t, "application/json", cfg.ResponseMIMEType)
+		require.Equal(t, schema, cfg.ResponseJsonSchema)
+	})
+
+	t.Run("json_schema with nil JSONSchema does not set mime type", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &genai.GenerateContentConfig{}
+		applyResponseFormat(cfg, &providers.ResponseFormat{Type: "json_schema"})
+		require.Empty(t, cfg.ResponseMIMEType)
+		require.Nil(t, cfg.ResponseJsonSchema)
+	})
+
+	t.Run("json_schema with nil Schema does not set mime type", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &genai.GenerateContentConfig{}
+		applyResponseFormat(cfg, &providers.ResponseFormat{
+			Type:       "json_schema",
+			JSONSchema: &providers.JSONSchema{Name: "test"},
+		})
+		require.Empty(t, cfg.ResponseMIMEType)
+		require.Nil(t, cfg.ResponseJsonSchema)
 	})
 }
 


### PR DESCRIPTION
## Summary
Fixes a bug where the Gemini provider silently dropped the JSON schema when `ResponseFormat.Type = "json_schema"` was set. `applyResponseFormat` only handled the `json_object` case, leaving `cfg.ResponseJsonSchema` unpopulated.

Gemini requires both `ResponseMIMEType` and `ResponseJsonSchema` to be set for schema-constrained output—only the MIME type was being set, so the API returned unstructured prose instead of schema-conforming JSON.

Closes #79 

## Changes
- Add `responseFormatJSONSchema = "json_schema"` constant to `providers/gemini/gemini.go`
- Add `json_schema` branch in `applyResponseFormat` that sets both `cfg.ResponseMIMEType` and `cfg.ResponseJsonSchema`
- Add nil guard at the top of `applyResponseFormat` (defensive, consistent with other providers)
- Add `TestConvertParams` to verify `json_object`, `json_schema`, and nil response formats are wired through `convertParams` correctly
- Extend `TestApplyResponseFormat` with three new sub-cases covering the `json_schema` branch and its nil guards

## Testing
Unit tests (no API key required):

```bash
make test-unit
```

The code example from #79  can also be used to confirm the response is now a JSON object conforming to the schema instead of unstructured prose.

## Checklist
- [x] Linting passes (`make lint`)
- [x] Tests pass locally (`make test`)
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)