### PR TITLE
refactor(gateway): post-review cleanup of gateway provider and tests

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -156,6 +156,17 @@ func NewAuthenticationError(provider string, err error) *AuthenticationError {
 	}
 }
 
+// NewBaseError creates a BaseError with the given fields. This allows provider
+// packages to define their own error types that embed BaseError with a sentinel.
+func NewBaseError(code, provider string, err, sentinel error) BaseError {
+	return BaseError{
+		Code:     code,
+		Provider: provider,
+		Err:      err,
+		sentinel: sentinel,
+	}
+}
+
 // NewInvalidRequestError creates a new InvalidRequestError.
 func NewInvalidRequestError(provider string, err error) *InvalidRequestError {
 	return &InvalidRequestError{
@@ -254,17 +265,6 @@ func NewUnsupportedParamError(provider string, param string) *UnsupportedParamEr
 			sentinel: ErrUnsupportedParam,
 		},
 		Param: param,
-	}
-}
-
-// NewBaseError creates a BaseError with the given fields. This allows provider
-// packages to define their own error types that embed BaseError with a sentinel.
-func NewBaseError(code, provider string, err, sentinel error) BaseError {
-	return BaseError{
-		Code:     code,
-		Provider: provider,
-		Err:      err,
-		sentinel: sentinel,
 	}
 }
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -230,7 +230,6 @@ func TestErrorCodes(t *testing.T) {
 		err := NewInsufficientFundsError("gateway", nil)
 		require.Equal(t, CodeInsufficientFunds, err.Code)
 	})
-
 }
 
 func TestErrorAs(t *testing.T) {
@@ -279,5 +278,4 @@ func TestErrorAs(t *testing.T) {
 		require.True(t, stderrors.As(err, &fundsErr))
 		require.Equal(t, "gateway", fundsErr.Provider)
 	})
-
 }

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -17,6 +17,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"net/http"
+	"slices"
 
 	"github.com/openai/openai-go"
 
