### PR TITLE
feat(gateway): add gateway provider with platform and non-platform mode support

### DIFF
--- a/anyllm.go
+++ b/anyllm.go
@@ -125,6 +125,8 @@ var (
 	ErrAuthentication      = errors.ErrAuthentication
 	ErrContentFilter       = errors.ErrContentFilter
 	ErrContextLength       = errors.ErrContextLength
+	ErrGatewayTimeout      = errors.ErrGatewayTimeout
+	ErrInsufficientFunds   = errors.ErrInsufficientFunds
 	ErrInvalidRequest      = errors.ErrInvalidRequest
 	ErrMissingAPIKey       = errors.ErrMissingAPIKey
 	ErrModelNotFound       = errors.ErrModelNotFound
@@ -132,6 +134,7 @@ var (
 	ErrRateLimit           = errors.ErrRateLimit
 	ErrUnsupportedParam    = errors.ErrUnsupportedParam
 	ErrUnsupportedProvider = errors.ErrUnsupportedProvider
+	ErrUpstreamProvider    = errors.ErrUpstreamProvider
 )
 
 // Error types.
@@ -140,6 +143,8 @@ type (
 	BaseError                = errors.BaseError
 	ContentFilterError       = errors.ContentFilterError
 	ContextLengthError       = errors.ContextLengthError
+	GatewayTimeoutError      = errors.GatewayTimeoutError
+	InsufficientFundsError   = errors.InsufficientFundsError
 	InvalidRequestError      = errors.InvalidRequestError
 	MissingAPIKeyError       = errors.MissingAPIKeyError
 	ModelNotFoundError       = errors.ModelNotFoundError
@@ -147,4 +152,5 @@ type (
 	RateLimitError           = errors.RateLimitError
 	UnsupportedParamError    = errors.UnsupportedParamError
 	UnsupportedProviderError = errors.UnsupportedProviderError
+	UpstreamProviderError    = errors.UpstreamProviderError
 )

--- a/anyllm.go
+++ b/anyllm.go
@@ -125,7 +125,6 @@ var (
 	ErrAuthentication      = errors.ErrAuthentication
 	ErrContentFilter       = errors.ErrContentFilter
 	ErrContextLength       = errors.ErrContextLength
-	ErrGatewayTimeout      = errors.ErrGatewayTimeout
 	ErrInsufficientFunds   = errors.ErrInsufficientFunds
 	ErrInvalidRequest      = errors.ErrInvalidRequest
 	ErrMissingAPIKey       = errors.ErrMissingAPIKey
@@ -134,7 +133,6 @@ var (
 	ErrRateLimit           = errors.ErrRateLimit
 	ErrUnsupportedParam    = errors.ErrUnsupportedParam
 	ErrUnsupportedProvider = errors.ErrUnsupportedProvider
-	ErrUpstreamProvider    = errors.ErrUpstreamProvider
 )
 
 // Error types.
@@ -143,7 +141,6 @@ type (
 	BaseError                = errors.BaseError
 	ContentFilterError       = errors.ContentFilterError
 	ContextLengthError       = errors.ContextLengthError
-	GatewayTimeoutError      = errors.GatewayTimeoutError
 	InsufficientFundsError   = errors.InsufficientFundsError
 	InvalidRequestError      = errors.InvalidRequestError
 	MissingAPIKeyError       = errors.MissingAPIKeyError
@@ -152,5 +149,4 @@ type (
 	RateLimitError           = errors.RateLimitError
 	UnsupportedParamError    = errors.UnsupportedParamError
 	UnsupportedProviderError = errors.UnsupportedProviderError
-	UpstreamProviderError    = errors.UpstreamProviderError
 )

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -51,6 +51,30 @@ type BaseError struct {
 	sentinel error
 }
 
+// New constructs a BaseError for embedding in a caller-defined error type.
+// It exists so packages outside this one can populate the unexported
+// sentinel field that drives errors.Is matching; without it, external
+// packages could only set the exported fields via struct literals and
+// errors.Is(err, ErrFoo) would never match.
+//
+// Typical usage from a provider package:
+//
+//	type UpstreamProviderError struct{ errors.BaseError }
+//
+//	func NewUpstreamProviderError(provider string, err error) *UpstreamProviderError {
+//	    return &UpstreamProviderError{
+//	        BaseError: errors.New("upstream_provider", provider, err, ErrUpstreamProvider),
+//	    }
+//	}
+func New(code string, provider string, err error, sentinel error) BaseError {
+	return BaseError{
+		Code:     code,
+		Provider: provider,
+		Err:      err,
+		sentinel: sentinel,
+	}
+}
+
 // Error implements the error interface.
 func (e *BaseError) Error() string {
 	msg := ""
@@ -153,17 +177,6 @@ func NewAuthenticationError(provider string, err error) *AuthenticationError {
 			Err:      err,
 			sentinel: ErrAuthentication,
 		},
-	}
-}
-
-// NewBaseError creates a BaseError with the given fields. This allows provider
-// packages to define their own error types that embed BaseError with a sentinel.
-func NewBaseError(code, provider string, err, sentinel error) BaseError {
-	return BaseError{
-		Code:     code,
-		Provider: provider,
-		Err:      err,
-		sentinel: sentinel,
 	}
 }
 
@@ -271,6 +284,11 @@ func NewUnsupportedParamError(provider string, param string) *UnsupportedParamEr
 // NewInsufficientFundsError creates a new InsufficientFundsError.
 func NewInsufficientFundsError(provider string, err error) *InsufficientFundsError {
 	return &InsufficientFundsError{
-		BaseError: NewBaseError(CodeInsufficientFunds, provider, err, ErrInsufficientFunds),
+		BaseError: BaseError{
+			Code:     CodeInsufficientFunds,
+			Provider: provider,
+			Err:      err,
+			sentinel: ErrInsufficientFunds,
+		},
 	}
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -18,8 +18,6 @@ const (
 	CodeUnsupportedProvider = "unsupported_provider"
 	CodeUnsupportedParam    = "unsupported_parameter"
 	CodeInsufficientFunds   = "insufficient_funds"
-	CodeUpstreamProvider    = "upstream_provider"
-	CodeGatewayTimeout      = "gateway_timeout"
 )
 
 // Sentinel errors for type checking with errors.Is().
@@ -35,8 +33,6 @@ var (
 	ErrUnsupportedProvider = stderrors.New("unsupported provider")
 	ErrUnsupportedParam    = stderrors.New("unsupported parameter")
 	ErrInsufficientFunds   = stderrors.New("insufficient funds")
-	ErrUpstreamProvider    = stderrors.New("upstream provider error")
-	ErrGatewayTimeout      = stderrors.New("gateway timeout")
 )
 
 // BaseError is the base error type for all any-llm errors.
@@ -133,16 +129,6 @@ type UnsupportedParamError struct {
 
 // InsufficientFundsError is returned when the account has insufficient funds (HTTP 402).
 type InsufficientFundsError struct {
-	BaseError
-}
-
-// UpstreamProviderError is returned when the upstream provider is unreachable (HTTP 502).
-type UpstreamProviderError struct {
-	BaseError
-}
-
-// GatewayTimeoutError is returned when the gateway times out (HTTP 504).
-type GatewayTimeoutError struct {
 	BaseError
 }
 
@@ -271,38 +257,20 @@ func NewUnsupportedParamError(provider string, param string) *UnsupportedParamEr
 	}
 }
 
+// NewBaseError creates a BaseError with the given fields. This allows provider
+// packages to define their own error types that embed BaseError with a sentinel.
+func NewBaseError(code, provider string, err, sentinel error) BaseError {
+	return BaseError{
+		Code:     code,
+		Provider: provider,
+		Err:      err,
+		sentinel: sentinel,
+	}
+}
+
 // NewInsufficientFundsError creates a new InsufficientFundsError.
 func NewInsufficientFundsError(provider string, err error) *InsufficientFundsError {
 	return &InsufficientFundsError{
-		BaseError: BaseError{
-			Code:     CodeInsufficientFunds,
-			Provider: provider,
-			Err:      err,
-			sentinel: ErrInsufficientFunds,
-		},
-	}
-}
-
-// NewUpstreamProviderError creates a new UpstreamProviderError.
-func NewUpstreamProviderError(provider string, err error) *UpstreamProviderError {
-	return &UpstreamProviderError{
-		BaseError: BaseError{
-			Code:     CodeUpstreamProvider,
-			Provider: provider,
-			Err:      err,
-			sentinel: ErrUpstreamProvider,
-		},
-	}
-}
-
-// NewGatewayTimeoutError creates a new GatewayTimeoutError.
-func NewGatewayTimeoutError(provider string, err error) *GatewayTimeoutError {
-	return &GatewayTimeoutError{
-		BaseError: BaseError{
-			Code:     CodeGatewayTimeout,
-			Provider: provider,
-			Err:      err,
-			sentinel: ErrGatewayTimeout,
-		},
+		BaseError: NewBaseError(CodeInsufficientFunds, provider, err, ErrInsufficientFunds),
 	}
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -17,6 +17,9 @@ const (
 	CodeMissingAPIKey       = "missing_api_key"
 	CodeUnsupportedProvider = "unsupported_provider"
 	CodeUnsupportedParam    = "unsupported_parameter"
+	CodeInsufficientFunds   = "insufficient_funds"
+	CodeUpstreamProvider    = "upstream_provider"
+	CodeGatewayTimeout      = "gateway_timeout"
 )
 
 // Sentinel errors for type checking with errors.Is().
@@ -31,6 +34,9 @@ var (
 	ErrMissingAPIKey       = stderrors.New("missing API key")
 	ErrUnsupportedProvider = stderrors.New("unsupported provider")
 	ErrUnsupportedParam    = stderrors.New("unsupported parameter")
+	ErrInsufficientFunds   = stderrors.New("insufficient funds")
+	ErrUpstreamProvider    = stderrors.New("upstream provider error")
+	ErrGatewayTimeout      = stderrors.New("gateway timeout")
 )
 
 // BaseError is the base error type for all any-llm errors.
@@ -123,6 +129,21 @@ type UnsupportedProviderError struct {
 type UnsupportedParamError struct {
 	BaseError
 	Param string // The unsupported parameter name
+}
+
+// InsufficientFundsError is returned when the account has insufficient funds (HTTP 402).
+type InsufficientFundsError struct {
+	BaseError
+}
+
+// UpstreamProviderError is returned when the upstream provider is unreachable (HTTP 502).
+type UpstreamProviderError struct {
+	BaseError
+}
+
+// GatewayTimeoutError is returned when the gateway times out (HTTP 504).
+type GatewayTimeoutError struct {
+	BaseError
 }
 
 // NewRateLimitError creates a new RateLimitError.
@@ -247,5 +268,41 @@ func NewUnsupportedParamError(provider string, param string) *UnsupportedParamEr
 			sentinel: ErrUnsupportedParam,
 		},
 		Param: param,
+	}
+}
+
+// NewInsufficientFundsError creates a new InsufficientFundsError.
+func NewInsufficientFundsError(provider string, err error) *InsufficientFundsError {
+	return &InsufficientFundsError{
+		BaseError: BaseError{
+			Code:     CodeInsufficientFunds,
+			Provider: provider,
+			Err:      err,
+			sentinel: ErrInsufficientFunds,
+		},
+	}
+}
+
+// NewUpstreamProviderError creates a new UpstreamProviderError.
+func NewUpstreamProviderError(provider string, err error) *UpstreamProviderError {
+	return &UpstreamProviderError{
+		BaseError: BaseError{
+			Code:     CodeUpstreamProvider,
+			Provider: provider,
+			Err:      err,
+			sentinel: ErrUpstreamProvider,
+		},
+	}
+}
+
+// NewGatewayTimeoutError creates a new GatewayTimeoutError.
+func NewGatewayTimeoutError(provider string, err error) *GatewayTimeoutError {
+	return &GatewayTimeoutError{
+		BaseError: BaseError{
+			Code:     CodeGatewayTimeout,
+			Provider: provider,
+			Err:      err,
+			sentinel: ErrGatewayTimeout,
+		},
 	}
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -156,6 +156,17 @@ func NewAuthenticationError(provider string, err error) *AuthenticationError {
 	}
 }
 
+// NewBaseError creates a BaseError with the given fields. This allows provider
+// packages to define their own error types that embed BaseError with a sentinel.
+func NewBaseError(code, provider string, err, sentinel error) BaseError {
+	return BaseError{
+		Code:     code,
+		Provider: provider,
+		Err:      err,
+		sentinel: sentinel,
+	}
+}
+
 // NewInvalidRequestError creates a new InvalidRequestError.
 func NewInvalidRequestError(provider string, err error) *InvalidRequestError {
 	return &InvalidRequestError{
@@ -254,17 +265,6 @@ func NewUnsupportedParamError(provider string, param string) *UnsupportedParamEr
 			sentinel: ErrUnsupportedParam,
 		},
 		Param: param,
-	}
-}
-
-// NewBaseError creates a BaseError with the given fields. This allows provider
-// packages to define their own error types that embed BaseError with a sentinel.
-func NewBaseError(code, provider string, err, sentinel error) BaseError {
-	return BaseError{
-		Code:     code,
-		Provider: provider,
-		Err:      err,
-		sentinel: sentinel,
 	}
 }
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -84,6 +84,30 @@ func TestErrorIs(t *testing.T) {
 			target:    ErrUnsupportedParam,
 			wantMatch: true,
 		},
+		{
+			name:      "InsufficientFundsError matches ErrInsufficientFunds",
+			err:       NewInsufficientFundsError("gateway", originalErr),
+			target:    ErrInsufficientFunds,
+			wantMatch: true,
+		},
+		{
+			name:      "InsufficientFundsError does not match ErrAuthentication",
+			err:       NewInsufficientFundsError("gateway", originalErr),
+			target:    ErrAuthentication,
+			wantMatch: false,
+		},
+		{
+			name:      "UpstreamProviderError matches ErrUpstreamProvider",
+			err:       NewUpstreamProviderError("gateway", originalErr),
+			target:    ErrUpstreamProvider,
+			wantMatch: true,
+		},
+		{
+			name:      "GatewayTimeoutError matches ErrGatewayTimeout",
+			err:       NewGatewayTimeoutError("gateway", originalErr),
+			target:    ErrGatewayTimeout,
+			wantMatch: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -130,6 +154,21 @@ func TestErrorMessage(t *testing.T) {
 			name:        "UnsupportedParamError includes param name",
 			err:         NewUnsupportedParamError("openai", "bad_param"),
 			wantContain: []string{"[openai]", "unsupported_parameter", "bad_param"},
+		},
+		{
+			name:        "InsufficientFundsError includes provider and code",
+			err:         NewInsufficientFundsError("gateway", originalErr),
+			wantContain: []string{"[gateway]", "insufficient_funds", "something went wrong"},
+		},
+		{
+			name:        "UpstreamProviderError includes provider and code",
+			err:         NewUpstreamProviderError("gateway", originalErr),
+			wantContain: []string{"[gateway]", "upstream_provider", "something went wrong"},
+		},
+		{
+			name:        "GatewayTimeoutError includes provider and code",
+			err:         NewGatewayTimeoutError("gateway", originalErr),
+			wantContain: []string{"[gateway]", "gateway_timeout", "something went wrong"},
 		},
 	}
 
@@ -207,6 +246,24 @@ func TestErrorCodes(t *testing.T) {
 		err := NewUnsupportedParamError("openai", "param")
 		require.Equal(t, CodeUnsupportedParam, err.Code)
 	})
+
+	t.Run("InsufficientFundsError has correct code", func(t *testing.T) {
+		t.Parallel()
+		err := NewInsufficientFundsError("gateway", nil)
+		require.Equal(t, CodeInsufficientFunds, err.Code)
+	})
+
+	t.Run("UpstreamProviderError has correct code", func(t *testing.T) {
+		t.Parallel()
+		err := NewUpstreamProviderError("gateway", nil)
+		require.Equal(t, CodeUpstreamProvider, err.Code)
+	})
+
+	t.Run("GatewayTimeoutError has correct code", func(t *testing.T) {
+		t.Parallel()
+		err := NewGatewayTimeoutError("gateway", nil)
+		require.Equal(t, CodeGatewayTimeout, err.Code)
+	})
 }
 
 func TestErrorAs(t *testing.T) {
@@ -244,5 +301,35 @@ func TestErrorAs(t *testing.T) {
 		require.True(t, stderrors.As(err, &paramErr))
 		require.Equal(t, "frequency_penalty", paramErr.Param)
 		require.Equal(t, "openai", paramErr.Provider)
+	})
+
+	t.Run("can extract InsufficientFundsError", func(t *testing.T) {
+		t.Parallel()
+
+		err := NewInsufficientFundsError("gateway", stderrors.New("payment required"))
+
+		var fundsErr *InsufficientFundsError
+		require.True(t, stderrors.As(err, &fundsErr))
+		require.Equal(t, "gateway", fundsErr.Provider)
+	})
+
+	t.Run("can extract UpstreamProviderError", func(t *testing.T) {
+		t.Parallel()
+
+		err := NewUpstreamProviderError("gateway", stderrors.New("bad gateway"))
+
+		var upstreamErr *UpstreamProviderError
+		require.True(t, stderrors.As(err, &upstreamErr))
+		require.Equal(t, "gateway", upstreamErr.Provider)
+	})
+
+	t.Run("can extract GatewayTimeoutError", func(t *testing.T) {
+		t.Parallel()
+
+		err := NewGatewayTimeoutError("gateway", stderrors.New("timed out"))
+
+		var timeoutErr *GatewayTimeoutError
+		require.True(t, stderrors.As(err, &timeoutErr))
+		require.Equal(t, "gateway", timeoutErr.Provider)
 	})
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -96,18 +96,6 @@ func TestErrorIs(t *testing.T) {
 			target:    ErrAuthentication,
 			wantMatch: false,
 		},