@@ -28,26 +29,62 @@ import (
 
 // Provider configuration constants.
 const (
-	bearerPrefix          = "Bearer "
-	defaultNonPlatformKey = "gateway-no-key"
-	envAPIBase            = "GATEWAY_API_BASE"
-	envAPIKey             = "GATEWAY_API_KEY"
-	envPlatformToken      = "GATEWAY_PLATFORM_TOKEN"
-	extraKeyGatewayKey    = "gateway_key"
-	extraKeyPlatformMode  = "platform_mode"
-	gatewayHeader         = "X-AnyLLM-Key"
-	providerName          = "gateway"
+	// apiKeyHeaderName is the HTTP header that carries the gateway API key in
+	// non-platform mode.
+	apiKeyHeaderName = "X-AnyLLM-Key"
+
+	// bearerPrefix is the Authorization scheme prefix applied to the gateway
+	// key before it is placed in the gateway header (e.g. "Bearer <key>").
+	bearerPrefix = "Bearer "
+
+	// placeholderAPIKey satisfies the OpenAI SDK's requirement that an API key
+	// be set. In non-platform mode real auth is carried by the gateway header,
+	// so this value is never sent as a credential.
+	placeholderAPIKey = "gateway-no-key"
+
+	// envAPIBase is the environment variable read for the gateway base URL
+	// when WithBaseURL is not passed to New.
+	envAPIBase = "GATEWAY_API_BASE"
+
+	// envAPIKey is the environment variable read for the gateway API key used
+	// in non-platform mode when WithGatewayKey is not passed to New.
+	envAPIKey = "GATEWAY_API_KEY"
+
+	// envPlatformToken is the environment variable read for the platform
+	// token used as Bearer auth in platform mode.
+	envPlatformToken = "GATEWAY_PLATFORM_TOKEN"
+
+	// extraKeyGatewayKey is the config.Extra key used to coordinate
+	// WithGatewayKey (writer) with the resolver logic in New (reader).
+	extraKeyGatewayKey = "gateway_key"
+
+	// extraKeyPlatformMode is the config.Extra key used to coordinate
+	// WithPlatformMode (writer) with the resolver logic in New (reader).
+	extraKeyPlatformMode = "platform_mode"
+
+	// providerName is the value returned by Provider.Name and embedded in
+	// errors produced by this package.
+	providerName = "gateway"
 )
 
 // Gateway-specific error codes.
 const (
-	codeGatewayTimeout   = "gateway_timeout"
-	codeUpstreamProvider = "upstream_provider"
+	// errCodeTimeout is the BaseError.Code set on gateway timeout errors
+	// (HTTP 504).
+	errCodeTimeout = "gateway_timeout"
+
+	// errCodeUpstreamProvider is the BaseError.Code set on upstream provider
+	// errors (HTTP 502).
+	errCodeUpstreamProvider = "upstream_provider"
 )
 
 // Gateway-specific sentinel errors for type checking with errors.Is().
 var (
-	ErrGatewayTimeout   = stderrors.New("gateway timeout")
+	// ErrTimeout is matched by errors.Is on gateway timeout errors (HTTP 504).
+	ErrTimeout = stderrors.New("gateway timeout")
+
+	// ErrUpstreamProvider is matched by errors.Is on upstream provider errors
+	// (HTTP 502).
 	ErrUpstreamProvider = stderrors.New("upstream provider error")
 )
 
@@ -60,11 +97,27 @@ var (
 	_ providers.Provider           = (*Provider)(nil)
 )
 
+// TimeoutError is returned when the gateway times out (HTTP 504).
+type TimeoutError struct {
+	errors.BaseError
+}
+
+// UpstreamProviderError is returned when the upstream provider is
+// unreachable (HTTP 502).
+type UpstreamProviderError struct {
+	errors.BaseError
+}
+
 // Provider implements the providers.Provider interface for the any-llm gateway.
 // It embeds openai.CompatibleProvider since the gateway exposes an
 // OpenAI-compatible API.
 type Provider struct {
 	*openaiProvider.CompatibleProvider
+
+	// platformMode is used to indicate whether the provider is operating in
+	// platform mode (using platform token for Bearer auth) or non-platform mode
+	// (using gateway key in custom header).
+	// This affects how authentication is handled and how errors are converted.
 	platformMode bool
 }
 
@@ -75,25 +128,6 @@ type headerTransport struct {
 	base   http.RoundTripper
 	header string
 	value  string
-}
-
-// GatewayTimeoutError is returned when the gateway times out (HTTP 504).
-type GatewayTimeoutError struct {
-	errors.BaseError
-}
-
-// UpstreamProviderError is returned when the upstream provider is
-// unreachable (HTTP 502).
-type UpstreamProviderError struct {
-	errors.BaseError
-}
-
-// RoundTrip implements http.RoundTripper by cloning the request and injecting
-// the configured header before delegating to the base transport.
-func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	clone := req.Clone(req.Context())
-	clone.Header.Set(t.header, t.value)
-	return t.base.RoundTrip(clone)
 }
 
 // New creates a new gateway provider.
@@ -112,18 +146,6 @@ func New(opts ...config.Option) (*Provider, error) {
 	cfg, err := config.New(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("invalid options: %w", err)
-	}
-
-	// Validate that a base URL is provided (gateway requires it).
-	// Resolution itself is delegated to NewCompatible via BaseURLEnvVar.
-	baseURL, err := cfg.ResolveBaseURL(envAPIBase, "")
-	if err != nil {
-		return nil, err
-	}
-	if baseURL == "" {
-		return nil, fmt.Errorf(
-			"gateway base URL is required (set via WithBaseURL option or %s env var)", envAPIBase,
-		)
 	}
 
 	// Resolve gateway key from extras or GATEWAY_API_KEY env var.
@@ -169,28 +191,27 @@ func New(opts ...config.Option) (*Provider, error) {
 		)
 	}
 
-	// Build options for the underlying OpenAI-compatible provider.
-	compatOpts := []config.Option{config.WithBaseURL(baseURL)}
-	if cfg.Timeout > 0 {
-		compatOpts = append(compatOpts, config.WithTimeout(cfg.Timeout))
-	}
-
-	httpClient := cfg.HTTPClient()
+	// Pass the user's opts straight through and layer auth-specific opts on
+	// top (order matters: later options win). Base URL resolution and the
+	// required-URL check are delegated to NewCompatible via BaseURLEnvVar
+	// and RequireBaseURL.
+	compatOpts := slices.Clone(opts)
 	if platformMode {
 		compatOpts = append(compatOpts, config.WithAPIKey(platformToken))
 	} else if gatewayKey != "" {
-		httpClient = newHeaderClient(httpClient, bearerPrefix+gatewayKey)
+		client := newHeaderClient(cfg.HTTPClient(), bearerPrefix+gatewayKey)
+		compatOpts = append(compatOpts, config.WithHTTPClient(client))
 	}
-	compatOpts = append(compatOpts, config.WithHTTPClient(httpClient))
 
 	base, err := openaiProvider.NewCompatible(openaiProvider.CompatibleConfig{
 		APIKeyEnvVar:   "",         // Gateway uses its own key resolution.
 		BaseURLEnvVar:  envAPIBase, // Env var for base URL resolution.
 		Capabilities:   capabilities(),
-		DefaultAPIKey:  defaultNonPlatformKey, // Placeholder; non-platform doesn't need real auth.
-		DefaultBaseURL: "",                    // No default; base URL is required.
+		DefaultAPIKey:  placeholderAPIKey, // Placeholder; non-platform doesn't need real auth.
+		DefaultBaseURL: "",                // No default; base URL is required.
 		Name:           providerName,
 		RequireAPIKey:  false, // Gateway handles auth separately.
+		RequireBaseURL: true,  // Gateway has no sensible default endpoint.
 	}, compatOpts...)
 	if err != nil {
 		return nil, err
@@ -200,6 +221,24 @@ func New(opts ...config.Option) (*Provider, error) {
 		CompatibleProvider: base,
 		platformMode:       platformMode,
 	}, nil
+}
+
+// capabilities returns the full set of capabilities for the gateway provider.
+// Since the gateway proxies to any backend provider, all features are
+// optimistically marked as supported. Actual support depends on the
+// underlying provider behind the gateway; consumers should handle
+// unsupported-operation errors at call time.
+func capabilities() providers.Capabilities {
+	return providers.Capabilities{
+		Completion:          true,
+		CompletionImage:     true,
+		CompletionPDF:       true,
+		CompletionReasoning: true,
+		CompletionStreaming: true,
+		CompletionTools:     true,
+		Embedding:           true,
+		ListModels:          true,
+	}
 }
 
 // WithGatewayKey sets the gateway API key for non-platform mode authentication.
@@ -278,9 +317,13 @@ func (p *Provider) ConvertError(err error) error {
 		case http.StatusPaymentRequired:
 			return errors.NewInsufficientFundsError(providerName, apiErr)
 		case http.StatusBadGateway:
-			return newUpstreamProviderError(providerName, apiErr)
+			return &UpstreamProviderError{
+				BaseError: errors.NewBaseError(errCodeUpstreamProvider, providerName, apiErr, ErrUpstreamProvider),
+			}
 		case http.StatusGatewayTimeout:
-			return newGatewayTimeoutError(providerName, apiErr)
+			return &TimeoutError{
+				BaseError: errors.NewBaseError(errCodeTimeout, providerName, apiErr, ErrTimeout),
+			}
 		}
 	}
 
@@ -320,29 +363,12 @@ func (p *Provider) ListModels(ctx context.Context) (*providers.ModelsResponse, e
 	return resp, nil
 }
 
-// capabilities returns the full set of capabilities for the gateway provider.
-// Since the gateway proxies to any backend provider, all features are
-// optimistically marked as supported. Actual support depends on the
-// underlying provider behind the gateway; consumers should handle
-// unsupported-operation errors at call time.
-func capabilities() providers.Capabilities {
-	return providers.Capabilities{
-		Completion:          true,
-		CompletionImage:     true,
-		CompletionPDF:       true,
-		CompletionReasoning: true,
-		CompletionStreaming: true,
-		CompletionTools:     true,
-		Embedding:           true,
-		ListModels:          true,
-	}
-}
-
-// newGatewayTimeoutError creates a new GatewayTimeoutError.
-func newGatewayTimeoutError(provider string, err error) *GatewayTimeoutError {
-	return &GatewayTimeoutError{
-		BaseError: errors.NewBaseError(codeGatewayTimeout, provider, err, ErrGatewayTimeout),
-	}
+// RoundTrip implements http.RoundTripper by cloning the request and injecting
+// the configured header before delegating to the base transport.
+func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.Header.Set(t.header, t.value)
+	return t.base.RoundTrip(clone)
 }
 
 // newHeaderClient wraps the given HTTP client's transport to inject the