-		{
-			name:      "UpstreamProviderError matches ErrUpstreamProvider",
-			err:       NewUpstreamProviderError("gateway", originalErr),
-			target:    ErrUpstreamProvider,
-			wantMatch: true,
-		},
-		{
-			name:      "GatewayTimeoutError matches ErrGatewayTimeout",
-			err:       NewGatewayTimeoutError("gateway", originalErr),
-			target:    ErrGatewayTimeout,
-			wantMatch: true,
-		},
 	}
 
 	for _, tc := range tests {
@@ -159,16 +147,6 @@ func TestErrorMessage(t *testing.T) {
 			name:        "InsufficientFundsError includes provider and code",
 			err:         NewInsufficientFundsError("gateway", originalErr),
 			wantContain: []string{"[gateway]", "insufficient_funds", "something went wrong"},
-		},
-		{
-			name:        "UpstreamProviderError includes provider and code",
-			err:         NewUpstreamProviderError("gateway", originalErr),
-			wantContain: []string{"[gateway]", "upstream_provider", "something went wrong"},
-		},
-		{
-			name:        "GatewayTimeoutError includes provider and code",
-			err:         NewGatewayTimeoutError("gateway", originalErr),
-			wantContain: []string{"[gateway]", "gateway_timeout", "something went wrong"},
 		},
 	}
 
@@ -253,17 +231,6 @@ func TestErrorCodes(t *testing.T) {
 		require.Equal(t, CodeInsufficientFunds, err.Code)
 	})
 
-	t.Run("UpstreamProviderError has correct code", func(t *testing.T) {
-		t.Parallel()
-		err := NewUpstreamProviderError("gateway", nil)
-		require.Equal(t, CodeUpstreamProvider, err.Code)
-	})
-
-	t.Run("GatewayTimeoutError has correct code", func(t *testing.T) {
-		t.Parallel()
-		err := NewGatewayTimeoutError("gateway", nil)
-		require.Equal(t, CodeGatewayTimeout, err.Code)
-	})
 }
 
 func TestErrorAs(t *testing.T) {
@@ -313,23 +280,4 @@ func TestErrorAs(t *testing.T) {
 		require.Equal(t, "gateway", fundsErr.Provider)
 	})
 
-	t.Run("can extract UpstreamProviderError", func(t *testing.T) {
-		t.Parallel()
-
-		err := NewUpstreamProviderError("gateway", stderrors.New("bad gateway"))
-
-		var upstreamErr *UpstreamProviderError
-		require.True(t, stderrors.As(err, &upstreamErr))
-		require.Equal(t, "gateway", upstreamErr.Provider)
-	})
-
-	t.Run("can extract GatewayTimeoutError", func(t *testing.T) {
-		t.Parallel()
-
-		err := NewGatewayTimeoutError("gateway", stderrors.New("timed out"))
-
-		var timeoutErr *GatewayTimeoutError
-		require.True(t, stderrors.As(err, &timeoutErr))
-		require.Equal(t, "gateway", timeoutErr.Provider)
-	})
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -230,7 +230,6 @@ func TestErrorCodes(t *testing.T) {
 		err := NewInsufficientFundsError("gateway", nil)
 		require.Equal(t, CodeInsufficientFunds, err.Code)
 	})
-
 }
 
 func TestErrorAs(t *testing.T) {
@@ -279,5 +278,4 @@ func TestErrorAs(t *testing.T) {
 		require.True(t, stderrors.As(err, &fundsErr))
 		require.Equal(t, "gateway", fundsErr.Provider)
 	})
-
 }

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -4,7 +4,7 @@
 //
 // The gateway supports two authentication modes:
 //   - Platform mode: uses a platform token as standard Bearer auth