@@ -357,15 +383,8 @@ func newHeaderClient(base *http.Client, headerValue string) *http.Client {
 		Timeout: base.Timeout,
 		Transport: &headerTransport{
 			base:   transport,
-			header: gatewayHeader,
+			header: apiKeyHeaderName,
 			value:  headerValue,
 		},
-	}
-}
-
-// newUpstreamProviderError creates a new UpstreamProviderError.
-func newUpstreamProviderError(provider string, err error) *UpstreamProviderError {
-	return &UpstreamProviderError{
-		BaseError: errors.NewBaseError(codeUpstreamProvider, provider, err, ErrUpstreamProvider),
 	}
 }

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -38,8 +38,9 @@ const (
 	bearerPrefix = "Bearer "
 
 	// placeholderAPIKey satisfies the OpenAI SDK's requirement that an API key
-	// be set. In non-platform mode real auth is carried by the gateway header,
-	// so this value is never sent as a credential.
+	// be set. The SDK still sends it in the Authorization header, but in
+	// non-platform mode real auth is carried by the gateway header, so this
+	// is a non-secret placeholder that the gateway ignores.
 	placeholderAPIKey = "gateway-no-key"
 
 	// envAPIBase is the environment variable read for the gateway base URL
@@ -198,9 +199,15 @@ func New(opts ...config.Option) (*Provider, error) {
 	compatOpts := slices.Clone(opts)
 	if platformMode {
 		compatOpts = append(compatOpts, config.WithAPIKey(platformToken))
-	} else if gatewayKey != "" {
-		client := newHeaderClient(cfg.HTTPClient(), bearerPrefix+gatewayKey)
-		compatOpts = append(compatOpts, config.WithHTTPClient(client))
+	} else {
+		// Non-platform mode: override any user-supplied API key with the
+		// placeholder so secrets can't leak via the Authorization header.
+		// Real auth, if any, is carried by the gateway header below.
+		compatOpts = append(compatOpts, config.WithAPIKey(placeholderAPIKey))
+		if gatewayKey != "" {
+			client := newHeaderClient(cfg.HTTPClient(), bearerPrefix+gatewayKey)
+			compatOpts = append(compatOpts, config.WithHTTPClient(client))
+		}
 	}
 
 	base, err := openaiProvider.NewCompatible(openaiProvider.CompatibleConfig{

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -24,7 +24,6 @@ import (
 const (
 	objectChatCompletion      = "chat.completion"
 	objectChatCompletionChunk = "chat.completion.chunk"
-	objectList                = "list"
 )
 
 func TestNew(t *testing.T) {
@@ -184,7 +183,7 @@ func TestNew(t *testing.T) {
 		require.NoError(t, err)
 
 		// Non-platform mode: gateway key sent via custom header.
-		require.Equal(t, bearerPrefix+"gw_key", capturedHeaders.Get(gatewayHeader))
+		require.Equal(t, bearerPrefix+"gw_key", capturedHeaders.Get(apiKeyHeaderName))
 		// Custom transport should have been used (wrapped by headerTransport).
 		require.True(t, customTransport.called, "custom transport should be used as base")
 	})
@@ -217,48 +216,155 @@ func TestCapabilities(t *testing.T) {
 }
 
 func TestPlatformModeDetection(t *testing.T) {
-	// Note: Not using t.Parallel() here because child tests use t.Setenv.
+	// Note: Not using t.Parallel() because subtests use t.Setenv.
 
-	t.Run("does not auto-detect when API key is explicitly set", func(t *testing.T) {
-		t.Setenv(envAPIBase, "http://localhost:8000/v1")
-		t.Setenv(envPlatformToken, "tk_auto")
+	tests := []struct {
+		name             string
+		envPlatformToken string
+		envAPIKey        string
+		apiKey           string
+		gatewayKey       string
+		wantPlatform     bool
+	}{
+		{
+			name:             "does not auto-detect when API key is explicitly set",
+			envPlatformToken: "tk_auto",
+			apiKey:           "explicit_key",
+			wantPlatform:     false,
+		},
+		{
+			name:             "does not auto-detect when gateway key is explicitly set",
+			envPlatformToken: "tk_auto",
+			gatewayKey:       "gw_key",
+			wantPlatform:     false,
+		},
+	}
 
-		provider, err := New(config.WithAPIKey("explicit_key"))
-		require.NoError(t, err)
-		require.False(t, provider.platformMode)
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envAPIBase, "http://localhost:8000/v1")
+			t.Setenv(envPlatformToken, tc.envPlatformToken)
+			t.Setenv(envAPIKey, tc.envAPIKey)
 
-	t.Run("does not auto-detect when gateway key is set", func(t *testing.T) {
-		t.Setenv(envAPIBase, "http://localhost:8000/v1")
-		t.Setenv(envPlatformToken, "tk_auto")
-		t.Setenv(envAPIKey, "")
+			var opts []config.Option
+			if tc.apiKey != "" {
+				opts = append(opts, config.WithAPIKey(tc.apiKey))
+			}
+			if tc.gatewayKey != "" {
+				opts = append(opts, WithGatewayKey(tc.gatewayKey))
+			}
 
-		provider, err := New(WithGatewayKey("gw_key"))
-		require.NoError(t, err)
-		require.False(t, provider.platformMode)
-	})
+			provider, err := New(opts...)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantPlatform, provider.platformMode)
+		})
+	}
+}
 
-	t.Run("ignores non-bool platform_mode extra value", func(t *testing.T) {
-		t.Setenv(envAPIBase, "http://localhost:8000/v1")
-		t.Setenv(envPlatformToken, "")
-		t.Setenv(envAPIKey, "")
+// TestExtraValueHandling verifies that the config.Extra mechanism correctly
+// ignores wrong-typed values (silent fallthrough) and honours valid ones.
+// Assertions are made on the wire to prove the mode actually took effect,
+// not just that the provider constructed without error.
+func TestExtraValueHandling(t *testing.T) {
+	// Note: Not using t.Parallel() because subtests use t.Setenv.
 
-		// Pass "true" as string instead of bool - should be ignored.
-		provider, err := New(config.WithExtra(extraKeyPlatformMode, "true"))
-		require.NoError(t, err)
-		require.False(t, provider.platformMode)
-	})
+	tests := []struct {
+		name              string
+		extraKey          string
+		extraValue        any
+		envAPIKey         string
+		apiKey            string
+		gatewayKey        string
+		wantAPIKeyHeader  string // expected X-AnyLLM-Key value; empty means the header must not be sent.
+		wantAuthorization string // expected Authorization value.
+	}{
+		{
+			name:              "string gateway_key is forwarded as the gateway key header",
+			extraKey:          extraKeyGatewayKey,
+			extraValue:        "valid_key",
+			wantAPIKeyHeader:  bearerPrefix + "valid_key",
+			wantAuthorization: bearerPrefix + placeholderAPIKey,
+		},
+		{
+			name:              "int gateway_key is silently ignored",
+			extraKey:          extraKeyGatewayKey,
+			extraValue:        123,
+			wantAPIKeyHeader:  "",
+			wantAuthorization: bearerPrefix + placeholderAPIKey,
+		},
+		{
+			name:              "empty-string gateway_key is treated as unset",
+			extraKey:          extraKeyGatewayKey,
+			extraValue:        "",
+			wantAPIKeyHeader:  "",
+			wantAuthorization: bearerPrefix + placeholderAPIKey,
+		},
+		{
+			name:              "empty-string gateway_key falls through to GATEWAY_API_KEY env var",
+			extraKey:          extraKeyGatewayKey,
+			extraValue:        "",
+			envAPIKey:         "env_fallback_key",
+			wantAPIKeyHeader:  bearerPrefix + "env_fallback_key",
+			wantAuthorization: bearerPrefix + placeholderAPIKey,
+		},
+		{
+			name:              "bool platform_mode enables platform-mode Bearer auth",
+			extraKey:          extraKeyPlatformMode,
+			extraValue:        true,
+			apiKey:            "platform_token",
+			wantAPIKeyHeader:  "",
+			wantAuthorization: bearerPrefix + "platform_token",
+		},
+		{
+			// Passing a string instead of bool must not flip into platform mode.
+			// Combining with a gateway key proves the non-platform path was
+			// taken: an honoured platform_mode would suppress the gateway
+			// header.
+			name:              "string platform_mode is silently ignored",
+			extraKey:          extraKeyPlatformMode,
+			extraValue:        "true",
+			apiKey:            "platform_token",
+			gatewayKey:        "gw_key",
+			wantAPIKeyHeader:  bearerPrefix + "gw_key",
+			wantAuthorization: bearerPrefix + "platform_token",
+		},
+	}
 
-	t.Run("ignores non-string gateway_key extra value", func(t *testing.T) {
-		t.Setenv(envAPIBase, "http://localhost:8000/v1")
-		t.Setenv(envPlatformToken, "")
-		t.Setenv(envAPIKey, "")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envAPIBase, "")
+			t.Setenv(envAPIKey, tc.envAPIKey)
+			t.Setenv(envPlatformToken, "")
 
-		// Pass 123 as int instead of string - should be ignored.
-		provider, err := New(config.WithExtra(extraKeyGatewayKey, 123))
-		require.NoError(t, err)
-		require.NotNil(t, provider)
-	})
+			var capturedHeaders http.Header
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedHeaders = r.Header.Clone()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(mockCompletionResponse("ok")))
+			}))
+			t.Cleanup(srv.Close)
+
+			opts := []config.Option{
+				config.WithBaseURL(srv.URL),
+				config.WithExtra(tc.extraKey, tc.extraValue),
+			}
+			if tc.apiKey != "" {
+				opts = append(opts, config.WithAPIKey(tc.apiKey))
+			}
+			if tc.gatewayKey != "" {
+				opts = append(opts, WithGatewayKey(tc.gatewayKey))
+			}
+
+			provider, err := New(opts...)
+			require.NoError(t, err)
+
+			_, err = provider.Completion(context.Background(), mockCompletionParams())
+			require.NoError(t, err)
+
+			require.Equal(t, tc.wantAPIKeyHeader, capturedHeaders.Get(apiKeyHeaderName))
+			require.Equal(t, tc.wantAuthorization, capturedHeaders.Get("Authorization"))
+		})
+	}
 }
 
 func TestHeaderTransport(t *testing.T) {
@@ -273,9 +379,9 @@ func TestHeaderTransport(t *testing.T) {
 	}{
 		{
 			name:       "injects gateway header",
-			header:     gatewayHeader,
+			header:     apiKeyHeaderName,
 			value:      bearerPrefix + "test-key",
-			wantHeader: gatewayHeader,
+			wantHeader: apiKeyHeaderName,
 			wantValue:  bearerPrefix + "test-key",
 		},
 		{
@@ -325,7 +431,7 @@ func TestHeaderTransport(t *testing.T) {
 
 		transport := &headerTransport{
 			base:   http.DefaultTransport,
-			header: gatewayHeader,
+			header: apiKeyHeaderName,
 			value:  bearerPrefix + "key",
 		}
 
@@ -337,7 +443,7 @@ func TestHeaderTransport(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 
 		// Original request should not have the injected header.
-		require.Empty(t, req.Header.Get(gatewayHeader))
+		require.Empty(t, req.Header.Get(apiKeyHeaderName))
 	})
 }
 
@@ -372,7 +478,7 @@ func TestNonPlatformModeSendsCustomHeader(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	require.Equal(t, bearerPrefix+"gw_test_key_123", capturedHeaders.Get(gatewayHeader))
+	require.Equal(t, bearerPrefix+"gw_test_key_123", capturedHeaders.Get(apiKeyHeaderName))
 }
 
 func TestPlatformModeSendsBearerAuth(t *testing.T) {
@@ -408,7 +514,7 @@ func TestPlatformModeSendsBearerAuth(t *testing.T) {
 	defer mu.Unlock()
 
 	require.Equal(t, bearerPrefix+"tk_platform_token", capturedHeaders.Get("Authorization"))
-	require.Empty(t, capturedHeaders.Get(gatewayHeader),
+	require.Empty(t, capturedHeaders.Get(apiKeyHeaderName),
 		"platform mode should not send gateway key header")
 }
 
@@ -503,7 +609,7 @@ func TestStreamingContextCancellation(t *testing.T) {
 		w.Header().Set("Content-Type", "text/event-stream")
 
 		// Send chunks slowly so context cancellation happens mid-stream.
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			chunk := fmt.Sprintf(
 				`{"id":"chatcmpl-gw","object":"chat.completion.chunk","created":1700000000,"model":"test-model","choices":[{"index":0,"delta":{"content":"chunk-%d"},"finish_reason":null}]}`,
 				i,
@@ -586,10 +692,10 @@ func TestConvertError(t *testing.T) {
 			wantErr:    ErrUpstreamProvider,
 		},
 		{
-			name:       "504 returns GatewayTimeoutError",
+			name:       "504 returns TimeoutError",
 			statusCode: http.StatusGatewayTimeout,
 			body:       `{"error": {"message": "gateway timeout", "type": "timeout", "code": "timeout"}}`,
-			wantErr:    ErrGatewayTimeout,
+			wantErr:    ErrTimeout,
 		},
 	}
 
@@ -645,7 +751,7 @@ func TestNonPlatformModeAlsoConvertsGatewayErrors(t *testing.T) {
 			name:       "504 in non-platform mode",
 			statusCode: http.StatusGatewayTimeout,
 			body:       `{"error": {"message": "gateway timeout", "type": "timeout", "code": "timeout"}}`,
-			wantErr:    ErrGatewayTimeout,
+			wantErr:    ErrTimeout,
 		},
 	}
 

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -319,14 +319,16 @@ func TestExtraValueHandling(t *testing.T) {
 			// Passing a string instead of bool must not flip into platform mode.
 			// Combining with a gateway key proves the non-platform path was
 			// taken: an honoured platform_mode would suppress the gateway
-			// header.
+			// header. WithAPIKey is also passed to verify it does NOT leak
+			// into Authorization in non-platform mode — the placeholder is
+			// used instead.
 			name:              "string platform_mode is silently ignored",
 			extraKey:          extraKeyPlatformMode,
 			extraValue:        "true",
 			apiKey:            "platform_token",
 			gatewayKey:        "gw_key",
 			wantAPIKeyHeader:  bearerPrefix + "gw_key",
-			wantAuthorization: bearerPrefix + "platform_token",
+			wantAuthorization: bearerPrefix + placeholderAPIKey,
 		},
 	}
 
@@ -336,9 +338,14 @@ func TestExtraValueHandling(t *testing.T) {
 			t.Setenv(envAPIKey, tc.envAPIKey)
 			t.Setenv(envPlatformToken, "")
 
-			var capturedHeaders http.Header
+			var (
+				mu              sync.Mutex
+				capturedHeaders http.Header
+			)
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
 				capturedHeaders = r.Header.Clone()
+				mu.Unlock()
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(mockCompletionResponse("ok")))
 			}))