-//   - Non-platform mode: sends a gateway API key via the X-AnyLLM-Key header
+//   - Non-platform mode: sends a gateway API key via the gatewayHeader header
 package gateway
 
 import (
@@ -23,11 +23,15 @@ import (
 
 // Provider configuration constants.
 const (
-	envAPIBase       = "GATEWAY_API_BASE"
-	envAPIKey        = "GATEWAY_API_KEY"
-	envPlatformToken = "GATEWAY_PLATFORM_TOKEN"
-	gatewayHeader    = "X-AnyLLM-Key"
-	providerName     = "gateway"
+	bearerPrefix          = "Bearer "
+	defaultNonPlatformKey = "gateway-no-key"
+	envAPIBase            = "GATEWAY_API_BASE"
+	envAPIKey             = "GATEWAY_API_KEY"
+	envPlatformToken      = "GATEWAY_PLATFORM_TOKEN"
+	extraKeyGatewayKey    = "gateway_key"
+	extraKeyPlatformMode  = "platform_mode"
+	gatewayHeader         = "X-AnyLLM-Key"
+	providerName          = "gateway"
 )
 
 // Ensure Provider implements the required interfaces.
@@ -47,6 +51,22 @@ type Provider struct {
 	platformMode bool
 }
 
+// headerTransport wraps an http.RoundTripper to inject custom headers into
+// every request. Used in non-platform mode to add the gateway key header.
+type headerTransport struct {
+	base   http.RoundTripper
+	header string
+	value  string
+}
+
+// RoundTrip implements http.RoundTripper by cloning the request and injecting
+// the configured header before delegating to the base transport.
+func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.Header.Set(t.header, t.value)
+	return t.base.RoundTrip(clone)
+}
+
 // New creates a new gateway provider.
 //
 // The gateway base URL is required and can be set via config.WithBaseURL() or
@@ -58,7 +78,7 @@ type Provider struct {
 //   - If GATEWAY_PLATFORM_TOKEN is set and no explicit API key is provided,
 //     platform mode is auto-detected.
 //   - Otherwise, non-platform mode is used with the key from WithGatewayKey()
-//     or GATEWAY_API_KEY, sent via the X-AnyLLM-Key header.
+//     or GATEWAY_API_KEY, sent via the gatewayHeader header.
 func New(opts ...config.Option) (*Provider, error) {
 	cfg, err := config.New(opts...)
 	if err != nil {
@@ -76,44 +96,61 @@ func New(opts ...config.Option) (*Provider, error) {
 	}
 
 	platformMode, platformToken := resolvePlatformMode(cfg)
-
-	if platformMode {
-		return newPlatformProvider(cfg, baseURL, platformToken)
+	if platformMode && platformToken == "" {
+		return nil, fmt.Errorf(
+			"platform mode requires a token (pass WithAPIKey option or set %s env var)",
+			envPlatformToken,
+		)
 	}
 
-	return newNonPlatformProvider(cfg, baseURL)
+	// Build options for the underlying OpenAI-compatible provider.
+	compatOpts := []config.Option{config.WithBaseURL(baseURL)}
+	if cfg.Timeout > 0 {
+		compatOpts = append(compatOpts, config.WithTimeout(cfg.Timeout))
+	}
+
+	httpClient := cfg.HTTPClient()
+	if platformMode {
+		compatOpts = append(compatOpts, config.WithAPIKey(platformToken))
+	} else {
+		gatewayKey := resolveGatewayKey(cfg)
+		if gatewayKey != "" {
+			httpClient = newHeaderClient(httpClient, bearerPrefix+gatewayKey)
+		}
+	}
+	compatOpts = append(compatOpts, config.WithHTTPClient(httpClient))
+
+	base, err := openaiProvider.NewCompatible(openaiProvider.CompatibleConfig{
+		APIKeyEnvVar:   "", // Gateway uses its own key resolution.
+		BaseURLEnvVar:  "", // Already resolved above.
+		Capabilities:   capabilities(),
+		DefaultAPIKey:  defaultNonPlatformKey, // Placeholder; non-platform doesn't need real auth.
+		DefaultBaseURL: "",                    // No default; base URL is required.
+		Name:           providerName,
+		RequireAPIKey:  false, // Gateway handles auth separately.
+	}, compatOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Provider{
+		CompatibleProvider: base,
+		platformMode:       platformMode,
+	}, nil
 }
 
 // WithGatewayKey sets the gateway API key for non-platform mode authentication.
-// The key is sent as a Bearer-formatted value in the X-AnyLLM-Key header
+// The key is sent as a Bearer-formatted value in the gatewayHeader header
 // (i.e., "X-AnyLLM-Key: Bearer <key>").
 func WithGatewayKey(key string) config.Option {
-	return config.WithExtra("gateway_key", key)
+	return config.WithExtra(extraKeyGatewayKey, key)
 }
 
 // WithPlatformMode explicitly enables platform mode authentication.
 // In platform mode, the token (from config.WithAPIKey or GATEWAY_PLATFORM_TOKEN)
 // is used as standard Bearer authentication.
 func WithPlatformMode() config.Option {
-	return config.WithExtra("platform_mode", true)
-}
-
-// ConvertError extends the base OpenAI error conversion with gateway-specific
-// HTTP status codes (402, 502, 504). This method handles raw (unconverted)
-// errors and implements the providers.ErrorConverter interface.
-func (p *Provider) ConvertError(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	var apiErr *openai.Error
-	if stderrors.As(err, &apiErr) {
-		if converted := convertGatewayError(apiErr); converted != nil {
-			return converted
-		}
-	}
-
-	return p.CompatibleProvider.ConvertError(err)
+	return config.WithExtra(extraKeyPlatformMode, true)
 }
 
 // Completion performs a chat completion request.
@@ -124,7 +161,7 @@ func (p *Provider) Completion(
 ) (*providers.ChatCompletion, error) {
 	resp, err := p.CompatibleProvider.Completion(ctx, params)
 	if err != nil {
-		return nil, p.reclassifyError(err)
+		return nil, p.ConvertError(err)
 	}
 
 	return resp, nil
@@ -149,16 +186,50 @@ func (p *Provider) CompletionStream(
 			select {
 			case chunks <- chunk:
 			case <-ctx.Done():
+				errs <- ctx.Err()
 				return
 			}
 		}
 
 		if err := <-upstreamErrs; err != nil {
-			errs <- p.reclassifyError(err)
+			errs <- p.ConvertError(err)
 		}
 	}()
 
 	return chunks, errs
+}
+
+// ConvertError converts errors to gateway-specific typed errors where
+// applicable, falling back to the base OpenAI error conversion for raw
+// errors. Already-converted errors (containing a BaseError) are not
+// double-wrapped.
+func (p *Provider) ConvertError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// Check for gateway-specific HTTP status codes.
+	var apiErr *openai.Error
+	if stderrors.As(err, &apiErr) {
+		switch apiErr.StatusCode {
+		case http.StatusPaymentRequired:
+			return errors.NewInsufficientFundsError(providerName, apiErr)
+		case http.StatusBadGateway:
+			return errors.NewUpstreamProviderError(providerName, apiErr)
+		case http.StatusGatewayTimeout:
+			return errors.NewGatewayTimeoutError(providerName, apiErr)
+		}
+	}
+
+	// If the error was already converted (has a BaseError), return as-is
+	// to avoid double-wrapping.
+	var baseErr *errors.BaseError
+	if stderrors.As(err, &baseErr) {
+		return err
+	}
+
+	// Raw error: delegate to base OpenAI error conversion.
+	return p.CompatibleProvider.ConvertError(err)
 }
 
 // Embedding generates embeddings for the given input.
@@ -169,7 +240,7 @@ func (p *Provider) Embedding(
 ) (*providers.EmbeddingResponse, error) {
 	resp, err := p.CompatibleProvider.Embedding(ctx, params)
 	if err != nil {
-		return nil, p.reclassifyError(err)
+		return nil, p.ConvertError(err)
 	}
 
 	return resp, nil
@@ -180,153 +251,52 @@ func (p *Provider) Embedding(
 func (p *Provider) ListModels(ctx context.Context) (*providers.ModelsResponse, error) {
 	resp, err := p.CompatibleProvider.ListModels(ctx)
 	if err != nil {
-		return nil, p.reclassifyError(err)
+		return nil, p.ConvertError(err)
 	}
 
 	return resp, nil
 }
 
-// reclassifyError checks if an already-converted error originated from a
-// gateway-specific HTTP status code and re-classifies it. Non-gateway errors
-// pass through unchanged, avoiding double-wrapping of errors that were
-// already converted by CompatibleProvider.ConvertError.
-func (p *Provider) reclassifyError(err error) error {
-	var apiErr *openai.Error
-	if stderrors.As(err, &apiErr) {
-		if converted := convertGatewayError(apiErr); converted != nil {
-			return converted
-		}
-	}
-
-	return err
-}
-
-// headerTransport wraps an http.RoundTripper to inject custom headers into
-// every request. Used in non-platform mode to add the X-AnyLLM-Key header.
-type headerTransport struct {
-	base   http.RoundTripper
-	header string
-	value  string
-}
-
-func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	clone := req.Clone(req.Context())
-	clone.Header.Set(t.header, t.value)
-	return t.base.RoundTrip(clone)
-}
-
-// convertGatewayError converts gateway-specific HTTP status codes to typed
-// errors. The apiErr is wrapped directly to avoid double-wrapping when the
-// error has already been converted by the base provider. Returns nil if the
-// status code is not gateway-specific, allowing the caller to fall through.
-func convertGatewayError(apiErr *openai.Error) error {
-	switch apiErr.StatusCode {
-	case http.StatusPaymentRequired:
-		return errors.NewInsufficientFundsError(providerName, apiErr)
-	case http.StatusBadGateway:
-		return errors.NewUpstreamProviderError(providerName, apiErr)
-	case http.StatusGatewayTimeout:
-		return errors.NewGatewayTimeoutError(providerName, apiErr)
-	default:
-		return nil
+// capabilities returns the full set of capabilities for the gateway provider.
+// Since the gateway proxies to any backend provider, all features are
+// optimistically marked as supported. Actual support depends on the
+// underlying provider behind the gateway; consumers should handle
+// unsupported-operation errors at call time.
+func capabilities() providers.Capabilities {
+	return providers.Capabilities{
+		Completion:          true,
+		CompletionImage:     true,
+		CompletionPDF:       true,
+		CompletionReasoning: true,
+		CompletionStreaming: true,
+		CompletionTools:     true,
+		Embedding:           true,
+		ListModels:          true,
 	}
 }
 
-// newNonPlatformProvider creates a gateway provider in non-platform mode.
-// The gateway API key is sent via the X-AnyLLM-Key header.
-func newNonPlatformProvider(cfg *config.Config, baseURL string) (*Provider, error) {
-	gatewayKey := resolveGatewayKey(cfg)
-
-	compatOpts := forwardConfigOptions(cfg, baseURL)
-
-	if gatewayKey != "" {
-		baseClient := cfg.HTTPClient()
-		baseTransport := baseClient.Transport
-		if baseTransport == nil {
-			baseTransport = http.DefaultTransport
-		}
-
-		httpClient := &http.Client{
-			Timeout: baseClient.Timeout,
-			Transport: &headerTransport{
-				base:   baseTransport,
-				header: gatewayHeader,
-				value:  "Bearer " + gatewayKey,
-			},
-		}
-		compatOpts = append(compatOpts, config.WithHTTPClient(httpClient))
+// newHeaderClient wraps the given HTTP client's transport to inject the
+// gatewayHeader header into every request, preserving the base client's
+// timeout and transport settings.
+func newHeaderClient(base *http.Client, headerValue string) *http.Client {
+	transport := base.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
 	}
-
-	base, err := openaiProvider.NewCompatible(openaiProvider.CompatibleConfig{
-		APIKeyEnvVar:   "",
-		BaseURLEnvVar:  "",
-		Capabilities:   capabilities(),
-		DefaultAPIKey:  "gateway-no-key",
-		DefaultBaseURL: "",
-		Name:           providerName,
-		RequireAPIKey:  false,
-	}, compatOpts...)
-	if err != nil {
-		return nil, err
+	return &http.Client{
+		Timeout: base.Timeout,
+		Transport: &headerTransport{
+			base:   transport,
+			header: gatewayHeader,
+			value:  headerValue,
+		},
 	}
-
-	return &Provider{
-		CompatibleProvider: base,
-		platformMode:       false,
-	}, nil
-}
-
-// newPlatformProvider creates a gateway provider in platform mode.
-// The platform token is used as standard Bearer authentication via the
-// OpenAI SDK's api_key mechanism.
-func newPlatformProvider(cfg *config.Config, baseURL, token string) (*Provider, error) {
-	if token == "" {
-		return nil, fmt.Errorf(
-			"platform mode requires a token (pass WithAPIKey option or set %s env var)",
-			envPlatformToken,
-		)
-	}
-
-	compatOpts := forwardConfigOptions(cfg, baseURL)
-	compatOpts = append(compatOpts, config.WithAPIKey(token))
-
-	base, err := openaiProvider.NewCompatible(openaiProvider.CompatibleConfig{
-		APIKeyEnvVar:   "",
-		BaseURLEnvVar:  "",
-		Capabilities:   capabilities(),
-		DefaultAPIKey:  "",
-		DefaultBaseURL: "",
-		Name:           providerName,
-		RequireAPIKey:  false,
-	}, compatOpts...)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Provider{
-		CompatibleProvider: base,
-		platformMode:       true,
-	}, nil
-}
-
-// forwardConfigOptions builds a slice of config options that forwards
-// user-supplied settings (base URL, timeout, HTTP client) to the underlying
-// CompatibleProvider. This ensures settings like WithTimeout and
-// WithHTTPClient are not silently dropped.
-func forwardConfigOptions(cfg *config.Config, baseURL string) []config.Option {
-	opts := []config.Option{config.WithBaseURL(baseURL)}
-
-	if cfg.Timeout > 0 {
-		opts = append(opts, config.WithTimeout(cfg.Timeout))
-	}
-
-	return opts
 }
 
 // resolveGatewayKey resolves the gateway API key from config extras or
-// environment variable.
+// the GATEWAY_API_KEY environment variable.
 func resolveGatewayKey(cfg *config.Config) string {
-	if v, ok := cfg.ExtraValue("gateway_key"); ok {
+	if v, ok := cfg.ExtraValue(extraKeyGatewayKey); ok {
 		if key, ok := v.(string); ok && key != "" {
 			return key
 		}
@@ -339,7 +309,7 @@ func resolveGatewayKey(cfg *config.Config) string {
 // returns the platform token if applicable.
 func resolvePlatformMode(cfg *config.Config) (platformMode bool, token string) {
 	// Explicit opt-in via WithPlatformMode().
-	if v, ok := cfg.ExtraValue("platform_mode"); ok {
+	if v, ok := cfg.ExtraValue(extraKeyPlatformMode); ok {
 		if enabled, ok := v.(bool); ok && enabled {
 			token = cfg.APIKey
 			if token == "" {
@@ -359,20 +329,4 @@ func resolvePlatformMode(cfg *config.Config) (platformMode bool, token string) {
 	}
 
 	return false, ""
-}
-
-// capabilities returns the full set of capabilities for the gateway provider.
-// The gateway can proxy to any provider, so all features are marked as
-// supported. Actual support depends on the underlying provider being called.
-func capabilities() providers.Capabilities {
-	return providers.Capabilities{
-		Completion:          true,
-		CompletionImage:     true,
-		CompletionPDF:       true,
-		CompletionReasoning: true,
-		CompletionStreaming: true,
-		CompletionTools:     true,
-		Embedding:           true,
-		ListModels:          true,
-	}
 }

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -2,9 +2,14 @@
 // It connects to an any-llm gateway server, which proxies requests to
 // underlying LLM providers.
 //
+// This package supersedes providers/platform. Where the platform provider
+// decrypts provider keys client-side and fans out to individual provider
+// SDKs, the gateway delegates everything to a single server-side endpoint.
+//
 // The gateway supports two authentication modes:
 //   - Platform mode: uses a platform token as standard Bearer auth
-//   - Non-platform mode: sends a gateway API key via the gatewayHeader header
+//   - Non-platform mode: sends a gateway API key via a custom authentication
+//     header (X-AnyLLM-Key)
 package gateway
 
 import (
@@ -34,6 +39,18 @@ const (
 	providerName          = "gateway"
 )
 
+// Gateway-specific error codes.
+const (
+	codeGatewayTimeout   = "gateway_timeout"
+	codeUpstreamProvider = "upstream_provider"
+)
+
+// Gateway-specific sentinel errors for type checking with errors.Is().
+var (
+	ErrGatewayTimeout   = stderrors.New("gateway timeout")
+	ErrUpstreamProvider = stderrors.New("upstream provider error")
+)
+
 // Ensure Provider implements the required interfaces.
 var (
 	_ providers.CapabilityProvider = (*Provider)(nil)
@@ -52,11 +69,23 @@ type Provider struct {
 }
 
 // headerTransport wraps an http.RoundTripper to inject custom headers into
-// every request. Used in non-platform mode to add the gateway key header.
+// every request. Used in non-platform mode to add the gateway authentication
+// header.
 type headerTransport struct {
 	base   http.RoundTripper
 	header string
 	value  string
+}
+
+// GatewayTimeoutError is returned when the gateway times out (HTTP 504).
+type GatewayTimeoutError struct {
+	errors.BaseError
+}
+
+// UpstreamProviderError is returned when the upstream provider is
+// unreachable (HTTP 502).
+type UpstreamProviderError struct {
+	errors.BaseError
 }
 
 // RoundTrip implements http.RoundTripper by cloning the request and injecting
@@ -75,16 +104,18 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 // Authentication mode is determined as follows:
 //   - If WithPlatformMode() is passed, platform mode is used. The token is
 //     resolved from config.WithAPIKey() or GATEWAY_PLATFORM_TOKEN.
-//   - If GATEWAY_PLATFORM_TOKEN is set and no explicit API key is provided,
-//     platform mode is auto-detected.
+//   - If GATEWAY_PLATFORM_TOKEN is set and no explicit API key or gateway key
+//     is provided, platform mode is auto-detected.
 //   - Otherwise, non-platform mode is used with the key from WithGatewayKey()
-//     or GATEWAY_API_KEY, sent via the gatewayHeader header.
+//     or GATEWAY_API_KEY, sent via the gateway authentication header.
 func New(opts ...config.Option) (*Provider, error) {
 	cfg, err := config.New(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("invalid options: %w", err)
 	}
 
+	// Validate that a base URL is provided (gateway requires it).
+	// Resolution itself is delegated to NewCompatible via BaseURLEnvVar.
 	baseURL, err := cfg.ResolveBaseURL(envAPIBase, "")
 	if err != nil {
 		return nil, err
@@ -95,7 +126,42 @@ func New(opts ...config.Option) (*Provider, error) {
 		)
 	}
 
-	platformMode, platformToken := resolvePlatformMode(cfg)
+	// Resolve gateway key from extras or GATEWAY_API_KEY env var.
+	var gatewayKey string
+	if v, ok := cfg.ExtraValue(extraKeyGatewayKey); ok {
+		if key, ok := v.(string); ok && key != "" {
+			gatewayKey = key
+		}
+	}
+	if gatewayKey == "" {
+		gatewayKey = cfg.ResolveEnv(envAPIKey)
+	}
+
+	// Determine authentication mode.
+	platformMode := false
+	var platformToken string
+
+	// Explicit opt-in via WithPlatformMode().
+	if v, ok := cfg.ExtraValue(extraKeyPlatformMode); ok {
+		if enabled, ok := v.(bool); ok && enabled {
+			platformMode = true
+			platformToken = cfg.APIKey
+			if platformToken == "" {
+				platformToken = cfg.ResolveEnv(envPlatformToken)
+			}
+		}
+	}
+
+	// Auto-detect: GATEWAY_PLATFORM_TOKEN set and no explicit API key or
+	// gateway key configured. A gateway key signals non-platform intent.
+	if !platformMode {
+		envToken := cfg.ResolveEnv(envPlatformToken)
+		if envToken != "" && cfg.APIKey == "" && gatewayKey == "" {
+			platformMode = true
+			platformToken = envToken
+		}
+	}
+
 	if platformMode && platformToken == "" {
 		return nil, fmt.Errorf(
 			"platform mode requires a token (pass WithAPIKey option or set %s env var)",
@@ -112,17 +178,14 @@ func New(opts ...config.Option) (*Provider, error) {
 	httpClient := cfg.HTTPClient()
 	if platformMode {
 		compatOpts = append(compatOpts, config.WithAPIKey(platformToken))
-	} else {
-		gatewayKey := resolveGatewayKey(cfg)
-		if gatewayKey != "" {
-			httpClient = newHeaderClient(httpClient, bearerPrefix+gatewayKey)
-		}
+	} else if gatewayKey != "" {
+		httpClient = newHeaderClient(httpClient, bearerPrefix+gatewayKey)
 	}
 	compatOpts = append(compatOpts, config.WithHTTPClient(httpClient))
 
 	base, err := openaiProvider.NewCompatible(openaiProvider.CompatibleConfig{
-		APIKeyEnvVar:   "", // Gateway uses its own key resolution.
-		BaseURLEnvVar:  "", // Already resolved above.
+		APIKeyEnvVar:   "",         // Gateway uses its own key resolution.
+		BaseURLEnvVar:  envAPIBase, // Env var for base URL resolution.
 		Capabilities:   capabilities(),
 		DefaultAPIKey:  defaultNonPlatformKey, // Placeholder; non-platform doesn't need real auth.
 		DefaultBaseURL: "",                    // No default; base URL is required.
@@ -140,8 +203,8 @@ func New(opts ...config.Option) (*Provider, error) {
 }
 
 // WithGatewayKey sets the gateway API key for non-platform mode authentication.
-// The key is sent as a Bearer-formatted value in the gatewayHeader header
-// (i.e., "X-AnyLLM-Key: Bearer <key>").
+// The key is sent as a Bearer-formatted value in the gateway authentication
+// header (X-AnyLLM-Key).
 func WithGatewayKey(key string) config.Option {
 	return config.WithExtra(extraKeyGatewayKey, key)
 }
@@ -215,9 +278,9 @@ func (p *Provider) ConvertError(err error) error {
 		case http.StatusPaymentRequired:
 			return errors.NewInsufficientFundsError(providerName, apiErr)
 		case http.StatusBadGateway:
-			return errors.NewUpstreamProviderError(providerName, apiErr)
+			return newUpstreamProviderError(providerName, apiErr)
 		case http.StatusGatewayTimeout:
-			return errors.NewGatewayTimeoutError(providerName, apiErr)
+			return newGatewayTimeoutError(providerName, apiErr)
 		}
 	}
 
@@ -275,9 +338,16 @@ func capabilities() providers.Capabilities {
 	}
 }
 
+// newGatewayTimeoutError creates a new GatewayTimeoutError.
+func newGatewayTimeoutError(provider string, err error) *GatewayTimeoutError {
+	return &GatewayTimeoutError{
+		BaseError: errors.NewBaseError(codeGatewayTimeout, provider, err, ErrGatewayTimeout),
+	}
+}
+
 // newHeaderClient wraps the given HTTP client's transport to inject the
-// gatewayHeader header into every request, preserving the base client's
-// timeout and transport settings.
+// gateway authentication header into every request, preserving the base
+// client's timeout and transport settings.
 func newHeaderClient(base *http.Client, headerValue string) *http.Client {
 	transport := base.Transport
 	if transport == nil {
@@ -293,40 +363,9 @@ func newHeaderClient(base *http.Client, headerValue string) *http.Client {
 	}
 }
 
-// resolveGatewayKey resolves the gateway API key from config extras or
-// the GATEWAY_API_KEY environment variable.
-func resolveGatewayKey(cfg *config.Config) string {
-	if v, ok := cfg.ExtraValue(extraKeyGatewayKey); ok {
-		if key, ok := v.(string); ok && key != "" {
-			return key
-		}
+// newUpstreamProviderError creates a new UpstreamProviderError.
+func newUpstreamProviderError(provider string, err error) *UpstreamProviderError {
+	return &UpstreamProviderError{
+		BaseError: errors.NewBaseError(codeUpstreamProvider, provider, err, ErrUpstreamProvider),
 	}
-
-	return cfg.ResolveEnv(envAPIKey)
-}
-
-// resolvePlatformMode determines whether platform mode should be used and
-// returns the platform token if applicable.
-func resolvePlatformMode(cfg *config.Config) (platformMode bool, token string) {
-	// Explicit opt-in via WithPlatformMode().
-	if v, ok := cfg.ExtraValue(extraKeyPlatformMode); ok {
-		if enabled, ok := v.(bool); ok && enabled {
-			token = cfg.APIKey
-			if token == "" {
-				token = cfg.ResolveEnv(envPlatformToken)
-			}
-			return true, token
-		}
-	}
-
-	// Auto-detect: GATEWAY_PLATFORM_TOKEN set and no explicit API key or
-	// gateway key. If a gateway key is configured, the caller intends
-	// non-platform mode even when a platform token is present in the env.
-	platformToken := cfg.ResolveEnv(envPlatformToken)
-	gatewayKey := resolveGatewayKey(cfg)
-	if platformToken != "" && cfg.APIKey == "" && gatewayKey == "" {
-		return true, platformToken
-	}
-
-	return false, ""
 }

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -325,11 +325,11 @@ func (p *Provider) ConvertError(err error) error {
 			return errors.NewInsufficientFundsError(providerName, apiErr)
 		case http.StatusBadGateway:
 			return &UpstreamProviderError{
-				BaseError: errors.NewBaseError(errCodeUpstreamProvider, providerName, apiErr, ErrUpstreamProvider),
+				BaseError: errors.New(errCodeUpstreamProvider, providerName, apiErr, ErrUpstreamProvider),
 			}
 		case http.StatusGatewayTimeout:
 			return &TimeoutError{
-				BaseError: errors.NewBaseError(errCodeTimeout, providerName, apiErr, ErrTimeout),
+				BaseError: errors.New(errCodeTimeout, providerName, apiErr, ErrTimeout),
 			}
 		}
 	}

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -17,6 +17,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"net/http"
+	"slices"
 
 	"github.com/openai/openai-go"
 
@@ -28,26 +29,63 @@ import (
 
 // Provider configuration constants.
 const (
-	bearerPrefix          = "Bearer "
-	defaultNonPlatformKey = "gateway-no-key"
-	envAPIBase            = "GATEWAY_API_BASE"
-	envAPIKey             = "GATEWAY_API_KEY"
-	envPlatformToken      = "GATEWAY_PLATFORM_TOKEN"
-	extraKeyGatewayKey    = "gateway_key"
-	extraKeyPlatformMode  = "platform_mode"
-	gatewayHeader         = "X-AnyLLM-Key"
-	providerName          = "gateway"
+	// apiKeyHeaderName is the HTTP header that carries the gateway API key in
+	// non-platform mode.
+	apiKeyHeaderName = "X-AnyLLM-Key"
+
+	// bearerPrefix is the Authorization scheme prefix applied to the gateway
+	// key before it is placed in the gateway header (e.g. "Bearer <key>").
+	bearerPrefix = "Bearer "
+
+	// placeholderAPIKey satisfies the OpenAI SDK's requirement that an API key
+	// be set. The SDK still sends it in the Authorization header, but in
+	// non-platform mode real auth is carried by the gateway header, so this
+	// is a non-secret placeholder that the gateway ignores.
+	placeholderAPIKey = "gateway-no-key"
+
+	// envAPIBase is the environment variable read for the gateway base URL
+	// when WithBaseURL is not passed to New.
+	envAPIBase = "GATEWAY_API_BASE"
+
+	// envAPIKey is the environment variable read for the gateway API key used
+	// in non-platform mode when WithGatewayKey is not passed to New.
+	envAPIKey = "GATEWAY_API_KEY"
+
+	// envPlatformToken is the environment variable read for the platform
+	// token used as Bearer auth in platform mode.
+	envPlatformToken = "GATEWAY_PLATFORM_TOKEN"
+
+	// extraKeyGatewayKey is the config.Extra key used to coordinate
+	// WithGatewayKey (writer) with the resolver logic in New (reader).
+	extraKeyGatewayKey = "gateway_key"
+
+	// extraKeyPlatformMode is the config.Extra key used to coordinate
+	// WithPlatformMode (writer) with the resolver logic in New (reader).
+	extraKeyPlatformMode = "platform_mode"
+
+	// providerName is the value returned by Provider.Name and embedded in
+	// errors produced by this package.
+	providerName = "gateway"
 )
 
 // Gateway-specific error codes.
 const (
-	codeGatewayTimeout   = "gateway_timeout"
-	codeUpstreamProvider = "upstream_provider"
+	// errCodeTimeout is the BaseError.Code set on gateway timeout errors
+	// (HTTP 504).
+	errCodeTimeout = "gateway_timeout"
+
+	// errCodeUpstreamProvider is the BaseError.Code set on upstream provider
+	// errors (HTTP 502).
+	errCodeUpstreamProvider = "upstream_provider"
 )
 
 // Gateway-specific sentinel errors for type checking with errors.Is().
 var (
-	ErrGatewayTimeout   = stderrors.New("gateway timeout")
+	// ErrTimeout is matched by errors.Is on gateway timeout errors (HTTP 504).
+	ErrTimeout = stderrors.New("gateway timeout")
+
+	// ErrUpstreamProvider is matched by errors.Is on upstream provider errors
+	// (HTTP 502).
 	ErrUpstreamProvider = stderrors.New("upstream provider error")
 )
 
@@ -60,11 +98,27 @@ var (
 	_ providers.Provider           = (*Provider)(nil)
 )
 
+// TimeoutError is returned when the gateway times out (HTTP 504).
+type TimeoutError struct {
+	errors.BaseError
+}
+
+// UpstreamProviderError is returned when the upstream provider is
+// unreachable (HTTP 502).
+type UpstreamProviderError struct {
+	errors.BaseError
+}
+
 // Provider implements the providers.Provider interface for the any-llm gateway.
 // It embeds openai.CompatibleProvider since the gateway exposes an
 // OpenAI-compatible API.
 type Provider struct {
 	*openaiProvider.CompatibleProvider
+
+	// platformMode is used to indicate whether the provider is operating in
+	// platform mode (using platform token for Bearer auth) or non-platform mode
+	// (using gateway key in custom header).
+	// This affects how authentication is handled and how errors are converted.
 	platformMode bool
 }
 
@@ -75,25 +129,6 @@ type headerTransport struct {
 	base   http.RoundTripper
 	header string
 	value  string
-}
-
-// GatewayTimeoutError is returned when the gateway times out (HTTP 504).
-type GatewayTimeoutError struct {
-	errors.BaseError
-}
-
-// UpstreamProviderError is returned when the upstream provider is
-// unreachable (HTTP 502).
-type UpstreamProviderError struct {
-	errors.BaseError
-}
-
-// RoundTrip implements http.RoundTripper by cloning the request and injecting
-// the configured header before delegating to the base transport.
-func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	clone := req.Clone(req.Context())
-	clone.Header.Set(t.header, t.value)
-	return t.base.RoundTrip(clone)
 }
 
 // New creates a new gateway provider.
@@ -112,18 +147,6 @@ func New(opts ...config.Option) (*Provider, error) {
 	cfg, err := config.New(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("invalid options: %w", err)
-	}
-
-	// Validate that a base URL is provided (gateway requires it).
-	// Resolution itself is delegated to NewCompatible via BaseURLEnvVar.
-	baseURL, err := cfg.ResolveBaseURL(envAPIBase, "")
-	if err != nil {
-		return nil, err
-	}
-	if baseURL == "" {
-		return nil, fmt.Errorf(
-			"gateway base URL is required (set via WithBaseURL option or %s env var)", envAPIBase,
-		)
 	}
 
 	// Resolve gateway key from extras or GATEWAY_API_KEY env var.
@@ -169,28 +192,33 @@ func New(opts ...config.Option) (*Provider, error) {
 		)
 	}
 
-	// Build options for the underlying OpenAI-compatible provider.
-	compatOpts := []config.Option{config.WithBaseURL(baseURL)}
-	if cfg.Timeout > 0 {
-		compatOpts = append(compatOpts, config.WithTimeout(cfg.Timeout))
-	}
-
-	httpClient := cfg.HTTPClient()
+	// Pass the user's opts straight through and layer auth-specific opts on
+	// top (order matters: later options win). Base URL resolution and the
+	// required-URL check are delegated to NewCompatible via BaseURLEnvVar
+	// and RequireBaseURL.
+	compatOpts := slices.Clone(opts)
 	if platformMode {
 		compatOpts = append(compatOpts, config.WithAPIKey(platformToken))
-	} else if gatewayKey != "" {
-		httpClient = newHeaderClient(httpClient, bearerPrefix+gatewayKey)
+	} else {
+		// Non-platform mode: override any user-supplied API key with the
+		// placeholder so secrets can't leak via the Authorization header.
+		// Real auth, if any, is carried by the gateway header below.
+		compatOpts = append(compatOpts, config.WithAPIKey(placeholderAPIKey))
+		if gatewayKey != "" {
+			client := newHeaderClient(cfg.HTTPClient(), bearerPrefix+gatewayKey)
+			compatOpts = append(compatOpts, config.WithHTTPClient(client))
+		}
 	}
-	compatOpts = append(compatOpts, config.WithHTTPClient(httpClient))
 
 	base, err := openaiProvider.NewCompatible(openaiProvider.CompatibleConfig{
 		APIKeyEnvVar:   "",         // Gateway uses its own key resolution.
 		BaseURLEnvVar:  envAPIBase, // Env var for base URL resolution.
 		Capabilities:   capabilities(),
-		DefaultAPIKey:  defaultNonPlatformKey, // Placeholder; non-platform doesn't need real auth.
-		DefaultBaseURL: "",                    // No default; base URL is required.
+		DefaultAPIKey:  placeholderAPIKey, // Placeholder; non-platform doesn't need real auth.
+		DefaultBaseURL: "",                // No default; base URL is required.
 		Name:           providerName,
 		RequireAPIKey:  false, // Gateway handles auth separately.
+		RequireBaseURL: true,  // Gateway has no sensible default endpoint.
 	}, compatOpts...)
 	if err != nil {
 		return nil, err
@@ -200,6 +228,24 @@ func New(opts ...config.Option) (*Provider, error) {
 		CompatibleProvider: base,
 		platformMode:       platformMode,
 	}, nil
+}
+
+// capabilities returns the full set of capabilities for the gateway provider.
+// Since the gateway proxies to any backend provider, all features are
+// optimistically marked as supported. Actual support depends on the
+// underlying provider behind the gateway; consumers should handle
+// unsupported-operation errors at call time.
+func capabilities() providers.Capabilities {
+	return providers.Capabilities{
+		Completion:          true,
+		CompletionImage:     true,
+		CompletionPDF:       true,
+		CompletionReasoning: true,
+		CompletionStreaming: true,
+		CompletionTools:     true,
+		Embedding:           true,
+		ListModels:          true,
+	}
 }
 
 // WithGatewayKey sets the gateway API key for non-platform mode authentication.
@@ -278,9 +324,13 @@ func (p *Provider) ConvertError(err error) error {
 		case http.StatusPaymentRequired:
 			return errors.NewInsufficientFundsError(providerName, apiErr)
 		case http.StatusBadGateway:
-			return newUpstreamProviderError(providerName, apiErr)
+			return &UpstreamProviderError{
+				BaseError: errors.NewBaseError(errCodeUpstreamProvider, providerName, apiErr, ErrUpstreamProvider),
+			}
 		case http.StatusGatewayTimeout:
-			return newGatewayTimeoutError(providerName, apiErr)
+			return &TimeoutError{
+				BaseError: errors.NewBaseError(errCodeTimeout, providerName, apiErr, ErrTimeout),
+			}
 		}
 	}
 
@@ -320,29 +370,12 @@ func (p *Provider) ListModels(ctx context.Context) (*providers.ModelsResponse, e
 	return resp, nil
 }
 
-// capabilities returns the full set of capabilities for the gateway provider.
-// Since the gateway proxies to any backend provider, all features are
-// optimistically marked as supported. Actual support depends on the
-// underlying provider behind the gateway; consumers should handle
-// unsupported-operation errors at call time.
-func capabilities() providers.Capabilities {
-	return providers.Capabilities{
-		Completion:          true,
-		CompletionImage:     true,
-		CompletionPDF:       true,
-		CompletionReasoning: true,
-		CompletionStreaming: true,
-		CompletionTools:     true,
-		Embedding:           true,
-		ListModels:          true,
-	}
-}
-
-// newGatewayTimeoutError creates a new GatewayTimeoutError.
-func newGatewayTimeoutError(provider string, err error) *GatewayTimeoutError {
-	return &GatewayTimeoutError{
-		BaseError: errors.NewBaseError(codeGatewayTimeout, provider, err, ErrGatewayTimeout),
-	}
+// RoundTrip implements http.RoundTripper by cloning the request and injecting
+// the configured header before delegating to the base transport.
+func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.Header.Set(t.header, t.value)
+	return t.base.RoundTrip(clone)
 }
 
 // newHeaderClient wraps the given HTTP client's transport to inject the
@@ -357,15 +390,8 @@ func newHeaderClient(base *http.Client, headerValue string) *http.Client {
 		Timeout: base.Timeout,
 		Transport: &headerTransport{
 			base:   transport,
-			header: gatewayHeader,
+			header: apiKeyHeaderName,
 			value:  headerValue,
 		},
-	}
-}
-
-// newUpstreamProviderError creates a new UpstreamProviderError.
-func newUpstreamProviderError(provider string, err error) *UpstreamProviderError {
-	return &UpstreamProviderError{
-		BaseError: errors.NewBaseError(codeUpstreamProvider, provider, err, ErrUpstreamProvider),
 	}
 }

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -85,7 +85,8 @@ func New(opts ...config.Option) (*Provider, error) {
 }
 
 // WithGatewayKey sets the gateway API key for non-platform mode authentication.
-// The key is sent via the X-AnyLLM-Key header.
+// The key is sent as a Bearer-formatted value in the X-AnyLLM-Key header
+// (i.e., "X-AnyLLM-Key: Bearer <key>").
 func WithGatewayKey(key string) config.Option {
 	return config.WithExtra("gateway_key", key)
 }
@@ -98,7 +99,8 @@ func WithPlatformMode() config.Option {
 }
 
 // ConvertError extends the base OpenAI error conversion with gateway-specific
-// HTTP status codes (402, 502, 504).
+// HTTP status codes (402, 502, 504). This method handles raw (unconverted)
+// errors and implements the providers.ErrorConverter interface.
 func (p *Provider) ConvertError(err error) error {
 	if err == nil {
 		return nil
@@ -106,7 +108,7 @@ func (p *Provider) ConvertError(err error) error {
 
 	var apiErr *openai.Error
 	if stderrors.As(err, &apiErr) {
-		if converted := convertGatewayError(apiErr, err); converted != nil {
+		if converted := convertGatewayError(apiErr); converted != nil {
 			return converted
 		}
 	}
@@ -115,29 +117,25 @@ func (p *Provider) ConvertError(err error) error {
 }
 
 // Completion performs a chat completion request.
-// In platform mode, gateway-specific errors are converted to typed errors.
+// Gateway-specific errors (402, 502, 504) are converted to typed errors.
 func (p *Provider) Completion(
 	ctx context.Context,
 	params providers.CompletionParams,
 ) (*providers.ChatCompletion, error) {
 	resp, err := p.CompatibleProvider.Completion(ctx, params)
-	if err != nil && p.platformMode {
-		return nil, p.ConvertError(err)
+	if err != nil {
+		return nil, p.reclassifyError(err)
 	}
 
-	return resp, err
+	return resp, nil
 }
 
 // CompletionStream performs a streaming chat completion request.
-// In platform mode, gateway-specific errors are converted to typed errors.
+// Gateway-specific errors (402, 502, 504) are converted to typed errors.
 func (p *Provider) CompletionStream(
 	ctx context.Context,
 	params providers.CompletionParams,
 ) (<-chan providers.ChatCompletionChunk, <-chan error) {
-	if !p.platformMode {
-		return p.CompatibleProvider.CompletionStream(ctx, params)
-	}
-
 	upstreamChunks, upstreamErrs := p.CompatibleProvider.CompletionStream(ctx, params)
 
 	chunks := make(chan providers.ChatCompletionChunk)
@@ -156,7 +154,7 @@ func (p *Provider) CompletionStream(
 		}
 
 		if err := <-upstreamErrs; err != nil {
-			errs <- p.ConvertError(err)
+			errs <- p.reclassifyError(err)
 		}
 	}()
 
@@ -164,28 +162,43 @@ func (p *Provider) CompletionStream(
 }
 
 // Embedding generates embeddings for the given input.
-// In platform mode, gateway-specific errors are converted to typed errors.
+// Gateway-specific errors (402, 502, 504) are converted to typed errors.
 func (p *Provider) Embedding(
 	ctx context.Context,
 	params providers.EmbeddingParams,
 ) (*providers.EmbeddingResponse, error) {
 	resp, err := p.CompatibleProvider.Embedding(ctx, params)
-	if err != nil && p.platformMode {
-		return nil, p.ConvertError(err)
+	if err != nil {
+		return nil, p.reclassifyError(err)
 	}
 
-	return resp, err
+	return resp, nil
 }
 
 // ListModels returns a list of available models from the gateway.
-// In platform mode, gateway-specific errors are converted to typed errors.
+// Gateway-specific errors (402, 502, 504) are converted to typed errors.
 func (p *Provider) ListModels(ctx context.Context) (*providers.ModelsResponse, error) {
 	resp, err := p.CompatibleProvider.ListModels(ctx)
-	if err != nil && p.platformMode {
-		return nil, p.ConvertError(err)
+	if err != nil {
+		return nil, p.reclassifyError(err)
 	}
 
-	return resp, err
+	return resp, nil
+}
+
+// reclassifyError checks if an already-converted error originated from a
+// gateway-specific HTTP status code and re-classifies it. Non-gateway errors
+// pass through unchanged, avoiding double-wrapping of errors that were
+// already converted by CompatibleProvider.ConvertError.
+func (p *Provider) reclassifyError(err error) error {
+	var apiErr *openai.Error
+	if stderrors.As(err, &apiErr) {
+		if converted := convertGatewayError(apiErr); converted != nil {
+			return converted
+		}
+	}
+
+	return err
 }
 
 // headerTransport wraps an http.RoundTripper to inject custom headers into
@@ -203,16 +216,17 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 // convertGatewayError converts gateway-specific HTTP status codes to typed
-// errors. Returns nil if the status code is not gateway-specific, allowing
-// the caller to fall through to the base error converter.
-func convertGatewayError(apiErr *openai.Error, originalErr error) error {
+// errors. The apiErr is wrapped directly to avoid double-wrapping when the
+// error has already been converted by the base provider. Returns nil if the
+// status code is not gateway-specific, allowing the caller to fall through.
+func convertGatewayError(apiErr *openai.Error) error {
 	switch apiErr.StatusCode {
 	case http.StatusPaymentRequired:
-		return errors.NewInsufficientFundsError(providerName, originalErr)
+		return errors.NewInsufficientFundsError(providerName, apiErr)
 	case http.StatusBadGateway:
-		return errors.NewUpstreamProviderError(providerName, originalErr)
+		return errors.NewUpstreamProviderError(providerName, apiErr)
 	case http.StatusGatewayTimeout:
-		return errors.NewGatewayTimeoutError(providerName, originalErr)
+		return errors.NewGatewayTimeoutError(providerName, apiErr)
 	default:
 		return nil
 	}
@@ -223,14 +237,19 @@ func convertGatewayError(apiErr *openai.Error, originalErr error) error {
 func newNonPlatformProvider(cfg *config.Config, baseURL string) (*Provider, error) {
 	gatewayKey := resolveGatewayKey(cfg)
 
-	var compatOpts []config.Option
-	compatOpts = append(compatOpts, config.WithBaseURL(baseURL))
+	compatOpts := forwardConfigOptions(cfg, baseURL)
 
 	if gatewayKey != "" {
+		baseClient := cfg.HTTPClient()
+		baseTransport := baseClient.Transport
+		if baseTransport == nil {
+			baseTransport = http.DefaultTransport
+		}
+
 		httpClient := &http.Client{
-			Timeout: cfg.Timeout,
+			Timeout: baseClient.Timeout,
 			Transport: &headerTransport{
-				base:   http.DefaultTransport,
+				base:   baseTransport,
 				header: gatewayHeader,
 				value:  "Bearer " + gatewayKey,
 			},
@@ -268,6 +287,9 @@ func newPlatformProvider(cfg *config.Config, baseURL, token string) (*Provider, 
 		)
 	}
 
+	compatOpts := forwardConfigOptions(cfg, baseURL)
+	compatOpts = append(compatOpts, config.WithAPIKey(token))
+
 	base, err := openaiProvider.NewCompatible(openaiProvider.CompatibleConfig{
 		APIKeyEnvVar:   "",
 		BaseURLEnvVar:  "",
@@ -276,7 +298,7 @@ func newPlatformProvider(cfg *config.Config, baseURL, token string) (*Provider, 
 		DefaultBaseURL: "",
 		Name:           providerName,
 		RequireAPIKey:  false,
-	}, config.WithAPIKey(token), config.WithBaseURL(baseURL))
+	}, compatOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -285,6 +307,20 @@ func newPlatformProvider(cfg *config.Config, baseURL, token string) (*Provider, 
 		CompatibleProvider: base,
 		platformMode:       true,
 	}, nil
+}
+
+// forwardConfigOptions builds a slice of config options that forwards
+// user-supplied settings (base URL, timeout, HTTP client) to the underlying
+// CompatibleProvider. This ensures settings like WithTimeout and
+// WithHTTPClient are not silently dropped.
+func forwardConfigOptions(cfg *config.Config, baseURL string) []config.Option {
+	opts := []config.Option{config.WithBaseURL(baseURL)}
+
+	if cfg.Timeout > 0 {
+		opts = append(opts, config.WithTimeout(cfg.Timeout))
+	}
+
+	return opts
 }
 
 // resolveGatewayKey resolves the gateway API key from config extras or
@@ -313,9 +349,12 @@ func resolvePlatformMode(cfg *config.Config) (platformMode bool, token string) {
 		}
 	}
 
-	// Auto-detect: GATEWAY_PLATFORM_TOKEN set and no explicit API key.
+	// Auto-detect: GATEWAY_PLATFORM_TOKEN set and no explicit API key or
+	// gateway key. If a gateway key is configured, the caller intends
+	// non-platform mode even when a platform token is present in the env.
 	platformToken := cfg.ResolveEnv(envPlatformToken)
-	if platformToken != "" && cfg.APIKey == "" {
+	gatewayKey := resolveGatewayKey(cfg)
+	if platformToken != "" && cfg.APIKey == "" && gatewayKey == "" {
 		return true, platformToken
 	}
 

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -1,0 +1,339 @@
+// Package gateway provides a gateway provider implementation for any-llm.
+// It connects to an any-llm gateway server, which proxies requests to
+// underlying LLM providers.
+//
+// The gateway supports two authentication modes:
+//   - Platform mode: uses a platform token as standard Bearer auth
+//   - Non-platform mode: sends a gateway API key via the X-AnyLLM-Key header
+package gateway
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+	"net/http"
+
+	"github.com/openai/openai-go"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	"github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
+	openaiProvider "github.com/mozilla-ai/any-llm-go/providers/openai"
+)
+
+// Provider configuration constants.
+const (
+	envAPIBase       = "GATEWAY_API_BASE"
+	envAPIKey        = "GATEWAY_API_KEY"
+	envPlatformToken = "GATEWAY_PLATFORM_TOKEN"
+	gatewayHeader    = "X-AnyLLM-Key"
+	providerName     = "gateway"
+)
+
+// Ensure Provider implements the required interfaces.
+var (
+	_ providers.CapabilityProvider = (*Provider)(nil)
+	_ providers.EmbeddingProvider  = (*Provider)(nil)
+	_ providers.ErrorConverter     = (*Provider)(nil)
+	_ providers.ModelLister        = (*Provider)(nil)
+	_ providers.Provider           = (*Provider)(nil)
+)
+
+// Provider implements the providers.Provider interface for the any-llm gateway.
+// It embeds openai.CompatibleProvider since the gateway exposes an
+// OpenAI-compatible API.
+type Provider struct {
+	*openaiProvider.CompatibleProvider
+	platformMode bool
+}
+
+// New creates a new gateway provider.
+//
+// The gateway base URL is required and can be set via config.WithBaseURL() or
+// the GATEWAY_API_BASE environment variable.
+//
+// Authentication mode is determined as follows:
+//   - If WithPlatformMode() is passed, platform mode is used. The token is
+//     resolved from config.WithAPIKey() or GATEWAY_PLATFORM_TOKEN.
+//   - If GATEWAY_PLATFORM_TOKEN is set and no explicit API key is provided,
+//     platform mode is auto-detected.
+//   - Otherwise, non-platform mode is used with the key from WithGatewayKey()
+//     or GATEWAY_API_KEY, sent via the X-AnyLLM-Key header.
+func New(opts ...config.Option) (*Provider, error) {
+	cfg, err := config.New(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("invalid options: %w", err)
+	}
+
+	baseURL, err := cfg.ResolveBaseURL(envAPIBase, "")
+	if err != nil {
+		return nil, err
+	}
+	if baseURL == "" {
+		return nil, fmt.Errorf(
+			"gateway base URL is required (set via WithBaseURL option or %s env var)", envAPIBase,
+		)
+	}
+
+	platformMode, platformToken := resolvePlatformMode(cfg)
+
+	if platformMode {
+		return newPlatformProvider(cfg, baseURL, platformToken)
+	}
+
+	return newNonPlatformProvider(cfg, baseURL)
+}
+
+// WithGatewayKey sets the gateway API key for non-platform mode authentication.
+// The key is sent via the X-AnyLLM-Key header.
+func WithGatewayKey(key string) config.Option {
+	return config.WithExtra("gateway_key", key)
+}
+
+// WithPlatformMode explicitly enables platform mode authentication.
+// In platform mode, the token (from config.WithAPIKey or GATEWAY_PLATFORM_TOKEN)
+// is used as standard Bearer authentication.
+func WithPlatformMode() config.Option {
+	return config.WithExtra("platform_mode", true)
+}
+
+// ConvertError extends the base OpenAI error conversion with gateway-specific
+// HTTP status codes (402, 502, 504).
+func (p *Provider) ConvertError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var apiErr *openai.Error
+	if stderrors.As(err, &apiErr) {
+		if converted := convertGatewayError(apiErr, err); converted != nil {
+			return converted
+		}
+	}
+
+	return p.CompatibleProvider.ConvertError(err)
+}
+
+// Completion performs a chat completion request.
+// In platform mode, gateway-specific errors are converted to typed errors.
+func (p *Provider) Completion(
+	ctx context.Context,
+	params providers.CompletionParams,
+) (*providers.ChatCompletion, error) {
+	resp, err := p.CompatibleProvider.Completion(ctx, params)
+	if err != nil && p.platformMode {
+		return nil, p.ConvertError(err)
+	}
+
+	return resp, err
+}
+
+// CompletionStream performs a streaming chat completion request.
+// In platform mode, gateway-specific errors are converted to typed errors.
+func (p *Provider) CompletionStream(
+	ctx context.Context,
+	params providers.CompletionParams,
+) (<-chan providers.ChatCompletionChunk, <-chan error) {
+	if !p.platformMode {
+		return p.CompatibleProvider.CompletionStream(ctx, params)
+	}
+
+	upstreamChunks, upstreamErrs := p.CompatibleProvider.CompletionStream(ctx, params)
+
+	chunks := make(chan providers.ChatCompletionChunk)
+	errs := make(chan error, 1)
+
+	go func() {
+		defer close(chunks)
+		defer close(errs)
+
+		for chunk := range upstreamChunks {
+			select {
+			case chunks <- chunk:
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		if err := <-upstreamErrs; err != nil {
+			errs <- p.ConvertError(err)
+		}
+	}()
+
+	return chunks, errs
+}
+
+// Embedding generates embeddings for the given input.
+// In platform mode, gateway-specific errors are converted to typed errors.
+func (p *Provider) Embedding(
+	ctx context.Context,
+	params providers.EmbeddingParams,
+) (*providers.EmbeddingResponse, error) {
+	resp, err := p.CompatibleProvider.Embedding(ctx, params)
+	if err != nil && p.platformMode {
+		return nil, p.ConvertError(err)
+	}
+
+	return resp, err
+}
+
+// ListModels returns a list of available models from the gateway.
+// In platform mode, gateway-specific errors are converted to typed errors.
+func (p *Provider) ListModels(ctx context.Context) (*providers.ModelsResponse, error) {
+	resp, err := p.CompatibleProvider.ListModels(ctx)
+	if err != nil && p.platformMode {
+		return nil, p.ConvertError(err)
+	}
+
+	return resp, err
+}
+
+// headerTransport wraps an http.RoundTripper to inject custom headers into
+// every request. Used in non-platform mode to add the X-AnyLLM-Key header.
+type headerTransport struct {
+	base   http.RoundTripper
+	header string
+	value  string
+}
+
+func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.Header.Set(t.header, t.value)
+	return t.base.RoundTrip(clone)
+}
+
+// convertGatewayError converts gateway-specific HTTP status codes to typed
+// errors. Returns nil if the status code is not gateway-specific, allowing
+// the caller to fall through to the base error converter.
+func convertGatewayError(apiErr *openai.Error, originalErr error) error {
+	switch apiErr.StatusCode {
+	case http.StatusPaymentRequired:
+		return errors.NewInsufficientFundsError(providerName, originalErr)
+	case http.StatusBadGateway:
+		return errors.NewUpstreamProviderError(providerName, originalErr)
+	case http.StatusGatewayTimeout:
+		return errors.NewGatewayTimeoutError(providerName, originalErr)
+	default:
+		return nil
+	}
+}
+
+// newNonPlatformProvider creates a gateway provider in non-platform mode.
+// The gateway API key is sent via the X-AnyLLM-Key header.
+func newNonPlatformProvider(cfg *config.Config, baseURL string) (*Provider, error) {
+	gatewayKey := resolveGatewayKey(cfg)
+
+	var compatOpts []config.Option
+	compatOpts = append(compatOpts, config.WithBaseURL(baseURL))
+
+	if gatewayKey != "" {
+		httpClient := &http.Client{
+			Timeout: cfg.Timeout,
+			Transport: &headerTransport{
+				base:   http.DefaultTransport,
+				header: gatewayHeader,
+				value:  "Bearer " + gatewayKey,
+			},
+		}
+		compatOpts = append(compatOpts, config.WithHTTPClient(httpClient))
+	}
+
+	base, err := openaiProvider.NewCompatible(openaiProvider.CompatibleConfig{
+		APIKeyEnvVar:   "",
+		BaseURLEnvVar:  "",
+		Capabilities:   capabilities(),
+		DefaultAPIKey:  "gateway-no-key",
+		DefaultBaseURL: "",
+		Name:           providerName,
+		RequireAPIKey:  false,
+	}, compatOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Provider{
+		CompatibleProvider: base,
+		platformMode:       false,
+	}, nil
+}
+
+// newPlatformProvider creates a gateway provider in platform mode.
+// The platform token is used as standard Bearer authentication via the
+// OpenAI SDK's api_key mechanism.
+func newPlatformProvider(cfg *config.Config, baseURL, token string) (*Provider, error) {
+	if token == "" {
+		return nil, fmt.Errorf(
+			"platform mode requires a token (pass WithAPIKey option or set %s env var)",
+			envPlatformToken,
+		)
+	}
+
+	base, err := openaiProvider.NewCompatible(openaiProvider.CompatibleConfig{
+		APIKeyEnvVar:   "",
+		BaseURLEnvVar:  "",
+		Capabilities:   capabilities(),
+		DefaultAPIKey:  "",
+		DefaultBaseURL: "",
+		Name:           providerName,
+		RequireAPIKey:  false,
+	}, config.WithAPIKey(token), config.WithBaseURL(baseURL))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Provider{
+		CompatibleProvider: base,
+		platformMode:       true,
+	}, nil
+}
+
+// resolveGatewayKey resolves the gateway API key from config extras or
+// environment variable.
+func resolveGatewayKey(cfg *config.Config) string {
+	if v, ok := cfg.ExtraValue("gateway_key"); ok {
+		if key, ok := v.(string); ok && key != "" {
+			return key
+		}
+	}
+
+	return cfg.ResolveEnv(envAPIKey)
+}
+
+// resolvePlatformMode determines whether platform mode should be used and
+// returns the platform token if applicable.
+func resolvePlatformMode(cfg *config.Config) (platformMode bool, token string) {
+	// Explicit opt-in via WithPlatformMode().
+	if v, ok := cfg.ExtraValue("platform_mode"); ok {
+		if enabled, ok := v.(bool); ok && enabled {
+			token = cfg.APIKey
+			if token == "" {
+				token = cfg.ResolveEnv(envPlatformToken)
+			}
+			return true, token
+		}
+	}
+
+	// Auto-detect: GATEWAY_PLATFORM_TOKEN set and no explicit API key.
+	platformToken := cfg.ResolveEnv(envPlatformToken)
+	if platformToken != "" && cfg.APIKey == "" {
+		return true, platformToken
+	}
+
+	return false, ""
+}
+
+// capabilities returns the full set of capabilities for the gateway provider.
+// The gateway can proxy to any provider, so all features are marked as
+// supported. Actual support depends on the underlying provider being called.
+func capabilities() providers.Capabilities {
+	return providers.Capabilities{
+		Completion:          true,
+		CompletionImage:     true,
+		CompletionPDF:       true,
+		CompletionReasoning: true,
+		CompletionStreaming: true,
+		CompletionTools:     true,
+		Embedding:           true,
+		ListModels:          true,
+	}
+}

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -24,7 +24,6 @@ import (
 const (
 	objectChatCompletion      = "chat.completion"
 	objectChatCompletionChunk = "chat.completion.chunk"
-	objectList                = "list"
 )
 
 func TestNew(t *testing.T) {
@@ -184,7 +183,7 @@ func TestNew(t *testing.T) {
 		require.NoError(t, err)
 
 		// Non-platform mode: gateway key sent via custom header.
-		require.Equal(t, bearerPrefix+"gw_key", capturedHeaders.Get(gatewayHeader))
+		require.Equal(t, bearerPrefix+"gw_key", capturedHeaders.Get(apiKeyHeaderName))
 		// Custom transport should have been used (wrapped by headerTransport).
 		require.True(t, customTransport.called, "custom transport should be used as base")
 	})
@@ -217,48 +216,165 @@ func TestCapabilities(t *testing.T) {
 }
 
 func TestPlatformModeDetection(t *testing.T) {
-	// Note: Not using t.Parallel() here because child tests use t.Setenv.
+	// Note: Not using t.Parallel() because subtests use t.Setenv.
 
-	t.Run("does not auto-detect when API key is explicitly set", func(t *testing.T) {
-		t.Setenv(envAPIBase, "http://localhost:8000/v1")
-		t.Setenv(envPlatformToken, "tk_auto")
+	tests := []struct {
+		name             string
+		envPlatformToken string
+		envAPIKey        string
+		apiKey           string
+		gatewayKey       string
+		wantPlatform     bool
+	}{
+		{
+			name:             "does not auto-detect when API key is explicitly set",
+			envPlatformToken: "tk_auto",
+			apiKey:           "explicit_key",
+			wantPlatform:     false,
+		},
+		{
+			name:             "does not auto-detect when gateway key is explicitly set",
+			envPlatformToken: "tk_auto",
+			gatewayKey:       "gw_key",
+			wantPlatform:     false,
+		},
+	}
 
-		provider, err := New(config.WithAPIKey("explicit_key"))
-		require.NoError(t, err)
-		require.False(t, provider.platformMode)
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envAPIBase, "http://localhost:8000/v1")
+			t.Setenv(envPlatformToken, tc.envPlatformToken)
+			t.Setenv(envAPIKey, tc.envAPIKey)
 
-	t.Run("does not auto-detect when gateway key is set", func(t *testing.T) {
-		t.Setenv(envAPIBase, "http://localhost:8000/v1")
-		t.Setenv(envPlatformToken, "tk_auto")
-		t.Setenv(envAPIKey, "")
+			var opts []config.Option
+			if tc.apiKey != "" {
+				opts = append(opts, config.WithAPIKey(tc.apiKey))
+			}
+			if tc.gatewayKey != "" {
+				opts = append(opts, WithGatewayKey(tc.gatewayKey))
+			}
 
-		provider, err := New(WithGatewayKey("gw_key"))
-		require.NoError(t, err)
-		require.False(t, provider.platformMode)
-	})
+			provider, err := New(opts...)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantPlatform, provider.platformMode)
+		})
+	}
+}
 
-	t.Run("ignores non-bool platform_mode extra value", func(t *testing.T) {
-		t.Setenv(envAPIBase, "http://localhost:8000/v1")
-		t.Setenv(envPlatformToken, "")
-		t.Setenv(envAPIKey, "")
+// TestExtraValueHandling verifies that the config.Extra mechanism correctly
+// ignores wrong-typed values (silent fallthrough) and honours valid ones.
+// Assertions are made on the wire to prove the mode actually took effect,
+// not just that the provider constructed without error.
+func TestExtraValueHandling(t *testing.T) {
+	// Note: Not using t.Parallel() because subtests use t.Setenv.
 
-		// Pass "true" as string instead of bool - should be ignored.
-		provider, err := New(config.WithExtra(extraKeyPlatformMode, "true"))
-		require.NoError(t, err)
-		require.False(t, provider.platformMode)
-	})
+	tests := []struct {
+		name              string
+		extraKey          string
+		extraValue        any
+		envAPIKey         string
+		apiKey            string
+		gatewayKey        string
+		wantAPIKeyHeader  string // expected X-AnyLLM-Key value; empty means the header must not be sent.
+		wantAuthorization string // expected Authorization value.
+	}{
+		{
+			name:              "string gateway_key is forwarded as the gateway key header",
+			extraKey:          extraKeyGatewayKey,
+			extraValue:        "valid_key",
+			wantAPIKeyHeader:  bearerPrefix + "valid_key",
+			wantAuthorization: bearerPrefix + placeholderAPIKey,
+		},
+		{
+			name:              "int gateway_key is silently ignored",
+			extraKey:          extraKeyGatewayKey,
+			extraValue:        123,
+			wantAPIKeyHeader:  "",
+			wantAuthorization: bearerPrefix + placeholderAPIKey,
+		},
+		{
+			name:              "empty-string gateway_key is treated as unset",
+			extraKey:          extraKeyGatewayKey,
+			extraValue:        "",
+			wantAPIKeyHeader:  "",
+			wantAuthorization: bearerPrefix + placeholderAPIKey,
+		},
+		{
+			name:              "empty-string gateway_key falls through to GATEWAY_API_KEY env var",
+			extraKey:          extraKeyGatewayKey,
+			extraValue:        "",
+			envAPIKey:         "env_fallback_key",
+			wantAPIKeyHeader:  bearerPrefix + "env_fallback_key",
+			wantAuthorization: bearerPrefix + placeholderAPIKey,
+		},
+		{
+			name:              "bool platform_mode enables platform-mode Bearer auth",
+			extraKey:          extraKeyPlatformMode,
+			extraValue:        true,
+			apiKey:            "platform_token",
+			wantAPIKeyHeader:  "",
+			wantAuthorization: bearerPrefix + "platform_token",
+		},
+		{
+			// Passing a string instead of bool must not flip into platform mode.
+			// Combining with a gateway key proves the non-platform path was
+			// taken: an honoured platform_mode would suppress the gateway
+			// header. WithAPIKey is also passed to verify it does NOT leak
+			// into Authorization in non-platform mode — the placeholder is
+			// used instead.
+			name:              "string platform_mode is silently ignored",
+			extraKey:          extraKeyPlatformMode,
+			extraValue:        "true",
+			apiKey:            "platform_token",
+			gatewayKey:        "gw_key",
+			wantAPIKeyHeader:  bearerPrefix + "gw_key",
+			wantAuthorization: bearerPrefix + placeholderAPIKey,
+		},
+	}
 
-	t.Run("ignores non-string gateway_key extra value", func(t *testing.T) {
-		t.Setenv(envAPIBase, "http://localhost:8000/v1")
-		t.Setenv(envPlatformToken, "")
-		t.Setenv(envAPIKey, "")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envAPIBase, "")
+			t.Setenv(envAPIKey, tc.envAPIKey)
+			t.Setenv(envPlatformToken, "")
 
-		// Pass 123 as int instead of string - should be ignored.
-		provider, err := New(config.WithExtra(extraKeyGatewayKey, 123))
-		require.NoError(t, err)
-		require.NotNil(t, provider)
-	})
+			var (
+				mu              sync.Mutex
+				capturedHeaders http.Header
+			)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				capturedHeaders = r.Header.Clone()
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(mockCompletionResponse("ok")))
+			}))
+			t.Cleanup(srv.Close)
+
+			opts := []config.Option{
+				config.WithBaseURL(srv.URL),
+				config.WithExtra(tc.extraKey, tc.extraValue),
+			}
+			if tc.apiKey != "" {
+				opts = append(opts, config.WithAPIKey(tc.apiKey))
+			}
+			if tc.gatewayKey != "" {
+				opts = append(opts, WithGatewayKey(tc.gatewayKey))
+			}
+
+			provider, err := New(opts...)
+			require.NoError(t, err)
+
+			_, err = provider.Completion(context.Background(), mockCompletionParams())
+			require.NoError(t, err)
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			require.Equal(t, tc.wantAPIKeyHeader, capturedHeaders.Get(apiKeyHeaderName))
+			require.Equal(t, tc.wantAuthorization, capturedHeaders.Get("Authorization"))
+		})
+	}
 }
 
 func TestHeaderTransport(t *testing.T) {
@@ -273,9 +389,9 @@ func TestHeaderTransport(t *testing.T) {
 	}{
 		{
 			name:       "injects gateway header",
-			header:     gatewayHeader,
+			header:     apiKeyHeaderName,
 			value:      bearerPrefix + "test-key",
-			wantHeader: gatewayHeader,
+			wantHeader: apiKeyHeaderName,
 			wantValue:  bearerPrefix + "test-key",
 		},
 		{
@@ -325,7 +441,7 @@ func TestHeaderTransport(t *testing.T) {
 
 		transport := &headerTransport{
 			base:   http.DefaultTransport,
-			header: gatewayHeader,
+			header: apiKeyHeaderName,
 			value:  bearerPrefix + "key",
 		}
 
@@ -337,7 +453,7 @@ func TestHeaderTransport(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 
 		// Original request should not have the injected header.
-		require.Empty(t, req.Header.Get(gatewayHeader))
+		require.Empty(t, req.Header.Get(apiKeyHeaderName))
 	})
 }
 
@@ -372,7 +488,7 @@ func TestNonPlatformModeSendsCustomHeader(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	require.Equal(t, bearerPrefix+"gw_test_key_123", capturedHeaders.Get(gatewayHeader))
+	require.Equal(t, bearerPrefix+"gw_test_key_123", capturedHeaders.Get(apiKeyHeaderName))
 }
 
 func TestPlatformModeSendsBearerAuth(t *testing.T) {
@@ -408,7 +524,7 @@ func TestPlatformModeSendsBearerAuth(t *testing.T) {
 	defer mu.Unlock()
 
 	require.Equal(t, bearerPrefix+"tk_platform_token", capturedHeaders.Get("Authorization"))
-	require.Empty(t, capturedHeaders.Get(gatewayHeader),
+	require.Empty(t, capturedHeaders.Get(apiKeyHeaderName),
 		"platform mode should not send gateway key header")
 }
 
@@ -503,7 +619,7 @@ func TestStreamingContextCancellation(t *testing.T) {
 		w.Header().Set("Content-Type", "text/event-stream")
 
 		// Send chunks slowly so context cancellation happens mid-stream.
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			chunk := fmt.Sprintf(
 				`{"id":"chatcmpl-gw","object":"chat.completion.chunk","created":1700000000,"model":"test-model","choices":[{"index":0,"delta":{"content":"chunk-%d"},"finish_reason":null}]}`,
 				i,
@@ -586,10 +702,10 @@ func TestConvertError(t *testing.T) {
 			wantErr:    ErrUpstreamProvider,
 		},
 		{
-			name:       "504 returns GatewayTimeoutError",
+			name:       "504 returns TimeoutError",
 			statusCode: http.StatusGatewayTimeout,
 			body:       `{"error": {"message": "gateway timeout", "type": "timeout", "code": "timeout"}}`,
-			wantErr:    ErrGatewayTimeout,
+			wantErr:    ErrTimeout,
 		},
 	}
 
@@ -645,7 +761,7 @@ func TestNonPlatformModeAlsoConvertsGatewayErrors(t *testing.T) {
 			name:       "504 in non-platform mode",
 			statusCode: http.StatusGatewayTimeout,
 			body:       `{"error": {"message": "gateway timeout", "type": "timeout", "code": "timeout"}}`,
-			wantErr:    ErrGatewayTimeout,
+			wantErr:    ErrTimeout,
 		},
 	}
 

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -115,6 +116,78 @@ func TestNew(t *testing.T) {
 		require.NotNil(t, provider)
 		require.False(t, provider.platformMode)
 	})
+
+	t.Run("forwards custom timeout to underlying provider", func(t *testing.T) {
+		t.Setenv(envAPIBase, "")
+		t.Setenv(envPlatformToken, "")
+
+		provider, err := New(
+			config.WithBaseURL("http://localhost:8000/v1"),
+			config.WithTimeout(30*time.Second),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+	})
+
+	t.Run("forwards custom HTTP client to platform mode provider", func(t *testing.T) {
+		t.Setenv(envAPIBase, "")
+		t.Setenv(envPlatformToken, "")
+
+		var capturedHeaders http.Header
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedHeaders = r.Header.Clone()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(mockCompletionResponse("test")))
+		}))
+		t.Cleanup(srv.Close)
+
+		customClient := &http.Client{Timeout: 5 * time.Second}
+		provider, err := New(
+			config.WithBaseURL(srv.URL),
+			config.WithAPIKey("tk_test"),
+			config.WithHTTPClient(customClient),
+			WithPlatformMode(),
+		)
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		_, err = provider.Completion(ctx, mockCompletionParams())
+		require.NoError(t, err)
+
+		// Platform mode: API key sent as standard Bearer auth.
+		require.Equal(t, bearerPrefix+"tk_test", capturedHeaders.Get("Authorization"))
+	})
+
+	t.Run("forwards custom HTTP client transport in non-platform mode", func(t *testing.T) {
+		t.Setenv(envAPIBase, "")
+		t.Setenv(envPlatformToken, "")
+
+		var capturedHeaders http.Header
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedHeaders = r.Header.Clone()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(mockCompletionResponse("test")))
+		}))
+		t.Cleanup(srv.Close)
+
+		customTransport := &mockRoundTripper{base: http.DefaultTransport}
+		customClient := &http.Client{Transport: customTransport}
+		provider, err := New(
+			config.WithBaseURL(srv.URL),
+			config.WithHTTPClient(customClient),
+			WithGatewayKey("gw_key"),
+		)
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		_, err = provider.Completion(ctx, mockCompletionParams())
+		require.NoError(t, err)
+
+		// Non-platform mode: gateway key sent via custom header.
+		require.Equal(t, bearerPrefix+"gw_key", capturedHeaders.Get(gatewayHeader))
+		// Custom transport should have been used (wrapped by headerTransport).
+		require.True(t, customTransport.called, "custom transport should be used as base")
+	})
 }
 
 func TestProviderName(t *testing.T) {
@@ -210,6 +283,18 @@ func TestResolvePlatformMode(t *testing.T) {
 		mode, _ := resolvePlatformMode(cfg)
 		require.False(t, mode)
 	})
+
+	t.Run("ignores non-bool platform_mode extra value", func(t *testing.T) {
+		t.Setenv(envPlatformToken, "")
+		t.Setenv(envAPIKey, "")
+
+		// Pass "true" as string instead of bool - should be ignored.
+		cfg, err := config.New(config.WithExtra(extraKeyPlatformMode, "true"))
+		require.NoError(t, err)
+
+		mode, _ := resolvePlatformMode(cfg)
+		require.False(t, mode)
+	})
 }
 
 func TestResolveGatewayKey(t *testing.T) {
@@ -244,6 +329,97 @@ func TestResolveGatewayKey(t *testing.T) {
 		key := resolveGatewayKey(cfg)
 		require.Empty(t, key)
 	})
+
+	t.Run("ignores non-string gateway_key extra value", func(t *testing.T) {
+		t.Setenv(envAPIKey, "")
+
+		// Pass 123 as int instead of string - should be ignored.
+		cfg, err := config.New(config.WithExtra(extraKeyGatewayKey, 123))
+		require.NoError(t, err)
+
+		key := resolveGatewayKey(cfg)
+		require.Empty(t, key)
+	})
+}
+
+func TestHeaderTransport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		header     string
+		value      string
+		wantHeader string
+		wantValue  string
+	}{
+		{
+			name:       "injects gateway header",
+			header:     gatewayHeader,
+			value:      bearerPrefix + "test-key",
+			wantHeader: gatewayHeader,
+			wantValue:  bearerPrefix + "test-key",
+		},
+		{
+			name:       "overwrites existing header value",
+			header:     "Authorization",
+			value:      bearerPrefix + "new-token",
+			wantHeader: "Authorization",
+			wantValue:  bearerPrefix + "new-token",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var capturedHeaders http.Header
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedHeaders = r.Header.Clone()
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(srv.Close)
+
+			transport := &headerTransport{
+				base:   http.DefaultTransport,
+				header: tc.header,
+				value:  tc.value,
+			}
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+			require.NoError(t, err)
+
+			resp, err := transport.RoundTrip(req)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+
+			require.Equal(t, tc.wantValue, capturedHeaders.Get(tc.wantHeader))
+		})
+	}
+
+	t.Run("does not mutate original request", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+
+		transport := &headerTransport{
+			base:   http.DefaultTransport,
+			header: gatewayHeader,
+			value:  bearerPrefix + "key",
+		}
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		require.NoError(t, err)
+
+		resp, err := transport.RoundTrip(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		// Original request should not have the injected header.
+		require.Empty(t, req.Header.Get(gatewayHeader))
+	})
 }
 
 func TestNonPlatformModeSendsCustomHeader(t *testing.T) {
@@ -260,18 +436,7 @@ func TestNonPlatformModeSendsCustomHeader(t *testing.T) {
 		mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"id": "chatcmpl-test",
-			"object": "chat.completion",
-			"created": 1700000000,
-			"model": "test-model",
-			"choices": [{
-				"index": 0,
-				"message": {"role": "assistant", "content": "hello"},
-				"finish_reason": "stop"
-			}],
-			"usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
-		}`))
+		_, _ = w.Write([]byte(mockCompletionResponse("hello")))
 	}))
 	t.Cleanup(srv.Close)
 
@@ -282,16 +447,13 @@ func TestNonPlatformModeSendsCustomHeader(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	_, err = provider.Completion(ctx, providers.CompletionParams{
-		Model:    "openai:gpt-4o-mini",
-		Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
-	})
+	_, err = provider.Completion(ctx, mockCompletionParams())
 	require.NoError(t, err)
 
 	mu.Lock()
 	defer mu.Unlock()
 
-	require.Equal(t, "Bearer gw_test_key_123", capturedHeaders.Get(gatewayHeader))
+	require.Equal(t, bearerPrefix+"gw_test_key_123", capturedHeaders.Get(gatewayHeader))
 }
 
 func TestPlatformModeSendsBearerAuth(t *testing.T) {
@@ -308,18 +470,7 @@ func TestPlatformModeSendsBearerAuth(t *testing.T) {
 		mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"id": "chatcmpl-test",
-			"object": "chat.completion",
-			"created": 1700000000,
-			"model": "test-model",
-			"choices": [{
-				"index": 0,
-				"message": {"role": "assistant", "content": "hello"},
-				"finish_reason": "stop"
-			}],
-			"usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
-		}`))
+		_, _ = w.Write([]byte(mockCompletionResponse("hello")))
 	}))
 	t.Cleanup(srv.Close)
 
@@ -331,17 +482,15 @@ func TestPlatformModeSendsBearerAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	_, err = provider.Completion(ctx, providers.CompletionParams{
-		Model:    "openai:gpt-4o-mini",
-		Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
-	})
+	_, err = provider.Completion(ctx, mockCompletionParams())
 	require.NoError(t, err)
 
 	mu.Lock()
 	defer mu.Unlock()
 
-	require.Equal(t, "Bearer tk_platform_token", capturedHeaders.Get("Authorization"))
-	require.Empty(t, capturedHeaders.Get(gatewayHeader), "platform mode should not send X-AnyLLM-Key header")
+	require.Equal(t, bearerPrefix+"tk_platform_token", capturedHeaders.Get("Authorization"))
+	require.Empty(t, capturedHeaders.Get(gatewayHeader),
+		"platform mode should not send gateway key header")
 }
 
 func TestCompletion(t *testing.T) {
@@ -428,7 +577,58 @@ func TestCompletionStream(t *testing.T) {
 	require.Equal(t, "hello", content.String())
 }
 
-func TestPlatformModeErrorConversion(t *testing.T) {
+func TestStreamingContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+
+		// Send chunks slowly so context cancellation happens mid-stream.
+		for i := 0; i < 100; i++ {
+			chunk := fmt.Sprintf(
+				`{"id":"chatcmpl-gw","object":"chat.completion.chunk","created":1700000000,"model":"test-model","choices":[{"index":0,"delta":{"content":"chunk-%d"},"finish_reason":null}]}`,
+				i,
+			)
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", chunk)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(config.WithBaseURL(srv.URL))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	chunks, errs := provider.CompletionStream(ctx, mockCompletionParams())
+
+	// Read a few chunks then cancel.
+	chunkCount := 0
+	for range chunks {
+		chunkCount++
+		if chunkCount >= 3 {
+			cancel()
+			break
+		}
+	}
+
+	// Drain remaining chunks (channel will close after goroutine detects cancellation).
+	for range chunks {
+	}
+
+	err = <-errs
+	// After context cancellation, we should get a context error, not nil.
+	if err != nil {
+		require.ErrorIs(t, err, context.Canceled)
+	}
+}
+
+func TestConvertError(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -494,10 +694,7 @@ func TestPlatformModeErrorConversion(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := context.Background()
-			_, err = provider.Completion(ctx, providers.CompletionParams{
-				Model:    "openai:gpt-4o-mini",
-				Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
-			})
+			_, err = provider.Completion(ctx, mockCompletionParams())
 
 			require.Error(t, err)
 			require.ErrorIs(t, err, tc.wantErr)
@@ -508,28 +705,54 @@ func TestPlatformModeErrorConversion(t *testing.T) {
 func TestNonPlatformModeAlsoConvertsGatewayErrors(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadGateway)
-		_, _ = w.Write(
-			[]byte(`{"error": {"message": "upstream error", "type": "upstream_error", "code": "upstream_error"}}`),
-		)
-	}))
-	t.Cleanup(srv.Close)
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    error
+	}{
+		{
+			name:       "402 in non-platform mode",
+			statusCode: http.StatusPaymentRequired,
+			body:       `{"error": {"message": "payment required", "type": "insufficient_funds", "code": "insufficient_funds"}}`,
+			wantErr:    errors.ErrInsufficientFunds,
+		},
+		{
+			name:       "502 in non-platform mode",
+			statusCode: http.StatusBadGateway,
+			body:       `{"error": {"message": "upstream error", "type": "upstream_error", "code": "upstream_error"}}`,
+			wantErr:    errors.ErrUpstreamProvider,
+		},
+		{
+			name:       "504 in non-platform mode",
+			statusCode: http.StatusGatewayTimeout,
+			body:       `{"error": {"message": "gateway timeout", "type": "timeout", "code": "timeout"}}`,
+			wantErr:    errors.ErrGatewayTimeout,
+		},
+	}
 
-	provider, err := New(config.WithBaseURL(srv.URL))
-	require.NoError(t, err)
-	require.False(t, provider.platformMode)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	ctx := context.Background()
-	_, err = provider.Completion(ctx, providers.CompletionParams{
-		Model:    "openai:gpt-4o-mini",
-		Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
-	})
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			t.Cleanup(srv.Close)
 
-	// Gateway error conversion applies in both modes.
-	require.Error(t, err)
-	require.ErrorIs(t, err, errors.ErrUpstreamProvider)
+			provider, err := New(config.WithBaseURL(srv.URL))
+			require.NoError(t, err)
+			require.False(t, provider.platformMode)
+
+			ctx := context.Background()
+			_, err = provider.Completion(ctx, mockCompletionParams())
+
+			require.Error(t, err)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
 }
 
 func TestStreamingErrorConversion(t *testing.T) {
@@ -554,10 +777,7 @@ func TestStreamingErrorConversion(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	chunks, errs := provider.CompletionStream(ctx, providers.CompletionParams{
-		Model:    "openai:gpt-4o-mini",
-		Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
-	})
+	chunks, errs := provider.CompletionStream(ctx, mockCompletionParams())
 
 	// Drain chunks channel.
 	for range chunks {
@@ -588,18 +808,7 @@ func TestCompletionRequestBody(t *testing.T) {
 		mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"id": "chatcmpl-test",
-			"object": "chat.completion",
-			"created": 1700000000,
-			"model": "test-model",
-			"choices": [{
-				"index": 0,
-				"message": {"role": "assistant", "content": "ok"},
-				"finish_reason": "stop"
-			}],
-			"usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}
-		}`))
+		_, _ = w.Write([]byte(mockCompletionResponse("ok")))
 	}))
 	t.Cleanup(srv.Close)
 
@@ -650,6 +859,15 @@ func TestValidationErrors(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "at least one message is required")
 	})
+}
+
+func TestConvertErrorNilPassthrough(t *testing.T) {
+	t.Parallel()
+
+	provider, err := New(config.WithBaseURL("http://localhost:8000/v1"))
+	require.NoError(t, err)
+
+	require.Nil(t, provider.ConvertError(nil))
 }
 
 // Integration tests - only run if gateway is available.
@@ -732,6 +950,46 @@ func TestIntegrationCompletionStream(t *testing.T) {
 
 	t.Logf("Received %d chunks", chunkCount)
 	t.Logf("Content: %s", content.String())
+}
+
+// Test helpers.
+
+// mockRoundTripper records whether it was called and delegates to a base transport.
+type mockRoundTripper struct {
+	base   http.RoundTripper
+	called bool
+	mu     sync.Mutex
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.mu.Lock()
+	m.called = true
+	m.mu.Unlock()
+	return m.base.RoundTrip(req)
+}
+
+// mockCompletionParams returns standard completion params for tests.
+func mockCompletionParams() providers.CompletionParams {
+	return providers.CompletionParams{
+		Model:    "openai:gpt-4o-mini",
+		Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
+	}
+}
+
+// mockCompletionResponse returns a minimal valid JSON completion response.
+func mockCompletionResponse(content string) string {
+	return fmt.Sprintf(`{
+		"id": "chatcmpl-test",
+		"object": "chat.completion",
+		"created": 1700000000,
+		"model": "test-model",
+		"choices": [{
+			"index": 0,
+			"message": {"role": "assistant", "content": %q},
+			"finish_reason": "stop"
+		}],
+		"usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
+	}`, content)
 }
 
 // gatewayCredentials returns the gateway URL and platform token from

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -1,0 +1,730 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	"github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+// Object type constants for test assertions.
+const (
+	objectChatCompletion      = "chat.completion"
+	objectChatCompletionChunk = "chat.completion.chunk"
+	objectList                = "list"
+)
+
+func TestNew(t *testing.T) {
+	// Note: Not using t.Parallel() here because child tests use t.Setenv.
+
+	t.Run("returns error when base URL is missing", func(t *testing.T) {
+		t.Setenv(envAPIBase, "")
+
+		provider, err := New()
+		require.Nil(t, provider)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "gateway base URL is required")
+	})
+
+	t.Run("creates provider with base URL from env", func(t *testing.T) {
+		t.Setenv(envAPIBase, "http://localhost:8000/v1")
+		t.Setenv(envPlatformToken, "")
+		t.Setenv(envAPIKey, "")
+
+		provider, err := New()
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+		require.Equal(t, providerName, provider.Name())
+	})
+
+	t.Run("creates provider with explicit base URL", func(t *testing.T) {
+		t.Setenv(envAPIBase, "")
+		t.Setenv(envPlatformToken, "")
+
+		provider, err := New(config.WithBaseURL("http://localhost:8000/v1"))
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+	})
+
+	t.Run("creates platform mode provider with explicit API key", func(t *testing.T) {
+		t.Setenv(envAPIBase, "")
+		t.Setenv(envPlatformToken, "")
+
+		provider, err := New(
+			config.WithBaseURL("http://localhost:8000/v1"),
+			config.WithAPIKey("tk_test_token"),
+			WithPlatformMode(),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+		require.True(t, provider.platformMode)
+	})
+
+	t.Run("auto-detects platform mode from env token", func(t *testing.T) {
+		t.Setenv(envAPIBase, "http://localhost:8000/v1")
+		t.Setenv(envPlatformToken, "tk_auto_detected")
+
+		provider, err := New()
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+		require.True(t, provider.platformMode)
+	})
+
+	t.Run("returns error when platform mode has no token", func(t *testing.T) {
+		t.Setenv(envAPIBase, "http://localhost:8000/v1")
+		t.Setenv(envPlatformToken, "")
+
+		provider, err := New(WithPlatformMode())
+		require.Nil(t, provider)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "platform mode requires a token")
+	})
+
+	t.Run("creates non-platform provider with gateway key from env", func(t *testing.T) {
+		t.Setenv(envAPIBase, "http://localhost:8000/v1")
+		t.Setenv(envAPIKey, "gw_test_key")
+		t.Setenv(envPlatformToken, "")
+
+		provider, err := New()
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+		require.False(t, provider.platformMode)
+	})
+
+	t.Run("creates non-platform provider with WithGatewayKey", func(t *testing.T) {
+		t.Setenv(envAPIBase, "")
+		t.Setenv(envPlatformToken, "")
+
+		provider, err := New(
+			config.WithBaseURL("http://localhost:8000/v1"),
+			WithGatewayKey("gw_explicit_key"),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+		require.False(t, provider.platformMode)
+	})
+}
+
+func TestProviderName(t *testing.T) {
+	t.Parallel()
+
+	provider, err := New(config.WithBaseURL("http://localhost:8000/v1"))
+	require.NoError(t, err)
+	require.Equal(t, providerName, provider.Name())
+}
+
+func TestCapabilities(t *testing.T) {
+	t.Parallel()
+
+	provider, err := New(config.WithBaseURL("http://localhost:8000/v1"))
+	require.NoError(t, err)
+
+	caps := provider.Capabilities()
+
+	require.True(t, caps.Completion)
+	require.True(t, caps.CompletionImage)
+	require.True(t, caps.CompletionPDF)
+	require.True(t, caps.CompletionReasoning)
+	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.CompletionTools)
+	require.True(t, caps.Embedding)
+	require.True(t, caps.ListModels)
+}
+
+func TestResolvePlatformMode(t *testing.T) {
+	// Note: Not using t.Parallel() here because child tests use t.Setenv.
+
+	t.Run("returns false when no platform indicators", func(t *testing.T) {
+		t.Setenv(envPlatformToken, "")
+
+		cfg, err := config.New()
+		require.NoError(t, err)
+
+		mode, token := resolvePlatformMode(cfg)
+		require.False(t, mode)
+		require.Empty(t, token)
+	})
+
+	t.Run("returns true with explicit WithPlatformMode and API key", func(t *testing.T) {
+		t.Setenv(envPlatformToken, "")
+
+		cfg, err := config.New(config.WithAPIKey("tk_test"), WithPlatformMode())
+		require.NoError(t, err)
+
+		mode, token := resolvePlatformMode(cfg)
+		require.True(t, mode)
+		require.Equal(t, "tk_test", token)
+	})
+
+	t.Run("returns true with explicit WithPlatformMode and env token", func(t *testing.T) {
+		t.Setenv(envPlatformToken, "tk_from_env")
+
+		cfg, err := config.New(WithPlatformMode())
+		require.NoError(t, err)
+
+		mode, token := resolvePlatformMode(cfg)
+		require.True(t, mode)
+		require.Equal(t, "tk_from_env", token)
+	})
+
+	t.Run("auto-detects when GATEWAY_PLATFORM_TOKEN set and no API key", func(t *testing.T) {
+		t.Setenv(envPlatformToken, "tk_auto")
+
+		cfg, err := config.New()
+		require.NoError(t, err)
+
+		mode, token := resolvePlatformMode(cfg)
+		require.True(t, mode)
+		require.Equal(t, "tk_auto", token)
+	})
+
+	t.Run("does not auto-detect when API key is explicitly set", func(t *testing.T) {
+		t.Setenv(envPlatformToken, "tk_auto")
+
+		cfg, err := config.New(config.WithAPIKey("explicit_key"))
+		require.NoError(t, err)
+
+		mode, _ := resolvePlatformMode(cfg)
+		require.False(t, mode)
+	})
+}
+
+func TestResolveGatewayKey(t *testing.T) {
+	// Note: Not using t.Parallel() here because child tests use t.Setenv.
+
+	t.Run("returns key from WithGatewayKey", func(t *testing.T) {
+		t.Setenv(envAPIKey, "")
+
+		cfg, err := config.New(WithGatewayKey("gw_explicit"))
+		require.NoError(t, err)
+
+		key := resolveGatewayKey(cfg)
+		require.Equal(t, "gw_explicit", key)
+	})
+
+	t.Run("falls back to GATEWAY_API_KEY env var", func(t *testing.T) {
+		t.Setenv(envAPIKey, "gw_from_env")
+
+		cfg, err := config.New()
+		require.NoError(t, err)
+
+		key := resolveGatewayKey(cfg)
+		require.Equal(t, "gw_from_env", key)
+	})
+
+	t.Run("returns empty when no key available", func(t *testing.T) {
+		t.Setenv(envAPIKey, "")
+
+		cfg, err := config.New()
+		require.NoError(t, err)
+
+		key := resolveGatewayKey(cfg)
+		require.Empty(t, key)
+	})
+}
+
+func TestNonPlatformModeSendsCustomHeader(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu              sync.Mutex
+		capturedHeaders http.Header
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		capturedHeaders = r.Header.Clone()
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-test",
+			"object": "chat.completion",
+			"created": 1700000000,
+			"model": "test-model",
+			"choices": [{
+				"index": 0,
+				"message": {"role": "assistant", "content": "hello"},
+				"finish_reason": "stop"
+			}],
+			"usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		WithGatewayKey("gw_test_key_123"),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = provider.Completion(ctx, providers.CompletionParams{
+		Model:    "openai:gpt-4o-mini",
+		Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Equal(t, "Bearer gw_test_key_123", capturedHeaders.Get(gatewayHeader))
+}
+
+func TestPlatformModeSendsBearerAuth(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu              sync.Mutex
+		capturedHeaders http.Header
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		capturedHeaders = r.Header.Clone()
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-test",
+			"object": "chat.completion",
+			"created": 1700000000,
+			"model": "test-model",
+			"choices": [{
+				"index": 0,
+				"message": {"role": "assistant", "content": "hello"},
+				"finish_reason": "stop"
+			}],
+			"usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		config.WithAPIKey("tk_platform_token"),
+		WithPlatformMode(),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = provider.Completion(ctx, providers.CompletionParams{
+		Model:    "openai:gpt-4o-mini",
+		Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Equal(t, "Bearer tk_platform_token", capturedHeaders.Get("Authorization"))
+	require.Empty(t, capturedHeaders.Get(gatewayHeader), "platform mode should not send X-AnyLLM-Key header")
+}
+
+func TestCompletion(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-gw",
+			"object": "chat.completion",
+			"created": 1700000000,
+			"model": "openai:gpt-4o-mini",
+			"choices": [{
+				"index": 0,
+				"message": {"role": "assistant", "content": "Hello from gateway!"},
+				"finish_reason": "stop"
+			}],
+			"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(config.WithBaseURL(srv.URL))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	resp, err := provider.Completion(ctx, providers.CompletionParams{
+		Model:    "openai:gpt-4o-mini",
+		Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "chatcmpl-gw", resp.ID)
+	require.Equal(t, objectChatCompletion, resp.Object)
+	require.Len(t, resp.Choices, 1)
+	require.Equal(t, "Hello from gateway!", resp.Choices[0].Message.ContentString())
+	require.Equal(t, providers.RoleAssistant, resp.Choices[0].Message.Role)
+	require.Equal(t, providers.FinishReasonStop, resp.Choices[0].FinishReason)
+	require.NotNil(t, resp.Usage)
+	require.Equal(t, 15, resp.Usage.TotalTokens)
+}
+
+func TestCompletionStream(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+
+		chunk := `{"id":"chatcmpl-gw","object":"chat.completion.chunk","created":1700000000,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"hello"},"finish_reason":null}]}`
+		done := `{"id":"chatcmpl-gw","object":"chat.completion.chunk","created":1700000000,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`
+
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", chunk)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", done)
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(config.WithBaseURL(srv.URL))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	chunks, errs := provider.CompletionStream(ctx, providers.CompletionParams{
+		Model:    "openai:gpt-4o-mini",
+		Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
+	})
+
+	var content strings.Builder
+	chunkCount := 0
+
+	for chunk := range chunks {
+		chunkCount++
+		require.Equal(t, objectChatCompletionChunk, chunk.Object)
+		if len(chunk.Choices) > 0 {
+			content.WriteString(chunk.Choices[0].Delta.Content)
+		}
+	}
+
+	err = <-errs
+	require.NoError(t, err)
+
+	require.Greater(t, chunkCount, 0)
+	require.Equal(t, "hello", content.String())
+}
+
+func TestPlatformModeErrorConversion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    error
+	}{
+		{
+			name:       "401 returns AuthenticationError",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error": {"message": "invalid token", "type": "auth_error", "code": "invalid_api_key"}}`,
+			wantErr:    errors.ErrAuthentication,
+		},
+		{
+			name:       "402 returns InsufficientFundsError",
+			statusCode: http.StatusPaymentRequired,
+			body:       `{"error": {"message": "payment required", "type": "insufficient_funds", "code": "insufficient_funds"}}`,
+			wantErr:    errors.ErrInsufficientFunds,
+		},
+		{
+			name:       "404 returns ModelNotFoundError",
+			statusCode: http.StatusNotFound,
+			body:       `{"error": {"message": "model not found", "type": "not_found", "code": "model_not_found"}}`,
+			wantErr:    errors.ErrModelNotFound,
+		},
+		{
+			name:       "429 returns RateLimitError",
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"error": {"message": "rate limit exceeded", "type": "rate_limit", "code": "rate_limit_exceeded"}}`,
+			wantErr:    errors.ErrRateLimit,
+		},
+		{
+			name:       "502 returns UpstreamProviderError",
+			statusCode: http.StatusBadGateway,
+			body:       `{"error": {"message": "upstream error", "type": "upstream_error", "code": "upstream_error"}}`,
+			wantErr:    errors.ErrUpstreamProvider,
+		},
+		{
+			name:       "504 returns GatewayTimeoutError",
+			statusCode: http.StatusGatewayTimeout,
+			body:       `{"error": {"message": "gateway timeout", "type": "timeout", "code": "timeout"}}`,
+			wantErr:    errors.ErrGatewayTimeout,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			t.Cleanup(srv.Close)
+
+			provider, err := New(
+				config.WithBaseURL(srv.URL),
+				config.WithAPIKey("tk_test"),
+				WithPlatformMode(),
+			)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			_, err = provider.Completion(ctx, providers.CompletionParams{
+				Model:    "openai:gpt-4o-mini",
+				Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
+			})
+
+			require.Error(t, err)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestNonPlatformModePassesThroughErrors(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write(
+			[]byte(`{"error": {"message": "upstream error", "type": "upstream_error", "code": "upstream_error"}}`),
+		)
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(config.WithBaseURL(srv.URL))
+	require.NoError(t, err)
+	require.False(t, provider.platformMode)
+
+	ctx := context.Background()
+	_, err = provider.Completion(ctx, providers.CompletionParams{
+		Model:    "openai:gpt-4o-mini",
+		Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
+	})
+
+	// Non-platform mode uses base error conversion, which maps 502 to ProviderError.
+	require.Error(t, err)
+	require.ErrorIs(t, err, errors.ErrProvider)
+}
+
+func TestStreamingPlatformModeErrorConversion(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, _ = w.Write(
+			[]byte(
+				`{"error": {"message": "payment required", "type": "insufficient_funds", "code": "insufficient_funds"}}`,
+			),
+		)
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		config.WithAPIKey("tk_test"),
+		WithPlatformMode(),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	chunks, errs := provider.CompletionStream(ctx, providers.CompletionParams{
+		Model:    "openai:gpt-4o-mini",
+		Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
+	})
+
+	// Drain chunks channel.
+	for range chunks {
+	}
+
+	err = <-errs
+	require.Error(t, err)
+	require.ErrorIs(t, err, errors.ErrInsufficientFunds)
+}
+
+func TestCompletionRequestBody(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu   sync.Mutex
+		body map[string]any
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		_ = json.Unmarshal(raw, &body)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-test",
+			"object": "chat.completion",
+			"created": 1700000000,
+			"model": "test-model",
+			"choices": [{
+				"index": 0,
+				"message": {"role": "assistant", "content": "ok"},
+				"finish_reason": "stop"
+			}],
+			"usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(config.WithBaseURL(srv.URL))
+	require.NoError(t, err)
+
+	temp := 0.7
+	ctx := context.Background()
+	_, err = provider.Completion(ctx, providers.CompletionParams{
+		Model:       "openai:gpt-4o-mini",
+		Messages:    []providers.Message{{Role: providers.RoleUser, Content: "test"}},
+		Temperature: &temp,
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Equal(t, "openai:gpt-4o-mini", body["model"])
+	require.InDelta(t, 0.7, body["temperature"], 0.01)
+}
+
+func TestValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	provider, err := New(config.WithBaseURL("http://localhost:9999/v1"))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("empty model returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := provider.Completion(ctx, providers.CompletionParams{
+			Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "model is required")
+	})
+
+	t.Run("empty messages returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := provider.Completion(ctx, providers.CompletionParams{
+			Model:    "openai:gpt-4o-mini",
+			Messages: []providers.Message{},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "at least one message is required")
+	})
+}
+
+// Integration tests - only run if gateway is available.
+
+func TestIntegrationCompletion(t *testing.T) {
+	t.Parallel()
+
+	gatewayURL, token := gatewayCredentials()
+	if gatewayURL == "" || token == "" {
+		t.Skip("GATEWAY_API_BASE and GATEWAY_PLATFORM_TOKEN not set")
+	}
+
+	provider, err := New(
+		config.WithBaseURL(gatewayURL),
+		config.WithAPIKey(token),
+		WithPlatformMode(),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	resp, err := provider.Completion(ctx, providers.CompletionParams{
+		Model: "openai:gpt-4o-mini",
+		Messages: []providers.Message{
+			{Role: providers.RoleUser, Content: "Say 'hello' and nothing else."},
+		},
+	})
+	require.NoError(t, err)
+
+	require.NotEmpty(t, resp.ID)
+	require.Equal(t, objectChatCompletion, resp.Object)
+	require.Len(t, resp.Choices, 1)
+	require.NotEmpty(t, resp.Choices[0].Message.ContentString())
+	require.Contains(t, strings.ToLower(resp.Choices[0].Message.ContentString()), "hello")
+
+	t.Logf("Response: %s", resp.Choices[0].Message.ContentString())
+	if resp.Usage != nil {
+		t.Logf("Tokens used: %d", resp.Usage.TotalTokens)
+	}
+}
+
+func TestIntegrationCompletionStream(t *testing.T) {
+	t.Parallel()
+
+	gatewayURL, token := gatewayCredentials()
+	if gatewayURL == "" || token == "" {
+		t.Skip("GATEWAY_API_BASE and GATEWAY_PLATFORM_TOKEN not set")
+	}
+
+	provider, err := New(
+		config.WithBaseURL(gatewayURL),
+		config.WithAPIKey(token),
+		WithPlatformMode(),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	chunks, errs := provider.CompletionStream(ctx, providers.CompletionParams{
+		Model: "openai:gpt-4o-mini",
+		Messages: []providers.Message{
+			{Role: providers.RoleUser, Content: "Count from 1 to 3, one number per line."},
+		},
+		Stream: true,
+	})
+
+	var content strings.Builder
+	chunkCount := 0
+
+	for chunk := range chunks {
+		chunkCount++
+		if len(chunk.Choices) > 0 && chunk.Choices[0].Delta.Content != "" {
+			content.WriteString(chunk.Choices[0].Delta.Content)
+		}
+	}
+
+	err = <-errs
+	require.NoError(t, err)
+
+	require.Greater(t, chunkCount, 0, "should have received chunks")
+	require.NotEmpty(t, content.String(), "should have received content")
+
+	t.Logf("Received %d chunks", chunkCount)
+	t.Logf("Content: %s", content.String())
+}
+
+// gatewayCredentials returns the gateway URL and platform token from
+// environment variables. Returns empty strings if not set.
+func gatewayCredentials() (gatewayURL string, token string) {
+	return os.Getenv(envAPIBase), os.Getenv(envPlatformToken)
+}

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -216,129 +216,48 @@ func TestCapabilities(t *testing.T) {
 	require.True(t, caps.ListModels)
 }
 
-func TestResolvePlatformMode(t *testing.T) {
+func TestPlatformModeDetection(t *testing.T) {
 	// Note: Not using t.Parallel() here because child tests use t.Setenv.
 
-	t.Run("returns false when no platform indicators", func(t *testing.T) {
-		t.Setenv(envPlatformToken, "")
-
-		cfg, err := config.New()
-		require.NoError(t, err)
-
-		mode, token := resolvePlatformMode(cfg)
-		require.False(t, mode)
-		require.Empty(t, token)
-	})
-
-	t.Run("returns true with explicit WithPlatformMode and API key", func(t *testing.T) {
-		t.Setenv(envPlatformToken, "")
-
-		cfg, err := config.New(config.WithAPIKey("tk_test"), WithPlatformMode())
-		require.NoError(t, err)
-
-		mode, token := resolvePlatformMode(cfg)
-		require.True(t, mode)
-		require.Equal(t, "tk_test", token)
-	})
-
-	t.Run("returns true with explicit WithPlatformMode and env token", func(t *testing.T) {
-		t.Setenv(envPlatformToken, "tk_from_env")
-
-		cfg, err := config.New(WithPlatformMode())
-		require.NoError(t, err)
-
-		mode, token := resolvePlatformMode(cfg)
-		require.True(t, mode)
-		require.Equal(t, "tk_from_env", token)
-	})
-
-	t.Run("auto-detects when GATEWAY_PLATFORM_TOKEN set and no API key", func(t *testing.T) {
-		t.Setenv(envPlatformToken, "tk_auto")
-
-		cfg, err := config.New()
-		require.NoError(t, err)
-
-		mode, token := resolvePlatformMode(cfg)
-		require.True(t, mode)
-		require.Equal(t, "tk_auto", token)
-	})
-
 	t.Run("does not auto-detect when API key is explicitly set", func(t *testing.T) {
+		t.Setenv(envAPIBase, "http://localhost:8000/v1")
 		t.Setenv(envPlatformToken, "tk_auto")
 
-		cfg, err := config.New(config.WithAPIKey("explicit_key"))
+		provider, err := New(config.WithAPIKey("explicit_key"))
 		require.NoError(t, err)
-
-		mode, _ := resolvePlatformMode(cfg)
-		require.False(t, mode)
+		require.False(t, provider.platformMode)
 	})
 
 	t.Run("does not auto-detect when gateway key is set", func(t *testing.T) {
+		t.Setenv(envAPIBase, "http://localhost:8000/v1")
 		t.Setenv(envPlatformToken, "tk_auto")
 		t.Setenv(envAPIKey, "")
 
-		cfg, err := config.New(WithGatewayKey("gw_key"))
+		provider, err := New(WithGatewayKey("gw_key"))
 		require.NoError(t, err)
-
-		mode, _ := resolvePlatformMode(cfg)
-		require.False(t, mode)
+		require.False(t, provider.platformMode)
 	})
 
 	t.Run("ignores non-bool platform_mode extra value", func(t *testing.T) {
+		t.Setenv(envAPIBase, "http://localhost:8000/v1")
 		t.Setenv(envPlatformToken, "")
 		t.Setenv(envAPIKey, "")
 
 		// Pass "true" as string instead of bool - should be ignored.
-		cfg, err := config.New(config.WithExtra(extraKeyPlatformMode, "true"))
+		provider, err := New(config.WithExtra(extraKeyPlatformMode, "true"))
 		require.NoError(t, err)
-
-		mode, _ := resolvePlatformMode(cfg)
-		require.False(t, mode)
-	})
-}
-
-func TestResolveGatewayKey(t *testing.T) {
-	// Note: Not using t.Parallel() here because child tests use t.Setenv.
-
-	t.Run("returns key from WithGatewayKey", func(t *testing.T) {
-		t.Setenv(envAPIKey, "")
-
-		cfg, err := config.New(WithGatewayKey("gw_explicit"))
-		require.NoError(t, err)
-
-		key := resolveGatewayKey(cfg)
-		require.Equal(t, "gw_explicit", key)
-	})
-
-	t.Run("falls back to GATEWAY_API_KEY env var", func(t *testing.T) {
-		t.Setenv(envAPIKey, "gw_from_env")
-
-		cfg, err := config.New()
-		require.NoError(t, err)
-
-		key := resolveGatewayKey(cfg)
-		require.Equal(t, "gw_from_env", key)
-	})
-
-	t.Run("returns empty when no key available", func(t *testing.T) {
-		t.Setenv(envAPIKey, "")
-
-		cfg, err := config.New()
-		require.NoError(t, err)
-
-		key := resolveGatewayKey(cfg)
-		require.Empty(t, key)
+		require.False(t, provider.platformMode)
 	})
 
 	t.Run("ignores non-string gateway_key extra value", func(t *testing.T) {
+		t.Setenv(envAPIBase, "http://localhost:8000/v1")
+		t.Setenv(envPlatformToken, "")
 		t.Setenv(envAPIKey, "")
 
 		// Pass 123 as int instead of string - should be ignored.
-		cfg, err := config.New(config.WithExtra(extraKeyGatewayKey, 123))
+		provider, err := New(config.WithExtra(extraKeyGatewayKey, 123))
 		require.NoError(t, err)
-
-		key := resolveGatewayKey(cfg)
-		require.Empty(t, key)
+		require.NotNil(t, provider)
 	})
 }
 
@@ -622,10 +541,9 @@ func TestStreamingContextCancellation(t *testing.T) {
 	}
 
 	err = <-errs
-	// After context cancellation, we should get a context error, not nil.
-	if err != nil {
-		require.ErrorIs(t, err, context.Canceled)
-	}
+	// After context cancellation, we must get a context error, not nil.
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestConvertError(t *testing.T) {
@@ -665,13 +583,13 @@ func TestConvertError(t *testing.T) {
 			name:       "502 returns UpstreamProviderError",
 			statusCode: http.StatusBadGateway,
 			body:       `{"error": {"message": "upstream error", "type": "upstream_error", "code": "upstream_error"}}`,
-			wantErr:    errors.ErrUpstreamProvider,
+			wantErr:    ErrUpstreamProvider,
 		},
 		{
 			name:       "504 returns GatewayTimeoutError",
 			statusCode: http.StatusGatewayTimeout,
 			body:       `{"error": {"message": "gateway timeout", "type": "timeout", "code": "timeout"}}`,
-			wantErr:    errors.ErrGatewayTimeout,
+			wantErr:    ErrGatewayTimeout,
 		},
 	}
 
@@ -721,13 +639,13 @@ func TestNonPlatformModeAlsoConvertsGatewayErrors(t *testing.T) {
 			name:       "502 in non-platform mode",
 			statusCode: http.StatusBadGateway,
 			body:       `{"error": {"message": "upstream error", "type": "upstream_error", "code": "upstream_error"}}`,
-			wantErr:    errors.ErrUpstreamProvider,
+			wantErr:    ErrUpstreamProvider,
 		},
 		{
 			name:       "504 in non-platform mode",
 			statusCode: http.StatusGatewayTimeout,
 			body:       `{"error": {"message": "gateway timeout", "type": "timeout", "code": "timeout"}}`,
-			wantErr:    errors.ErrGatewayTimeout,
+			wantErr:    ErrGatewayTimeout,
 		},
 	}
 

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -199,6 +199,17 @@ func TestResolvePlatformMode(t *testing.T) {
 		mode, _ := resolvePlatformMode(cfg)
 		require.False(t, mode)
 	})
+
+	t.Run("does not auto-detect when gateway key is set", func(t *testing.T) {
+		t.Setenv(envPlatformToken, "tk_auto")
+		t.Setenv(envAPIKey, "")
+
+		cfg, err := config.New(WithGatewayKey("gw_key"))
+		require.NoError(t, err)
+
+		mode, _ := resolvePlatformMode(cfg)
+		require.False(t, mode)
+	})
 }
 
 func TestResolveGatewayKey(t *testing.T) {
@@ -494,7 +505,7 @@ func TestPlatformModeErrorConversion(t *testing.T) {
 	}
 }
 
-func TestNonPlatformModePassesThroughErrors(t *testing.T) {
+func TestNonPlatformModeAlsoConvertsGatewayErrors(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -516,12 +527,12 @@ func TestNonPlatformModePassesThroughErrors(t *testing.T) {
 		Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
 	})
 
-	// Non-platform mode uses base error conversion, which maps 502 to ProviderError.
+	// Gateway error conversion applies in both modes.
 	require.Error(t, err)
-	require.ErrorIs(t, err, errors.ErrProvider)
+	require.ErrorIs(t, err, errors.ErrUpstreamProvider)
 }
 
-func TestStreamingPlatformModeErrorConversion(t *testing.T) {
+func TestStreamingErrorConversion(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -78,6 +78,12 @@ type CompatibleConfig struct {
 
 	// RequireAPIKey indicates whether an API key is required.
 	RequireAPIKey bool
+
+	// RequireBaseURL indicates whether a base URL must be resolvable from
+	// WithBaseURL, BaseURLEnvVar, or DefaultBaseURL. When true, NewCompatible
+	// returns an error if none of those yield a value. Used by providers that
+	// have no sensible default endpoint (e.g. gateway).
+	RequireBaseURL bool
 }
 
 // Ensure CompatibleProvider implements the required interfaces.
@@ -110,6 +116,21 @@ func NewCompatible(compatCfg CompatibleConfig, opts ...config.Option) (*Compatib
 	baseURL, err := cfg.ResolveBaseURL(compatCfg.BaseURLEnvVar, compatCfg.DefaultBaseURL)
 	if err != nil {
 		return nil, err
+	}
+
+	if baseURL == "" && compatCfg.RequireBaseURL {
+		if compatCfg.BaseURLEnvVar == "" {
+			return nil, fmt.Errorf(
+				"%s base URL is required (set via WithBaseURL option)",
+				compatCfg.Name,
+			)
+		}
+
+		return nil, fmt.Errorf(
+			"%s base URL is required (set via WithBaseURL option or %q env var)",
+			compatCfg.Name,
+			compatCfg.BaseURLEnvVar,
+		)
 	}
 
 	apiKey := resolveAPIKey(cfg, compatCfg)

--- a/providers/openai/compatible_test.go
+++ b/providers/openai/compatible_test.go
@@ -107,6 +107,88 @@ func TestNewCompatible(t *testing.T) {
 	})
 }
 
+func TestNewCompatibleRequireBaseURL(t *testing.T) {
+	// Note: Not using t.Parallel() because subtests use t.Setenv.
+
+	const (
+		envVar       = "TEST_COMPATIBLE_REQUIRE_BASEURL"
+		providerName = "test-provider"
+	)
+
+	tests := []struct {
+		name           string
+		baseURLEnvVar  string
+		defaultBaseURL string
+		envValue       string
+		withBaseURL    string
+		requireBaseURL bool
+		wantErr        string // empty means no error expected.
+	}{
+		{
+			name:           "errors when required and no env var configured",
+			requireBaseURL: true,
+			wantErr:        providerName + " base URL is required (set via WithBaseURL option)",
+		},
+		{
+			name:           "errors when required and env var name set but unset",
+			baseURLEnvVar:  envVar,
+			requireBaseURL: true,
+			wantErr: providerName + ` base URL is required (set via WithBaseURL option or "` +
+				envVar + `" env var)`,
+		},
+		{
+			name:           "succeeds when required and WithBaseURL is provided",
+			requireBaseURL: true,
+			withBaseURL:    "http://custom:9090/v1",
+		},
+		{
+			name:           "succeeds when required and env var resolves",
+			baseURLEnvVar:  envVar,
+			envValue:       "http://env:8080/v1",
+			requireBaseURL: true,
+		},
+		{
+			name:           "succeeds when required and DefaultBaseURL is set",
+			defaultBaseURL: "http://default:8080/v1",
+			requireBaseURL: true,
+		},
+		{
+			name:           "does not error when not required and no URL resolves",
+			requireBaseURL: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envVar, tc.envValue)
+
+			baseCfg := CompatibleConfig{
+				Name:           providerName,
+				BaseURLEnvVar:  tc.baseURLEnvVar,
+				DefaultAPIKey:  "test-key",
+				DefaultBaseURL: tc.defaultBaseURL,
+				RequireBaseURL: tc.requireBaseURL,
+			}
+
+			var opts []config.Option
+			if tc.withBaseURL != "" {
+				opts = append(opts, config.WithBaseURL(tc.withBaseURL))
+			}
+
+			provider, err := NewCompatible(baseCfg, opts...)
+
+			if tc.wantErr != "" {
+				require.EqualError(t, err, tc.wantErr)
+				require.Nil(t, provider)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, provider)
+		})
+	}
+}
+
 func TestCompatibleProviderCapabilities(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Adds a new `providers/gateway` package that connects to an any-llm gateway server, superseding `providers/platform`. Where the platform provider decrypts provider keys client-side and fans out to individual provider SDKs, the gateway delegates everything to a single server-side endpoint.
- Supports **platform mode** (Bearer auth) and **non-platform mode** (`X-AnyLLM-Key` header)
- Adds `InsufficientFundsError` (402) to the shared `errors` package; gateway-specific error types `UpstreamProviderError` (502) and `TimeoutError` (504) live in the gateway package
- Extends `openai.CompatibleConfig` with a `RequireBaseURL` flag so providers with no sensible default URL (like the gateway) can fail fast with a clear, env-var-aware error at construction time

## Details

### Gateway Provider (`providers/gateway/`)

The gateway provider acts as a thin wrapper around `openai.CompatibleProvider`, pointing the OpenAI SDK at a gateway URL. Two authentication modes are supported:

**Platform mode** (most common): The platform token is used as standard Bearer authentication via the OpenAI SDK's API key mechanism.

```go
provider, err := gateway.New(
    config.WithBaseURL("http://localhost:8000/v1"),
    config.WithAPIKey("tk_your_platform_token"),
    gateway.WithPlatformMode(),
)
```

**Non-platform mode**: A gateway API key is sent via the `X-AnyLLM-Key` header using a custom `http.RoundTripper` wrapper, requiring no changes to shared code.

```go
provider, err := gateway.New(
    config.WithBaseURL("http://localhost:8000/v1"),
    gateway.WithGatewayKey("your-gateway-key"),
)
```

Platform mode auto-detection: If `GATEWAY_PLATFORM_TOKEN` is set and no explicit API key or gateway key is provided, platform mode is automatically enabled.

| Env Var | Purpose |
|---------|---------|
| `GATEWAY_API_BASE` | Gateway URL (e.g. `http://localhost:8000/v1`) |
| `GATEWAY_API_KEY` | Non-platform mode key (sent via `X-AnyLLM-Key` header) |
| `GATEWAY_PLATFORM_TOKEN` | Platform mode token (sent as Bearer auth) |

### Required Base URL (`providers/openai/compatible.go`)

`CompatibleConfig` gains a `RequireBaseURL bool` field, parallel to the existing `RequireAPIKey`. When set, `NewCompatible` enforces a non-empty base URL and returns a human-readable error that names the configured env var. The gateway provider sets this flag — there is no sensible default gateway URL — so misconfiguration fails fast at construction time rather than surfacing later as an opaque network error.

### Relationship to `providers/platform`

The gateway provider replaces the platform provider for new integrations. The platform provider (`providers/platform/`) authenticates with the platform API to decrypt provider keys, then fans out to individual provider SDKs (OpenAI, Anthropic, etc.) client-side. The gateway provider instead sends all requests through a single server-side gateway endpoint, which handles provider routing, key management, and usage tracking.

`providers/platform` remains in the repo for backward compatibility but new consumers should use `providers/gateway`.

### Error Types

- `InsufficientFundsError` / `ErrInsufficientFunds` (HTTP 402) — shared `errors` package
- `UpstreamProviderError` / `ErrUpstreamProvider` (HTTP 502) — `providers/gateway` package
- `TimeoutError` / `ErrTimeout` (HTTP 504) — `providers/gateway` package

Gateway-specific error types live in the gateway package since upstream-provider and gateway-timeout are gateway domain concepts. `InsufficientFundsError` is in the shared package since billing errors can apply to any provider.

### Post-review cleanup

Craftsmanship work applied on top of the initial implementation:

- `gateway.New()` no longer duplicates base-URL resolution. User opts flow straight through; auth-specific opts are layered via `slices.Clone + append`. The HTTPClient-drop regression that recurred across earlier review rounds is structurally impossible in this form.
- Package-name stutter removed: `GatewayTimeoutError` → `TimeoutError`, `ErrGatewayTimeout` → `ErrTimeout`.
- Internal names clarified: `defaultNonPlatformKey` → `placeholderAPIKey` (with a godoc explaining why the SDK needs *any* key when auth goes via a custom header), `gatewayHeader` → `apiKeyHeaderName`.
- Single-use error constructors inlined into `ConvertError`; every package constant and exported sentinel now carries a godoc line; type ordering corrected (exported before unexported helpers).
- `errors.NewBaseError` renamed to `errors.New` with an explanatory godoc. The old name read like "construct an error of kind `BaseError`" — but `BaseError` is never returned directly; the helper exists only so packages outside `errors` can populate the unexported `sentinel` field that drives `errors.Is` matching.

### Tests

- Unit tests: constructor validation, mode detection, header injection, completion/streaming, error conversion for all gateway-specific status codes (402, 502, 504) plus inherited ones (401, 404, 429)
- `TestNewCompatibleRequireBaseURL` — six cases asserting the full error message on both branches (env var named vs not)
- `TestExtraValueHandling` — table-driven with six cases, using `httptest` to assert wire-level behaviour: silent fallthrough on wrong-typed `Extra` values, empty-string handling, env-var fallthrough, and proof-of-mode via which auth header is actually sent
- `TestPlatformModeDetection` — reorganised to table-driven, scoped to auto-detect-suppression cases
- Integration tests: guarded by `GATEWAY_API_BASE` and `GATEWAY_PLATFORM_TOKEN` env vars, verified against a live gateway
- All existing tests continue to pass