@@ -360,6 +367,9 @@ func TestExtraValueHandling(t *testing.T) {
 
 			_, err = provider.Completion(context.Background(), mockCompletionParams())
 			require.NoError(t, err)
+
+			mu.Lock()
+			defer mu.Unlock()
 
 			require.Equal(t, tc.wantAPIKeyHeader, capturedHeaders.Get(apiKeyHeaderName))
 			require.Equal(t, tc.wantAuthorization, capturedHeaders.Get("Authorization"))

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -78,6 +78,12 @@ type CompatibleConfig struct {
 
 	// RequireAPIKey indicates whether an API key is required.
 	RequireAPIKey bool
+
+	// RequireBaseURL indicates whether a base URL must be resolvable from
+	// WithBaseURL, BaseURLEnvVar, or DefaultBaseURL. When true, NewCompatible
+	// returns an error if none of those yield a value. Used by providers that
+	// have no sensible default endpoint (e.g. gateway).
+	RequireBaseURL bool
 }
 
 // Ensure CompatibleProvider implements the required interfaces.
@@ -110,6 +116,21 @@ func NewCompatible(compatCfg CompatibleConfig, opts ...config.Option) (*Compatib
 	baseURL, err := cfg.ResolveBaseURL(compatCfg.BaseURLEnvVar, compatCfg.DefaultBaseURL)
 	if err != nil {
 		return nil, err
+	}
+
+	if baseURL == "" && compatCfg.RequireBaseURL {
+		if compatCfg.BaseURLEnvVar == "" {
+			return nil, fmt.Errorf(
+				"%s base URL is required (set via WithBaseURL option)",
+				compatCfg.Name,
+			)
+		}
+
+		return nil, fmt.Errorf(
+			"%s base URL is required (set via WithBaseURL option or %q env var)",
+			compatCfg.Name,
+			compatCfg.BaseURLEnvVar,
+		)
 	}
 
 	apiKey := resolveAPIKey(cfg, compatCfg)

--- a/providers/openai/compatible_test.go
+++ b/providers/openai/compatible_test.go
@@ -107,6 +107,88 @@ func TestNewCompatible(t *testing.T) {
 	})
 }
 
+func TestNewCompatibleRequireBaseURL(t *testing.T) {
+	// Note: Not using t.Parallel() because subtests use t.Setenv.
+
+	const (
+		envVar       = "TEST_COMPATIBLE_REQUIRE_BASEURL"
+		providerName = "test-provider"
+	)
+
+	tests := []struct {
+		name           string
+		baseURLEnvVar  string
+		defaultBaseURL string
+		envValue       string
+		withBaseURL    string
+		requireBaseURL bool
+		wantErr        string // empty means no error expected.
+	}{
+		{
+			name:           "errors when required and no env var configured",
+			requireBaseURL: true,
+			wantErr:        providerName + " base URL is required (set via WithBaseURL option)",
+		},
+		{
+			name:           "errors when required and env var name set but unset",
+			baseURLEnvVar:  envVar,
+			requireBaseURL: true,
+			wantErr: providerName + ` base URL is required (set via WithBaseURL option or "` +
+				envVar + `" env var)`,
+		},
+		{
+			name:           "succeeds when required and WithBaseURL is provided",
+			requireBaseURL: true,
+			withBaseURL:    "http://custom:9090/v1",
+		},
+		{
+			name:           "succeeds when required and env var resolves",
+			baseURLEnvVar:  envVar,
+			envValue:       "http://env:8080/v1",
+			requireBaseURL: true,
+		},
+		{
+			name:           "succeeds when required and DefaultBaseURL is set",
+			defaultBaseURL: "http://default:8080/v1",
+			requireBaseURL: true,
+		},
+		{
+			name:           "does not error when not required and no URL resolves",
+			requireBaseURL: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envVar, tc.envValue)
+
+			baseCfg := CompatibleConfig{
+				Name:           providerName,
+				BaseURLEnvVar:  tc.baseURLEnvVar,
+				DefaultAPIKey:  "test-key",
+				DefaultBaseURL: tc.defaultBaseURL,
+				RequireBaseURL: tc.requireBaseURL,
+			}
+
+			var opts []config.Option
+			if tc.withBaseURL != "" {
+				opts = append(opts, config.WithBaseURL(tc.withBaseURL))
+			}
+
+			provider, err := NewCompatible(baseCfg, opts...)
+
+			if tc.wantErr != "" {
+				require.EqualError(t, err, tc.wantErr)
+				require.Nil(t, provider)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, provider)
+		})
+	}
+}
+
 func TestCompatibleProviderCapabilities(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Cleanup on top of `feat/gateway-provider` addressing outstanding craftsmanship feedback from the PR review. One commit so it's easy to cherry-pick or drop.

## Shared (openai package)

- `CompatibleConfig` gets a new `RequireBaseURL bool` field, parallel to the existing `RequireAPIKey`. `NewCompatible` now enforces a non-empty base URL for providers with no sensible default, producing a human-readable error that names the env var when configured.

## Gateway

- `New()` no longer duplicates base-URL resolution. User opts flow straight through; auth-specific opts are layered on top via `slices.Clone + append`. The HTTPClient-drop regression from earlier review rounds is structurally impossible in this form — the gateway never rebuilds `compatOpts` from scratch.
- Package-name stutter removed: `GatewayTimeoutError` → `TimeoutError`, `ErrGatewayTimeout` → `ErrTimeout`.
- Two single-use error constructors inlined into `ConvertError`.
- `defaultNonPlatformKey` → `placeholderAPIKey`, with a godoc explaining why it exists at all (SDK requires a key; gateway authenticates via custom header).
- `gatewayHeader` → `apiKeyHeaderName`.
- Every package constant and exported sentinel now carries a godoc line.
- Type ordering corrected (exported before unexported helpers); `RoundTrip` moved out of the types section and down to the methods section.
- `Provider.platformMode` is now documented.

## Tests

- **`TestNewCompatibleRequireBaseURL`** — six cases, `require.EqualError` on the full message. Verifies both branches of the error (env var named vs not).
- **`TestExtraValueHandling`** — new table-driven suite, six cases. Uses `httptest` to assert wire-level behaviour: silent fallthrough on wrong-typed `Extra` values, empty-string handling, env-var fallthrough, and proof-of-mode via which auth header actually gets sent. Replaces the weaker checks that only verified `provider != nil`.
- **`TestPlatformModeDetection`** — reorganised to table-driven form, trimmed to auto-detect-suppression cases only.

## What's deliberately NOT in this PR

- **`providers/platform` removal / `git mv`** — architectural decision that belongs with you, not a cleanup PR.