### PR TITLE
feat: add batch API support with gateway provider

### DIFF
--- a/anyllm.go
+++ b/anyllm.go
@@ -149,7 +149,6 @@ var (
 // Sentinel errors for type checking with errors.Is().
 var (
 	ErrAuthentication      = errors.ErrAuthentication
-	ErrBatchNotComplete    = errors.ErrBatchNotComplete
 	ErrContentFilter       = errors.ErrContentFilter
 	ErrContextLength       = errors.ErrContextLength
 	ErrInsufficientFunds   = errors.ErrInsufficientFunds
@@ -166,7 +165,6 @@ var (
 type (
 	AuthenticationError      = errors.AuthenticationError
 	BaseError                = errors.BaseError
-	BatchNotCompleteError    = errors.BatchNotCompleteError
 	ContentFilterError       = errors.ContentFilterError
 	ContextLengthError       = errors.ContextLengthError
 	InsufficientFundsError   = errors.InsufficientFundsError

--- a/anyllm.go
+++ b/anyllm.go
@@ -39,6 +39,18 @@ const (
 	FinishReasonToolCalls     = providers.FinishReasonToolCalls
 )
 
+// Batch status constants.
+const (
+	BatchStatusCancelled  = providers.BatchStatusCancelled
+	BatchStatusCancelling = providers.BatchStatusCancelling
+	BatchStatusCompleted  = providers.BatchStatusCompleted
+	BatchStatusExpired    = providers.BatchStatusExpired
+	BatchStatusFailed     = providers.BatchStatusFailed
+	BatchStatusFinalizing = providers.BatchStatusFinalizing
+	BatchStatusInProgress = providers.BatchStatusInProgress
+	BatchStatusValidating = providers.BatchStatusValidating
+)
+
 // ReasoningEffort levels.
 const (
 	ReasoningEffortAuto   = providers.ReasoningEffortAuto
@@ -50,11 +62,24 @@ const (
 
 // Provider types.
 type (
+	BatchProvider      = providers.BatchProvider
 	Capabilities       = providers.Capabilities
 	CapabilityProvider = providers.CapabilityProvider
 	EmbeddingProvider  = providers.EmbeddingProvider
 	ModelLister        = providers.ModelLister
 	Provider           = providers.Provider
+)
+
+// Batch types.
+type (
+	Batch              = providers.Batch
+	BatchRequestCounts = providers.BatchRequestCounts
+	BatchRequestItem   = providers.BatchRequestItem
+	BatchResult        = providers.BatchResult
+	BatchResultError   = providers.BatchResultError
+	BatchResultItem    = providers.BatchResultItem
+	CreateBatchParams  = providers.CreateBatchParams
+	ListBatchesOptions = providers.ListBatchesOptions
 )
 
 // Request/Response types.
@@ -97,6 +122,7 @@ type (
 
 // Usage and model types.
 type (
+	BatchStatus     = providers.BatchStatus
 	EmbeddingData   = providers.EmbeddingData
 	EmbeddingUsage  = providers.EmbeddingUsage
 	Model           = providers.Model
@@ -123,6 +149,7 @@ var (
 // Sentinel errors for type checking with errors.Is().
 var (
 	ErrAuthentication      = errors.ErrAuthentication
+	ErrBatchNotComplete    = errors.ErrBatchNotComplete
 	ErrContentFilter       = errors.ErrContentFilter
 	ErrContextLength       = errors.ErrContextLength
 	ErrInsufficientFunds   = errors.ErrInsufficientFunds
@@ -139,6 +166,7 @@ var (
 type (
 	AuthenticationError      = errors.AuthenticationError
 	BaseError                = errors.BaseError
+	BatchNotCompleteError    = errors.BatchNotCompleteError
 	ContentFilterError       = errors.ContentFilterError
 	ContextLengthError       = errors.ContextLengthError
 	InsufficientFundsError   = errors.InsufficientFundsError

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -18,7 +18,6 @@ const (
 	CodeUnsupportedProvider = "unsupported_provider"
 	CodeUnsupportedParam    = "unsupported_parameter"
 	CodeInsufficientFunds   = "insufficient_funds"
-	CodeBatchNotComplete    = "batch_not_complete"
 )
 
 // Sentinel errors for type checking with errors.Is().
@@ -34,7 +33,6 @@ var (
 	ErrUnsupportedProvider = stderrors.New("unsupported provider")
 	ErrUnsupportedParam    = stderrors.New("unsupported parameter")
 	ErrInsufficientFunds   = stderrors.New("insufficient funds")
-	ErrBatchNotComplete    = stderrors.New("batch not yet complete")
 )
 
 // BaseError is the base error type for all any-llm errors.
@@ -295,24 +293,4 @@ func NewInsufficientFundsError(provider string, err error) *InsufficientFundsErr
 	}
 }
 
-// BatchNotCompleteError is returned when retrieve_batch_results is called
-// on a batch that is not yet complete.
-type BatchNotCompleteError struct {
-	BaseError
-	BatchID string
-	Status  string
-}
 
-// NewBatchNotCompleteError creates a new BatchNotCompleteError.
-func NewBatchNotCompleteError(provider string, batchID string, status string) *BatchNotCompleteError {
-	return &BatchNotCompleteError{
-		BaseError: BaseError{
-			Code:     CodeBatchNotComplete,
-			Provider: provider,
-			Err:      fmt.Errorf("batch '%s' is not yet complete (status: %s)", batchID, status),
-			sentinel: ErrBatchNotComplete,
-		},
-		BatchID: batchID,
-		Status:  status,
-	}
-}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -292,5 +292,3 @@ func NewInsufficientFundsError(provider string, err error) *InsufficientFundsErr
 		},
 	}
 }
-
-

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -18,6 +18,7 @@ const (
 	CodeUnsupportedProvider = "unsupported_provider"
 	CodeUnsupportedParam    = "unsupported_parameter"
 	CodeInsufficientFunds   = "insufficient_funds"
+	CodeBatchNotComplete    = "batch_not_complete"
 )
 
 // Sentinel errors for type checking with errors.Is().
@@ -33,6 +34,7 @@ var (
 	ErrUnsupportedProvider = stderrors.New("unsupported provider")
 	ErrUnsupportedParam    = stderrors.New("unsupported parameter")
 	ErrInsufficientFunds   = stderrors.New("insufficient funds")
+	ErrBatchNotComplete    = stderrors.New("batch not yet complete")
 )
 
 // BaseError is the base error type for all any-llm errors.
@@ -290,5 +292,27 @@ func NewInsufficientFundsError(provider string, err error) *InsufficientFundsErr
 			Err:      err,
 			sentinel: ErrInsufficientFunds,
 		},
+	}
+}
+
+// BatchNotCompleteError is returned when retrieve_batch_results is called
+// on a batch that is not yet complete.
+type BatchNotCompleteError struct {
+	BaseError
+	BatchID string
+	Status  string
+}
+
+// NewBatchNotCompleteError creates a new BatchNotCompleteError.
+func NewBatchNotCompleteError(provider string, batchID string, status string) *BatchNotCompleteError {
+	return &BatchNotCompleteError{
+		BaseError: BaseError{
+			Code:     CodeBatchNotComplete,
+			Provider: provider,
+			Err:      fmt.Errorf("batch '%s' is not yet complete (status: %s)", batchID, status),
+			sentinel: ErrBatchNotComplete,
+		},
+		BatchID: batchID,
+		Status:  status,
 	}
 }

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -85,6 +85,7 @@ var providerEnvKeys = map[string]string{
 	"cohere":     "COHERE_API_KEY",
 	"deepseek":   "DEEPSEEK_API_KEY",
 	"fireworks":  "FIREWORKS_API_KEY",
+	"gateway":    "GATEWAY_API_KEY",
 	"gemini":     "GEMINI_API_KEY",
 	"groq":       "GROQ_API_KEY",
 	"mistral":    "MISTRAL_API_KEY",

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -19,7 +19,6 @@ import (
 	stderrors "errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -634,12 +633,12 @@ func (p *Provider) callBatchJSON(
 	return nil
 }
 
-// closeBody closes an HTTP response body and logs any close error; intended
-// for use in defer statements.
+// closeBody closes an HTTP response body; intended for use in defer
+// statements. The close error is deliberately discarded because this SDK
+// does not expose a logger through config, and callers have already
+// consumed the body by the time this runs.
 func closeBody(resp *http.Response) {
-	if err := resp.Body.Close(); err != nil {
-		log.Printf("gateway: failed to close response body: %v", err)
-	}
+	_ = resp.Body.Close()
 }
 
 // doRequest sends an HTTP request to the gateway API for batch operations.

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -259,19 +259,28 @@ func New(opts ...config.Option) (*Provider, error) {
 		)
 	}
 
-	// Resolve apiBase for batch API calls.
+	// Resolve apiBase once here and pass the resolved value through to
+	// NewCompatible via WithBaseURL. Resolving in a single place avoids
+	// the possibility of the batch HTTP client and the OpenAI SDK client
+	// disagreeing (e.g. if config state changed between resolutions) and
+	// lets us surface resolution errors directly instead of relying on
+	// NewCompatible's RequireBaseURL check.
 	apiBase, err := cfg.ResolveBaseURL(envAPIBase, "")
-	if err != nil || apiBase == "" {
-		// Will be caught by NewCompatible's RequireBaseURL, but resolve
-		// for our own use.
-		apiBase = ""
+	if err != nil {
+		return nil, err
+	}
+	if apiBase == "" {
+		return nil, fmt.Errorf(
+			"gateway base URL is required (set via WithBaseURL option or %s env var)",
+			envAPIBase,
+		)
 	}
 	apiBase = strings.TrimRight(apiBase, "/")
 
 	// Pass the user's opts straight through and layer auth-specific opts on
-	// top (order matters: later options win). Base URL resolution and the
-	// required-URL check are delegated to NewCompatible via BaseURLEnvVar
-	// and RequireBaseURL.
+	// top (order matters: later options win). WithBaseURL is appended last
+	// so NewCompatible sees the already-resolved, trimmed URL and does not
+	// re-run ResolveBaseURL.
 	compatOpts := slices.Clone(opts)
 	if platformMode {
 		compatOpts = append(compatOpts, config.WithAPIKey(platformToken))
@@ -285,16 +294,17 @@ func New(opts ...config.Option) (*Provider, error) {
 			compatOpts = append(compatOpts, config.WithHTTPClient(client))
 		}
 	}
+	compatOpts = append(compatOpts, config.WithBaseURL(apiBase))
 
 	base, err := openaiProvider.NewCompatible(openaiProvider.CompatibleConfig{
-		APIKeyEnvVar:   "",         // Gateway uses its own key resolution.
-		BaseURLEnvVar:  envAPIBase, // Env var for base URL resolution.
+		APIKeyEnvVar:   "", // Gateway uses its own key resolution.
+		BaseURLEnvVar:  "", // Base URL is already resolved above.
 		Capabilities:   capabilities(),
 		DefaultAPIKey:  placeholderAPIKey, // Placeholder; non-platform doesn't need real auth.
 		DefaultBaseURL: "",                // No default; base URL is required.
 		Name:           providerName,
 		RequireAPIKey:  false, // Gateway handles auth separately.
-		RequireBaseURL: true,  // Gateway has no sensible default endpoint.
+		RequireBaseURL: true,  // Guarded above; defensive double-check.
 	}, compatOpts...)
 	if err != nil {
 		return nil, err

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -87,6 +87,10 @@ const (
 
 // Gateway-specific error codes.
 const (
+	// errCodeBatchNotComplete is the BaseError.Code set when a batch result
+	// is requested before the batch has finished processing (HTTP 409).
+	errCodeBatchNotComplete = "batch_not_complete"
+
 	// errCodeTimeout is the BaseError.Code set on gateway timeout errors
 	// (HTTP 504).
 	errCodeTimeout = "gateway_timeout"
@@ -108,6 +112,10 @@ const (
 
 // Gateway-specific sentinel errors for type checking with errors.Is().
 var (
+	// ErrBatchNotComplete is matched by errors.Is when retrieving batch
+	// results on a batch that has not yet finished processing (HTTP 409).
+	ErrBatchNotComplete = stderrors.New("batch not yet complete")
+
 	// ErrTimeout is matched by errors.Is on gateway timeout errors (HTTP 504).
 	ErrTimeout = stderrors.New("gateway timeout")
 
@@ -126,6 +134,14 @@ var (
 	_ providers.Provider           = (*Provider)(nil)
 )
 
+// BatchNotCompleteError is returned when RetrieveBatchResults is called on
+// a batch that has not finished processing yet (HTTP 409).
+type BatchNotCompleteError struct {
+	errors.BaseError
+	BatchID string
+	Status  string
+}
+
 // TimeoutError is returned when the gateway times out (HTTP 504).
 type TimeoutError struct {
 	errors.BaseError
@@ -135,6 +151,17 @@ type TimeoutError struct {
 // unreachable (HTTP 502).
 type UpstreamProviderError struct {
 	errors.BaseError
+}
+
+// newBatchNotCompleteError constructs a BatchNotCompleteError for the given
+// batch and upstream-reported status.
+func newBatchNotCompleteError(batchID, status string) *BatchNotCompleteError {
+	cause := fmt.Errorf("batch '%s' is not yet complete (status: %s)", batchID, status)
+	return &BatchNotCompleteError{
+		BaseError: errors.New(errCodeBatchNotComplete, providerName, cause, ErrBatchNotComplete),
+		BatchID:   batchID,
+		Status:    status,
+	}
 }
 
 // Provider implements the providers.Provider interface for the any-llm gateway.
@@ -670,7 +697,7 @@ func (p *Provider) handleBatchError(resp *http.Response, path string) error {
 		return errors.NewModelNotFoundError(providerName, stderrors.New(msg))
 	case http.StatusConflict:
 		batchID, batchStatus := parseBatchNotCompleteDetail(msg)
-		return errors.NewBatchNotCompleteError(providerName, batchID, batchStatus)
+		return newBatchNotCompleteError(batchID, batchStatus)
 	case http.StatusUnprocessableEntity:
 		return errors.NewProviderError(providerName, stderrors.New(msg))
 	case http.StatusTooManyRequests:

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -646,38 +646,6 @@ func (p *Provider) doRequest(
 	return resp, nil
 }
 
-// handleHTTPError handles HTTP error responses for non-batch endpoints
-// (e.g. completions). It does not include batch-specific error mappings
-// such as 409 → BatchNotCompleteError or 404 → "upgrade your gateway".
-func (p *Provider) handleHTTPError(resp *http.Response, _ string) error {
-	bodyBytes, _ := io.ReadAll(resp.Body)
-
-	var detail struct {
-		Detail string `json:"detail"`
-	}
-	_ = json.Unmarshal(bodyBytes, &detail)
-
-	msg := detail.Detail
-	if msg == "" {
-		msg = string(bodyBytes)
-	}
-
-	switch resp.StatusCode {
-	case http.StatusUnauthorized, http.StatusForbidden:
-		return errors.NewAuthenticationError(providerName, fmt.Errorf("%s", msg))
-	case http.StatusNotFound:
-		return errors.NewModelNotFoundError(providerName, fmt.Errorf("%s", msg))
-	case http.StatusUnprocessableEntity:
-		return errors.NewProviderError(providerName, fmt.Errorf("%s", msg))
-	case http.StatusTooManyRequests:
-		return errors.NewRateLimitError(providerName, fmt.Errorf("%s", msg))
-	case http.StatusBadGateway:
-		return errors.NewProviderError(providerName, fmt.Errorf("upstream provider error: %s", msg))
-	default:
-		return errors.NewProviderError(providerName, fmt.Errorf("HTTP %d: %s", resp.StatusCode, msg))
-	}
-}
-
 // handleBatchError handles HTTP error responses and maps them to typed errors.
 func (p *Provider) handleBatchError(resp *http.Response, path string) error {
 	bodyBytes, _ := io.ReadAll(resp.Body)

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -13,11 +13,18 @@
 package gateway
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"fmt"
+	"io"
+	"log"
 	"net/http"
+	"net/url"
+	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/openai/openai-go"
 
@@ -91,6 +98,7 @@ var (
 
 // Ensure Provider implements the required interfaces.
 var (
+	_ providers.BatchProvider      = (*Provider)(nil)
 	_ providers.CapabilityProvider = (*Provider)(nil)
 	_ providers.EmbeddingProvider  = (*Provider)(nil)
 	_ providers.ErrorConverter     = (*Provider)(nil)
@@ -120,6 +128,18 @@ type Provider struct {
 	// (using gateway key in custom header).
 	// This affects how authentication is handled and how errors are converted.
 	platformMode bool
+
+	// apiBase is the gateway base URL, used for batch API calls that bypass
+	// the OpenAI SDK.
+	apiBase string
+
+	// apiKey is the gateway API key for non-platform mode, or the platform
+	// token in platform mode, used for batch API calls that bypass the
+	// OpenAI SDK.
+	apiKey string
+
+	// httpClient is used for batch API calls that bypass the OpenAI SDK.
+	httpClient *http.Client
 }
 
 // headerTransport wraps an http.RoundTripper to inject custom headers into
@@ -192,6 +212,15 @@ func New(opts ...config.Option) (*Provider, error) {
 		)
 	}
 
+	// Resolve apiBase for batch API calls.
+	apiBase, err := cfg.ResolveBaseURL(envAPIBase, "")
+	if err != nil || apiBase == "" {
+		// Will be caught by NewCompatible's RequireBaseURL, but resolve
+		// for our own use.
+		apiBase = ""
+	}
+	apiBase = strings.TrimRight(apiBase, "/")
+
 	// Pass the user's opts straight through and layer auth-specific opts on
 	// top (order matters: later options win). Base URL resolution and the
 	// required-URL check are delegated to NewCompatible via BaseURLEnvVar
@@ -224,9 +253,20 @@ func New(opts ...config.Option) (*Provider, error) {
 		return nil, err
 	}
 
+	// Determine the key to use for batch API calls.
+	var batchAPIKey string
+	if platformMode {
+		batchAPIKey = platformToken
+	} else {
+		batchAPIKey = gatewayKey
+	}
+
 	return &Provider{
 		CompatibleProvider: base,
 		platformMode:       platformMode,
+		apiBase:            apiBase,
+		apiKey:             batchAPIKey,
+		httpClient:         cfg.HTTPClient(),
 	}, nil
 }
 
@@ -394,4 +434,263 @@ func newHeaderClient(base *http.Client, headerValue string) *http.Client {
 			value:  headerValue,
 		},
 	}
+}
+
+// --- Batch API methods ---
+//
+// These methods use raw HTTP (via doRequest) rather than the embedded OpenAI
+// SDK because the SDK does not expose the gateway batch endpoints.
+
+// CreateBatch creates a new batch job.
+func (p *Provider) CreateBatch(
+	ctx context.Context,
+	params providers.CreateBatchParams,
+) (*providers.Batch, error) {
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, errors.NewInvalidRequestError(providerName, err)
+	}
+
+	resp, err := p.doRequest(ctx, http.MethodPost, "/v1/batches", body)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("gateway: failed to close response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, p.handleBatchError(resp, "/v1/batches")
+	}
+
+	var batch providers.Batch
+	if err := json.NewDecoder(resp.Body).Decode(&batch); err != nil {
+		return nil, errors.NewProviderError(providerName, fmt.Errorf("failed to decode batch response: %w", err))
+	}
+
+	return &batch, nil
+}
+
+// RetrieveBatch retrieves a batch job by ID.
+func (p *Provider) RetrieveBatch(
+	ctx context.Context,
+	batchID string,
+	provider string,
+) (*providers.Batch, error) {
+	path := fmt.Sprintf("/v1/batches/%s?provider=%s", url.PathEscape(batchID), url.QueryEscape(provider))
+
+	resp, err := p.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("gateway: failed to close response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, p.handleBatchError(resp, path)
+	}
+
+	var batch providers.Batch
+	if err := json.NewDecoder(resp.Body).Decode(&batch); err != nil {
+		return nil, errors.NewProviderError(providerName, fmt.Errorf("failed to decode batch response: %w", err))
+	}
+
+	return &batch, nil
+}
+
+// CancelBatch cancels a batch job.
+func (p *Provider) CancelBatch(
+	ctx context.Context,
+	batchID string,
+	provider string,
+) (*providers.Batch, error) {
+	path := fmt.Sprintf(
+		"/v1/batches/%s/cancel?provider=%s",
+		url.PathEscape(batchID),
+		url.QueryEscape(provider),
+	)
+
+	resp, err := p.doRequest(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("gateway: failed to close response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, p.handleBatchError(resp, path)
+	}
+
+	var batch providers.Batch
+	if err := json.NewDecoder(resp.Body).Decode(&batch); err != nil {
+		return nil, errors.NewProviderError(providerName, fmt.Errorf("failed to decode batch response: %w", err))
+	}
+
+	return &batch, nil
+}
+
+// ListBatches lists batch jobs for a provider.
+func (p *Provider) ListBatches(
+	ctx context.Context,
+	provider string,
+	opts providers.ListBatchesOptions,
+) ([]providers.Batch, error) {
+	params := url.Values{"provider": {provider}}
+	if opts.After != "" {
+		params.Set("after", opts.After)
+	}
+	if opts.Limit != nil {
+		params.Set("limit", fmt.Sprintf("%d", *opts.Limit))
+	}
+
+	path := "/v1/batches?" + params.Encode()
+
+	resp, err := p.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("gateway: failed to close response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, p.handleBatchError(resp, path)
+	}
+
+	var listResp struct {
+		Data []providers.Batch `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
+		return nil, errors.NewProviderError(providerName, fmt.Errorf("failed to decode list response: %w", err))
+	}
+
+	return listResp.Data, nil
+}
+
+// RetrieveBatchResults retrieves the results of a completed batch job.
+func (p *Provider) RetrieveBatchResults(
+	ctx context.Context,
+	batchID string,
+	provider string,
+) (*providers.BatchResult, error) {
+	path := fmt.Sprintf(
+		"/v1/batches/%s/results?provider=%s",
+		url.PathEscape(batchID),
+		url.QueryEscape(provider),
+	)
+
+	resp, err := p.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("gateway: failed to close response body: %v", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, p.handleBatchError(resp, path)
+	}
+
+	var result providers.BatchResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, errors.NewProviderError(providerName, fmt.Errorf("failed to decode batch results: %w", err))
+	}
+
+	return &result, nil
+}
+
+// doRequest sends an HTTP request to the gateway API for batch operations.
+func (p *Provider) doRequest(
+	ctx context.Context,
+	method, path string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := p.apiBase + path
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, errors.NewProviderError(providerName, err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if p.apiKey != "" {
+		if p.platformMode {
+			req.Header.Set("Authorization", bearerPrefix+p.apiKey)
+		} else {
+			req.Header.Set(apiKeyHeaderName, bearerPrefix+p.apiKey)
+		}
+	}
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, errors.NewProviderError(providerName, err)
+	}
+
+	return resp, nil
+}
+
+// handleBatchError handles HTTP error responses and maps them to typed errors.
+func (p *Provider) handleBatchError(resp *http.Response, path string) error {
+	bodyBytes, _ := io.ReadAll(resp.Body)
+
+	var detail struct {
+		Detail string `json:"detail"`
+	}
+	_ = json.Unmarshal(bodyBytes, &detail)
+
+	msg := detail.Detail
+	if msg == "" {
+		msg = string(bodyBytes)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return errors.NewAuthenticationError(providerName, fmt.Errorf("%s", msg))
+	case http.StatusNotFound:
+		if strings.Contains(path, "/v1/batches") {
+			return errors.NewProviderError(providerName,
+				fmt.Errorf("this gateway does not support batch operations; upgrade your gateway"))
+		}
+		return errors.NewModelNotFoundError(providerName, fmt.Errorf("%s", msg))
+	case http.StatusConflict:
+		batchID, batchStatus := parseBatchNotCompleteDetail(msg)
+		return errors.NewBatchNotCompleteError(providerName, batchID, batchStatus)
+	case http.StatusUnprocessableEntity:
+		return errors.NewProviderError(providerName, fmt.Errorf("%s", msg))
+	case http.StatusTooManyRequests:
+		return errors.NewRateLimitError(providerName, fmt.Errorf("%s", msg))
+	case http.StatusBadGateway:
+		return errors.NewProviderError(providerName, fmt.Errorf("upstream provider error: %s", msg))
+	default:
+		return errors.NewProviderError(providerName, fmt.Errorf("HTTP %d: %s", resp.StatusCode, msg))
+	}
+}
+
+// batchNotCompleteRE matches: Batch 'batch_abc' is not yet complete (status: in_progress)
+var batchNotCompleteRE = regexp.MustCompile(`[Bb]atch\s+'([^']+)'.*\(status:\s*(\w+)\)`)
+
+// parseBatchNotCompleteDetail extracts batch ID and status from the error detail.
+func parseBatchNotCompleteDetail(detail string) (batchID, status string) {
+	matches := batchNotCompleteRE.FindStringSubmatch(detail)
+	if len(matches) >= 3 {
+		return matches[1], matches[2]
+	}
+	return "", "unknown"
 }

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -646,6 +646,38 @@ func (p *Provider) doRequest(
 	return resp, nil
 }
 
+// handleHTTPError handles HTTP error responses for non-batch endpoints
+// (e.g. completions). It does not include batch-specific error mappings
+// such as 409 → BatchNotCompleteError or 404 → "upgrade your gateway".
+func (p *Provider) handleHTTPError(resp *http.Response, _ string) error {
+	bodyBytes, _ := io.ReadAll(resp.Body)
+
+	var detail struct {
+		Detail string `json:"detail"`
+	}
+	_ = json.Unmarshal(bodyBytes, &detail)
+
+	msg := detail.Detail
+	if msg == "" {
+		msg = string(bodyBytes)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return errors.NewAuthenticationError(providerName, fmt.Errorf("%s", msg))
+	case http.StatusNotFound:
+		return errors.NewModelNotFoundError(providerName, fmt.Errorf("%s", msg))
+	case http.StatusUnprocessableEntity:
+		return errors.NewProviderError(providerName, fmt.Errorf("%s", msg))
+	case http.StatusTooManyRequests:
+		return errors.NewRateLimitError(providerName, fmt.Errorf("%s", msg))
+	case http.StatusBadGateway:
+		return errors.NewProviderError(providerName, fmt.Errorf("upstream provider error: %s", msg))
+	default:
+		return errors.NewProviderError(providerName, fmt.Errorf("HTTP %d: %s", resp.StatusCode, msg))
+	}
+}
+
 // handleBatchError handles HTTP error responses and maps them to typed errors.
 func (p *Provider) handleBatchError(resp *http.Response, path string) error {
 	bodyBytes, _ := io.ReadAll(resp.Body)

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/openai/openai-go"
@@ -40,9 +41,18 @@ const (
 	// non-platform mode.
 	apiKeyHeaderName = "AnyLLM-Key"
 
+	// authorizationHeader is the standard HTTP Authorization header.
+	authorizationHeader = "Authorization"
+
 	// bearerPrefix is the Authorization scheme prefix applied to the gateway
 	// key before it is placed in the gateway header (e.g. "Bearer <key>").
 	bearerPrefix = "Bearer "
+
+	// contentTypeHeader is the standard HTTP Content-Type header.
+	contentTypeHeader = "Content-Type"
+
+	// contentTypeJSON is the Content-Type value for JSON request bodies.
+	contentTypeJSON = "application/json"
 
 	// placeholderAPIKey satisfies the OpenAI SDK's requirement that an API key
 	// be set. The SDK still sends it in the Authorization header, but in
@@ -86,6 +96,16 @@ const (
 	errCodeUpstreamProvider = "upstream_provider"
 )
 
+// Batch API path constants.
+const (
+	// batchesPath is the base path for batch operations on the gateway.
+	batchesPath = "/v1/batches"
+
+	// providerQueryParam is the query-string key identifying the upstream
+	// provider for batch operations.
+	providerQueryParam = "provider"
+)
+
 // Gateway-specific sentinel errors for type checking with errors.Is().
 var (
 	// ErrTimeout is matched by errors.Is on gateway timeout errors (HTTP 504).
@@ -123,12 +143,6 @@ type UpstreamProviderError struct {
 type Provider struct {
 	*openaiProvider.CompatibleProvider
 
-	// platformMode is used to indicate whether the provider is operating in
-	// platform mode (using platform token for Bearer auth) or non-platform mode
-	// (using gateway key in custom header).
-	// This affects how authentication is handled and how errors are converted.
-	platformMode bool
-
 	// apiBase is the gateway base URL, used for batch API calls that bypass
 	// the OpenAI SDK.
 	apiBase string
@@ -140,6 +154,12 @@ type Provider struct {
 
 	// httpClient is used for batch API calls that bypass the OpenAI SDK.
 	httpClient *http.Client
+
+	// platformMode indicates whether the provider is operating in platform
+	// mode (using platform token for Bearer auth) or non-platform mode
+	// (using gateway key in custom header). This affects how authentication
+	// is handled and how errors are converted.
+	platformMode bool
 }
 
 // headerTransport wraps an http.RoundTripper to inject custom headers into
@@ -263,10 +283,10 @@ func New(opts ...config.Option) (*Provider, error) {
 
 	return &Provider{
 		CompatibleProvider: base,
-		platformMode:       platformMode,
 		apiBase:            apiBase,
 		apiKey:             batchAPIKey,
 		httpClient:         cfg.HTTPClient(),
+		platformMode:       platformMode,
 	}, nil
 }
 
@@ -451,23 +471,9 @@ func (p *Provider) CreateBatch(
 		return nil, errors.NewInvalidRequestError(providerName, err)
 	}
 
-	resp, err := p.doRequest(ctx, http.MethodPost, "/v1/batches", body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			log.Printf("gateway: failed to close response body: %v", err)
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, p.handleBatchError(resp, "/v1/batches")
-	}
-
 	var batch providers.Batch
-	if err := json.NewDecoder(resp.Body).Decode(&batch); err != nil {
-		return nil, errors.NewProviderError(providerName, fmt.Errorf("failed to decode batch response: %w", err))
+	if err := p.callBatchJSON(ctx, http.MethodPost, batchesPath, body, &batch); err != nil {
+		return nil, err
 	}
 
 	return &batch, nil
@@ -479,25 +485,17 @@ func (p *Provider) RetrieveBatch(
 	batchID string,
 	provider string,
 ) (*providers.Batch, error) {
-	path := fmt.Sprintf("/v1/batches/%s?provider=%s", url.PathEscape(batchID), url.QueryEscape(provider))
-
-	resp, err := p.doRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			log.Printf("gateway: failed to close response body: %v", err)
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, p.handleBatchError(resp, path)
-	}
+	path := fmt.Sprintf(
+		"%s/%s?%s=%s",
+		batchesPath,
+		url.PathEscape(batchID),
+		providerQueryParam,
+		url.QueryEscape(provider),
+	)
 
 	var batch providers.Batch
-	if err := json.NewDecoder(resp.Body).Decode(&batch); err != nil {
-		return nil, errors.NewProviderError(providerName, fmt.Errorf("failed to decode batch response: %w", err))
+	if err := p.callBatchJSON(ctx, http.MethodGet, path, nil, &batch); err != nil {
+		return nil, err
 	}
 
 	return &batch, nil
@@ -510,28 +508,16 @@ func (p *Provider) CancelBatch(
 	provider string,
 ) (*providers.Batch, error) {
 	path := fmt.Sprintf(
-		"/v1/batches/%s/cancel?provider=%s",
+		"%s/%s/cancel?%s=%s",
+		batchesPath,
 		url.PathEscape(batchID),
+		providerQueryParam,
 		url.QueryEscape(provider),
 	)
 
-	resp, err := p.doRequest(ctx, http.MethodPost, path, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			log.Printf("gateway: failed to close response body: %v", err)
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, p.handleBatchError(resp, path)
-	}
-
 	var batch providers.Batch
-	if err := json.NewDecoder(resp.Body).Decode(&batch); err != nil {
-		return nil, errors.NewProviderError(providerName, fmt.Errorf("failed to decode batch response: %w", err))
+	if err := p.callBatchJSON(ctx, http.MethodPost, path, nil, &batch); err != nil {
+		return nil, err
 	}
 
 	return &batch, nil
@@ -543,35 +529,21 @@ func (p *Provider) ListBatches(
 	provider string,
 	opts providers.ListBatchesOptions,
 ) ([]providers.Batch, error) {
-	params := url.Values{"provider": {provider}}
+	params := url.Values{providerQueryParam: {provider}}
 	if opts.After != "" {
 		params.Set("after", opts.After)
 	}
 	if opts.Limit != nil {
-		params.Set("limit", fmt.Sprintf("%d", *opts.Limit))
+		params.Set("limit", strconv.Itoa(*opts.Limit))
 	}
 
-	path := "/v1/batches?" + params.Encode()
-
-	resp, err := p.doRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			log.Printf("gateway: failed to close response body: %v", err)
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, p.handleBatchError(resp, path)
-	}
+	path := batchesPath + "?" + params.Encode()
 
 	var listResp struct {
 		Data []providers.Batch `json:"data"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
-		return nil, errors.NewProviderError(providerName, fmt.Errorf("failed to decode list response: %w", err))
+	if err := p.callBatchJSON(ctx, http.MethodGet, path, nil, &listResp); err != nil {
+		return nil, err
 	}
 
 	return listResp.Data, nil
@@ -584,31 +556,53 @@ func (p *Provider) RetrieveBatchResults(
 	provider string,
 ) (*providers.BatchResult, error) {
 	path := fmt.Sprintf(
-		"/v1/batches/%s/results?provider=%s",
+		"%s/%s/results?%s=%s",
+		batchesPath,
 		url.PathEscape(batchID),
+		providerQueryParam,
 		url.QueryEscape(provider),
 	)
 
-	resp, err := p.doRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			log.Printf("gateway: failed to close response body: %v", err)
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, p.handleBatchError(resp, path)
-	}
-
 	var result providers.BatchResult
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, errors.NewProviderError(providerName, fmt.Errorf("failed to decode batch results: %w", err))
+	if err := p.callBatchJSON(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return nil, err
 	}
 
 	return &result, nil
+}
+
+// callBatchJSON performs a batch HTTP request and decodes a JSON success
+// response into out. Non-2xx responses are mapped to typed errors via
+// handleBatchError.
+func (p *Provider) callBatchJSON(
+	ctx context.Context,
+	method, path string,
+	body []byte,
+	out any,
+) error {
+	resp, err := p.doRequest(ctx, method, path, body)
+	if err != nil {
+		return err
+	}
+	defer closeBody(resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return p.handleBatchError(resp, path)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return errors.NewProviderError(providerName, fmt.Errorf("failed to decode batch response: %w", err))
+	}
+
+	return nil
+}
+
+// closeBody closes an HTTP response body and logs any close error; intended
+// for use in defer statements.
+func closeBody(resp *http.Response) {
+	if err := resp.Body.Close(); err != nil {
+		log.Printf("gateway: failed to close response body: %v", err)
+	}
 }
 
 // doRequest sends an HTTP request to the gateway API for batch operations.
@@ -629,10 +623,10 @@ func (p *Provider) doRequest(
 		return nil, errors.NewProviderError(providerName, err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(contentTypeHeader, contentTypeJSON)
 	if p.apiKey != "" {
 		if p.platformMode {
-			req.Header.Set("Authorization", bearerPrefix+p.apiKey)
+			req.Header.Set(authorizationHeader, bearerPrefix+p.apiKey)
 		} else {
 			req.Header.Set(apiKeyHeaderName, bearerPrefix+p.apiKey)
 		}
@@ -648,11 +642,16 @@ func (p *Provider) doRequest(
 
 // handleBatchError handles HTTP error responses and maps them to typed errors.
 func (p *Provider) handleBatchError(resp *http.Response, path string) error {
+	// ReadAll error is ignored: if reading fails, we fall back to an empty
+	// body and still produce a typed error based on status code.
 	bodyBytes, _ := io.ReadAll(resp.Body)
 
 	var detail struct {
 		Detail string `json:"detail"`
 	}
+	// Unmarshal error is ignored: responses may not be JSON (e.g. plain
+	// text from a misbehaving proxy); in that case we fall back to the raw
+	// body below.
 	_ = json.Unmarshal(bodyBytes, &detail)
 
 	msg := detail.Detail
@@ -662,20 +661,20 @@ func (p *Provider) handleBatchError(resp *http.Response, path string) error {
 
 	switch resp.StatusCode {
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return errors.NewAuthenticationError(providerName, fmt.Errorf("%s", msg))
+		return errors.NewAuthenticationError(providerName, stderrors.New(msg))
 	case http.StatusNotFound:
-		if strings.Contains(path, "/v1/batches") {
+		if strings.Contains(path, batchesPath) {
 			return errors.NewProviderError(providerName,
-				fmt.Errorf("this gateway does not support batch operations; upgrade your gateway"))
+				stderrors.New("this gateway does not support batch operations; upgrade your gateway"))
 		}
-		return errors.NewModelNotFoundError(providerName, fmt.Errorf("%s", msg))
+		return errors.NewModelNotFoundError(providerName, stderrors.New(msg))
 	case http.StatusConflict:
 		batchID, batchStatus := parseBatchNotCompleteDetail(msg)
 		return errors.NewBatchNotCompleteError(providerName, batchID, batchStatus)
 	case http.StatusUnprocessableEntity:
-		return errors.NewProviderError(providerName, fmt.Errorf("%s", msg))
+		return errors.NewProviderError(providerName, stderrors.New(msg))
 	case http.StatusTooManyRequests:
-		return errors.NewRateLimitError(providerName, fmt.Errorf("%s", msg))
+		return errors.NewRateLimitError(providerName, stderrors.New(msg))
 	case http.StatusBadGateway:
 		return errors.NewProviderError(providerName, fmt.Errorf("upstream provider error: %s", msg))
 	default:

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -599,17 +599,16 @@ func (p *Provider) RetrieveBatchResults(
 	return &result, nil
 }
 
-// batchItemPath builds a path for /v1/batches/{id}[/action]?provider=X using
-// url.URL so that batchID and provider are encoded safely.
+// batchItemPath builds a path for /v1/batches/{id}[/action]?provider=X.
+// It uses url.URL.JoinPath (Go 1.19+) which escapes each path segment
+// individually, so a batchID containing "/" or ".." is encoded as a single
+// segment rather than traversing into a sibling route.
 func batchItemPath(batchID, action, provider string) string {
-	path := batchesPath + "/" + batchID
+	u := (&url.URL{Path: batchesPath}).JoinPath(batchID)
 	if action != "" {
-		path += "/" + action
+		u = u.JoinPath(action)
 	}
-	u := url.URL{
-		Path:     path,
-		RawQuery: url.Values{providerQueryParam: {provider}}.Encode(),
-	}
+	u.RawQuery = url.Values{providerQueryParam: {provider}}.Encode()
 	return u.RequestURI()
 }
 
@@ -697,7 +696,7 @@ func (p *Provider) handleBatchError(resp *http.Response, batchID string) error {
 	// body and still produce a typed error based on status code.
 	bodyBytes, _ := io.ReadAll(resp.Body)
 
-	detail := decodeBatchErrorBody(bodyBytes)
+	detail, parseErr := parseBatchError(bodyBytes)
 
 	switch resp.StatusCode {
 	case http.StatusUnauthorized, http.StatusForbidden:
@@ -707,6 +706,14 @@ func (p *Provider) handleBatchError(resp *http.Response, batchID string) error {
 		return errors.NewProviderError(providerName,
 			stderrors.New("this gateway does not support batch operations; upgrade your gateway"))
 	case http.StatusConflict:
+		// For 409 the Status field matters (it tells the caller why the
+		// batch isn't ready). If the body wasn't valid JSON, wrap the
+		// parse error so drift in the gateway's response format is
+		// visible instead of silently returning an empty Status.
+		if parseErr != nil {
+			return newBatchNotCompleteError(batchID, "",
+				fmt.Errorf("failed to parse batch error response: %w", parseErr))
+		}
 		return newBatchNotCompleteError(batchID, detail.Status, detail.toError())
 	case http.StatusUnprocessableEntity:
 		return errors.NewProviderError(providerName,
@@ -723,9 +730,9 @@ func (p *Provider) handleBatchError(resp *http.Response, batchID string) error {
 	}
 }
 
-// batchErrorBody is the structured JSON shape gateway error responses may
-// use. All fields are optional; callers must cope with arbitrary bodies.
-type batchErrorBody struct {
+// batchError is the structured JSON shape gateway error responses may use.
+// All fields are optional; callers must cope with arbitrary bodies.
+type batchError struct {
 	// Detail is the human-readable error message (FastAPI-style payload).
 	Detail string `json:"detail"`
 
@@ -739,7 +746,7 @@ type batchErrorBody struct {
 }
 
 // message returns the best human-readable description of the error body.
-func (b batchErrorBody) message() string {
+func (b batchError) message() string {
 	if b.Detail != "" {
 		return b.Detail
 	}
@@ -748,7 +755,7 @@ func (b batchErrorBody) message() string {
 
 // toError wraps message() in an error value suitable for embedding in a
 // typed error's cause chain, or nil when no detail is available.
-func (b batchErrorBody) toError() error {
+func (b batchError) toError() error {
 	msg := b.message()
 	if msg == "" {
 		return nil
@@ -756,13 +763,14 @@ func (b batchErrorBody) toError() error {
 	return stderrors.New(msg)
 }
 
-// decodeBatchErrorBody parses a gateway error response. Non-JSON bodies are
-// preserved via the raw field so callers can still surface the server's
-// text in the typed error.
-func decodeBatchErrorBody(body []byte) batchErrorBody {
-	out := batchErrorBody{raw: string(body)}
-	// Unmarshal error is ignored: responses may not be JSON (e.g. plain
-	// text from a misbehaving proxy); the raw body is used instead.
-	_ = json.Unmarshal(body, &out)
-	return out
+// parseBatchError parses a gateway error response body. The parse error is
+// returned so callers can decide per-status whether a JSON parse failure is
+// tolerable (e.g. log and fall through for generic errors) or should be
+// treated as a hard failure (e.g. for 409 where Status matters). Non-JSON
+// bodies are preserved via the raw field so callers can still surface the
+// server's text in the typed error.
+func parseBatchError(body []byte) (batchError, error) {
+	out := batchError{raw: string(body)}
+	err := json.Unmarshal(body, &out)
+	return out, err
 }

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -153,9 +152,19 @@ type UpstreamProviderError struct {
 }
 
 // newBatchNotCompleteError constructs a BatchNotCompleteError for the given
-// batch and upstream-reported status.
-func newBatchNotCompleteError(batchID, status string) *BatchNotCompleteError {
-	cause := fmt.Errorf("batch '%s' is not yet complete (status: %s)", batchID, status)
+// batch and upstream-reported status. status may be empty when the gateway
+// did not include a structured status field in the response.
+func newBatchNotCompleteError(batchID, status string, cause error) *BatchNotCompleteError {
+	if cause == nil {
+		switch {
+		case batchID != "" && status != "":
+			cause = fmt.Errorf("batch %q is not yet complete (status: %s)", batchID, status)
+		case batchID != "":
+			cause = fmt.Errorf("batch %q is not yet complete", batchID)
+		default:
+			cause = stderrors.New("batch is not yet complete")
+		}
+	}
 	return &BatchNotCompleteError{
 		BaseError: errors.New(errCodeBatchNotComplete, providerName, cause, ErrBatchNotComplete),
 		BatchID:   batchID,
@@ -508,7 +517,7 @@ func (p *Provider) CreateBatch(
 	}
 
 	var batch providers.Batch
-	if err := p.callBatchJSON(ctx, http.MethodPost, batchesPath, body, &batch); err != nil {
+	if err := p.callBatchJSON(ctx, http.MethodPost, batchesPath, "", body, &batch); err != nil {
 		return nil, err
 	}
 
@@ -521,16 +530,10 @@ func (p *Provider) RetrieveBatch(
 	batchID string,
 	provider string,
 ) (*providers.Batch, error) {
-	path := fmt.Sprintf(
-		"%s/%s?%s=%s",
-		batchesPath,
-		url.PathEscape(batchID),
-		providerQueryParam,
-		url.QueryEscape(provider),
-	)
+	path := batchItemPath(batchID, "", provider)
 
 	var batch providers.Batch
-	if err := p.callBatchJSON(ctx, http.MethodGet, path, nil, &batch); err != nil {
+	if err := p.callBatchJSON(ctx, http.MethodGet, path, batchID, nil, &batch); err != nil {
 		return nil, err
 	}
 
@@ -543,16 +546,10 @@ func (p *Provider) CancelBatch(
 	batchID string,
 	provider string,
 ) (*providers.Batch, error) {
-	path := fmt.Sprintf(
-		"%s/%s/cancel?%s=%s",
-		batchesPath,
-		url.PathEscape(batchID),
-		providerQueryParam,
-		url.QueryEscape(provider),
-	)
+	path := batchItemPath(batchID, "cancel", provider)
 
 	var batch providers.Batch
-	if err := p.callBatchJSON(ctx, http.MethodPost, path, nil, &batch); err != nil {
+	if err := p.callBatchJSON(ctx, http.MethodPost, path, batchID, nil, &batch); err != nil {
 		return nil, err
 	}
 
@@ -573,12 +570,13 @@ func (p *Provider) ListBatches(
 		params.Set("limit", strconv.Itoa(*opts.Limit))
 	}
 
-	path := batchesPath + "?" + params.Encode()
+	u := url.URL{Path: batchesPath, RawQuery: params.Encode()}
+	path := u.RequestURI()
 
 	var listResp struct {
 		Data []providers.Batch `json:"data"`
 	}
-	if err := p.callBatchJSON(ctx, http.MethodGet, path, nil, &listResp); err != nil {
+	if err := p.callBatchJSON(ctx, http.MethodGet, path, "", nil, &listResp); err != nil {
 		return nil, err
 	}
 
@@ -591,28 +589,38 @@ func (p *Provider) RetrieveBatchResults(
 	batchID string,
 	provider string,
 ) (*providers.BatchResult, error) {
-	path := fmt.Sprintf(
-		"%s/%s/results?%s=%s",
-		batchesPath,
-		url.PathEscape(batchID),
-		providerQueryParam,
-		url.QueryEscape(provider),
-	)
+	path := batchItemPath(batchID, "results", provider)
 
 	var result providers.BatchResult
-	if err := p.callBatchJSON(ctx, http.MethodGet, path, nil, &result); err != nil {
+	if err := p.callBatchJSON(ctx, http.MethodGet, path, batchID, nil, &result); err != nil {
 		return nil, err
 	}
 
 	return &result, nil
 }
 
+// batchItemPath builds a path for /v1/batches/{id}[/action]?provider=X using
+// url.URL so that batchID and provider are encoded safely.
+func batchItemPath(batchID, action, provider string) string {
+	path := batchesPath + "/" + batchID
+	if action != "" {
+		path += "/" + action
+	}
+	u := url.URL{
+		Path:     path,
+		RawQuery: url.Values{providerQueryParam: {provider}}.Encode(),
+	}
+	return u.RequestURI()
+}
+
 // callBatchJSON performs a batch HTTP request and decodes a JSON success
 // response into out. Non-2xx responses are mapped to typed errors via
-// handleBatchError.
+// handleBatchError. batchID is used to enrich 409 errors with the specific
+// batch identifier the caller requested; pass "" when not applicable
+// (create, list).
 func (p *Provider) callBatchJSON(
 	ctx context.Context,
-	method, path string,
+	method, path, batchID string,
 	body []byte,
 	out any,
 ) error {
@@ -623,7 +631,7 @@ func (p *Provider) callBatchJSON(
 	defer closeBody(resp)
 
 	if resp.StatusCode != http.StatusOK {
-		return p.handleBatchError(resp, path)
+		return p.handleBatchError(resp, batchID)
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
@@ -676,56 +684,85 @@ func (p *Provider) doRequest(
 	return resp, nil
 }
 
-// handleBatchError handles HTTP error responses and maps them to typed errors.
-func (p *Provider) handleBatchError(resp *http.Response, path string) error {
+// handleBatchError maps a non-2xx batch HTTP response to a typed error.
+// batchID is the batch identifier the caller operated on (empty for
+// create/list); it is used to enrich 409 errors without parsing
+// free-text error messages.
+//
+// All callers of this function operate on /v1/batches, so a 404 is
+// interpreted as "gateway does not expose the batch API" and is not
+// mapped to ModelNotFoundError.
+func (p *Provider) handleBatchError(resp *http.Response, batchID string) error {
 	// ReadAll error is ignored: if reading fails, we fall back to an empty
 	// body and still produce a typed error based on status code.
 	bodyBytes, _ := io.ReadAll(resp.Body)
 
-	var detail struct {
-		Detail string `json:"detail"`
-	}
-	// Unmarshal error is ignored: responses may not be JSON (e.g. plain
-	// text from a misbehaving proxy); in that case we fall back to the raw
-	// body below.
-	_ = json.Unmarshal(bodyBytes, &detail)
-
-	msg := detail.Detail
-	if msg == "" {
-		msg = string(bodyBytes)
-	}
+	detail := decodeBatchErrorBody(bodyBytes)
 
 	switch resp.StatusCode {
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return errors.NewAuthenticationError(providerName, stderrors.New(msg))
+		return errors.NewAuthenticationError(providerName,
+			fmt.Errorf("unauthorized: %s", detail.message()))
 	case http.StatusNotFound:
-		if strings.Contains(path, batchesPath) {
-			return errors.NewProviderError(providerName,
-				stderrors.New("this gateway does not support batch operations; upgrade your gateway"))
-		}
-		return errors.NewModelNotFoundError(providerName, stderrors.New(msg))
+		return errors.NewProviderError(providerName,
+			stderrors.New("this gateway does not support batch operations; upgrade your gateway"))
 	case http.StatusConflict:
-		batchID, batchStatus := parseBatchNotCompleteDetail(msg)
-		return newBatchNotCompleteError(batchID, batchStatus)
+		return newBatchNotCompleteError(batchID, detail.Status, detail.toError())
 	case http.StatusUnprocessableEntity:
-		return errors.NewProviderError(providerName, stderrors.New(msg))
+		return errors.NewProviderError(providerName,
+			fmt.Errorf("unprocessable request: %s", detail.message()))
 	case http.StatusTooManyRequests:
-		return errors.NewRateLimitError(providerName, stderrors.New(msg))
+		return errors.NewRateLimitError(providerName,
+			fmt.Errorf("rate limit: %s", detail.message()))
 	case http.StatusBadGateway:
-		return errors.NewProviderError(providerName, fmt.Errorf("upstream provider error: %s", msg))
+		return errors.NewProviderError(providerName,
+			fmt.Errorf("upstream provider error: %s", detail.message()))
 	default:
-		return errors.NewProviderError(providerName, fmt.Errorf("HTTP %d: %s", resp.StatusCode, msg))
+		return errors.NewProviderError(providerName,
+			fmt.Errorf("HTTP %d: %s", resp.StatusCode, detail.message()))
 	}
 }
 
-// batchNotCompleteRE matches: Batch 'batch_abc' is not yet complete (status: in_progress)
-var batchNotCompleteRE = regexp.MustCompile(`[Bb]atch\s+'([^']+)'.*\(status:\s*(\w+)\)`)
+// batchErrorBody is the structured JSON shape gateway error responses may
+// use. All fields are optional; callers must cope with arbitrary bodies.
+type batchErrorBody struct {
+	// Detail is the human-readable error message (FastAPI-style payload).
+	Detail string `json:"detail"`
 
-// parseBatchNotCompleteDetail extracts batch ID and status from the error detail.
-func parseBatchNotCompleteDetail(detail string) (batchID, status string) {
-	matches := batchNotCompleteRE.FindStringSubmatch(detail)
-	if len(matches) >= 3 {
-		return matches[1], matches[2]
+	// Status is the batch status when the gateway returns a 409 for
+	// RetrieveBatchResults; empty when not applicable or not provided.
+	Status string `json:"status"`
+
+	// raw is the untouched response body, used as a last-resort message
+	// when the body is not JSON or does not include Detail.
+	raw string
+}
+
+// message returns the best human-readable description of the error body.
+func (b batchErrorBody) message() string {
+	if b.Detail != "" {
+		return b.Detail
 	}
-	return "", "unknown"
+	return b.raw
+}
+
+// toError wraps message() in an error value suitable for embedding in a
+// typed error's cause chain, or nil when no detail is available.
+func (b batchErrorBody) toError() error {
+	msg := b.message()
+	if msg == "" {
+		return nil
+	}
+	return stderrors.New(msg)
+}
+
+// decodeBatchErrorBody parses a gateway error response. Non-JSON bodies are
+// preserved via the raw field so callers can still surface the server's
+// text in the typed error.
+func decodeBatchErrorBody(body []byte) batchErrorBody {
+	out := batchErrorBody{raw: string(body)}
+	// Unmarshal error is ignored: responses may not be JSON (e.g. plain
+	// text from a misbehaving proxy); the raw body is used instead.
+	_ = json.Unmarshal(body, &out)
+	return out
 }

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -904,7 +905,516 @@ func TestConvertErrorNilPassthrough(t *testing.T) {
 	require.Nil(t, provider.ConvertError(nil))
 }
 
-// Integration tests - only run if gateway is available.
+// --- Batch tests ---
+
+func TestCreateBatchSuccess(t *testing.T) {
+	t.Parallel()
+
+	var capturedBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v1/batches", r.URL.Path)
+
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(raw, &capturedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "batch_abc123",
+			"object": "batch",
+			"endpoint": "/v1/chat/completions",
+			"status": "validating",
+			"created_at": 1714502400,
+			"completion_window": "24h",
+			"request_counts": {"total": 2, "completed": 0, "failed": 0},
+			"metadata": {"key": "value"},
+			"provider": "openai"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		WithGatewayKey("test-key"),
+	)
+	require.NoError(t, err)
+
+	batch, err := provider.CreateBatch(context.Background(), providers.CreateBatchParams{
+		Model: "openai:gpt-4o-mini",
+		Requests: []providers.BatchRequestItem{
+			{
+				CustomID: "req-1",
+				Body: map[string]any{
+					"messages":   []any{map[string]any{"role": "user", "content": "Hello"}},
+					"max_tokens": 100,
+				},
+			},
+		},
+		CompletionWindow: "24h",
+		Metadata:         map[string]string{"key": "value"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "batch_abc123", batch.ID)
+	require.Equal(t, "batch", batch.Object)
+	require.Equal(t, "/v1/chat/completions", batch.Endpoint)
+	require.Equal(t, providers.BatchStatusValidating, batch.Status)
+	require.Equal(t, int64(1714502400), batch.CreatedAt)
+	require.Equal(t, "24h", batch.CompletionWindow)
+	require.NotNil(t, batch.RequestCounts)
+	require.Equal(t, 2, batch.RequestCounts.Total)
+	require.Equal(t, 0, batch.RequestCounts.Completed)
+	require.Equal(t, 0, batch.RequestCounts.Failed)
+	require.Equal(t, "openai", batch.Provider)
+	require.Equal(t, map[string]string{"key": "value"}, batch.Metadata)
+
+	// Verify the request body.
+	require.Equal(t, "openai:gpt-4o-mini", capturedBody["model"])
+	require.Equal(t, "24h", capturedBody["completion_window"])
+}
+
+func TestCreateBatchSendsAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	var capturedAuthHeader string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuthHeader = r.Header.Get(apiKeyHeaderName)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "batch_test",
+			"object": "batch",
+			"endpoint": "/v1/chat/completions",
+			"status": "validating",
+			"created_at": 1714502400,
+			"completion_window": "24h"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		WithGatewayKey("batch-api-key"),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.CreateBatch(context.Background(), providers.CreateBatchParams{
+		Model: "openai:gpt-4o-mini",
+		Requests: []providers.BatchRequestItem{
+			{CustomID: "req-1", Body: map[string]any{"messages": []any{}}},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Bearer batch-api-key", capturedAuthHeader)
+}
+
+func TestRetrieveBatchSendsProviderParam(t *testing.T) {
+	t.Parallel()
+
+	var capturedPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.RequestURI()
+		require.Equal(t, http.MethodGet, r.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "batch_abc123",
+			"object": "batch",
+			"endpoint": "/v1/chat/completions",
+			"status": "in_progress",
+			"created_at": 1714502400,
+			"completion_window": "24h",
+			"provider": "openai"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		WithGatewayKey("test-key"),
+	)
+	require.NoError(t, err)
+
+	batch, err := provider.RetrieveBatch(context.Background(), "batch_abc123", "openai")
+	require.NoError(t, err)
+	require.Equal(t, "batch_abc123", batch.ID)
+	require.Equal(t, providers.BatchStatusInProgress, batch.Status)
+	require.Contains(t, capturedPath, "provider=openai")
+	require.Contains(t, capturedPath, "/v1/batches/batch_abc123")
+}
+
+func TestCancelBatchSuccess(t *testing.T) {
+	t.Parallel()
+
+	var capturedMethod string
+	var capturedPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.RequestURI()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "batch_abc123",
+			"object": "batch",
+			"endpoint": "/v1/chat/completions",
+			"status": "cancelling",
+			"created_at": 1714502400,
+			"completion_window": "24h"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		WithGatewayKey("test-key"),
+	)
+	require.NoError(t, err)
+
+	batch, err := provider.CancelBatch(context.Background(), "batch_abc123", "openai")
+	require.NoError(t, err)
+	require.Equal(t, "batch_abc123", batch.ID)
+	require.Equal(t, providers.BatchStatusCancelling, batch.Status)
+	require.Equal(t, http.MethodPost, capturedMethod)
+	require.Contains(t, capturedPath, "/v1/batches/batch_abc123/cancel")
+	require.Contains(t, capturedPath, "provider=openai")
+}
+
+func TestListBatchesPagination(t *testing.T) {
+	t.Parallel()
+
+	var capturedPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.RequestURI()
+		require.Equal(t, http.MethodGet, r.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{
+					"id": "batch_1",
+					"object": "batch",
+					"endpoint": "/v1/chat/completions",
+					"status": "completed",
+					"created_at": 1714502400,
+					"completion_window": "24h"
+				},
+				{
+					"id": "batch_2",
+					"object": "batch",
+					"endpoint": "/v1/chat/completions",
+					"status": "in_progress",
+					"created_at": 1714502500,
+					"completion_window": "24h"
+				}
+			]
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		WithGatewayKey("test-key"),
+	)
+	require.NoError(t, err)
+
+	limit := 10
+	batches, err := provider.ListBatches(context.Background(), "openai", providers.ListBatchesOptions{
+		After: "batch_0",
+		Limit: &limit,
+	})
+	require.NoError(t, err)
+	require.Len(t, batches, 2)
+	require.Equal(t, "batch_1", batches[0].ID)
+	require.Equal(t, "batch_2", batches[1].ID)
+
+	// Verify query params.
+	require.Contains(t, capturedPath, "provider=openai")
+	require.Contains(t, capturedPath, "after=batch_0")
+	require.Contains(t, capturedPath, "limit=10")
+}
+
+func TestListBatchesWithoutPagination(t *testing.T) {
+	t.Parallel()
+
+	var capturedPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": []}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		WithGatewayKey("test-key"),
+	)
+	require.NoError(t, err)
+
+	batches, err := provider.ListBatches(context.Background(), "openai", providers.ListBatchesOptions{})
+	require.NoError(t, err)
+	require.Empty(t, batches)
+
+	// Verify only provider param is sent (no after or limit).
+	require.Contains(t, capturedPath, "provider=openai")
+	require.NotContains(t, capturedPath, "after=")
+	require.NotContains(t, capturedPath, "limit=")
+}
+
+func TestRetrieveBatchResultsSuccess(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Contains(t, r.URL.Path, "/v1/batches/batch_abc123/results")
+		require.Equal(t, "openai", r.URL.Query().Get("provider"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"results": [
+				{
+					"custom_id": "req-1",
+					"result": {
+						"id": "chatcmpl-1",
+						"object": "chat.completion",
+						"created": 1700000000,
+						"model": "gpt-4o-mini",
+						"choices": [{"index": 0, "message": {"role": "assistant", "content": "Hello"}, "finish_reason": "stop"}],
+						"usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
+					},
+					"error": null
+				},
+				{
+					"custom_id": "req-2",
+					"result": null,
+					"error": {"code": "rate_limit", "message": "Rate limit exceeded"}
+				}
+			]
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		WithGatewayKey("test-key"),
+	)
+	require.NoError(t, err)
+
+	result, err := provider.RetrieveBatchResults(context.Background(), "batch_abc123", "openai")
+	require.NoError(t, err)
+	require.Len(t, result.Results, 2)
+
+	// First result: successful.
+	require.Equal(t, "req-1", result.Results[0].CustomID)
+	require.NotNil(t, result.Results[0].Result)
+	require.Equal(t, "chatcmpl-1", result.Results[0].Result.ID)
+	require.Nil(t, result.Results[0].Error)
+
+	// Second result: error.
+	require.Equal(t, "req-2", result.Results[1].CustomID)
+	require.Nil(t, result.Results[1].Result)
+	require.NotNil(t, result.Results[1].Error)
+	require.Equal(t, "rate_limit", result.Results[1].Error.Code)
+	require.Equal(t, "Rate limit exceeded", result.Results[1].Error.Message)
+}
+
+// --- Batch error tests ---
+
+func TestBatchError409(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"detail": "Batch 'batch_xyz' is not yet complete (status: in_progress)"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		WithGatewayKey("test-key"),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.RetrieveBatchResults(context.Background(), "batch_xyz", "openai")
+	require.Error(t, err)
+
+	// Check sentinel error.
+	require.True(t, stderrors.Is(err, errors.ErrBatchNotComplete),
+		"expected error to match ErrBatchNotComplete, got %v", err)
+
+	// Check typed error with fields.
+	var batchErr *errors.BatchNotCompleteError
+	require.True(t, stderrors.As(err, &batchErr))
+	require.Equal(t, "batch_xyz", batchErr.BatchID)
+	require.Equal(t, "in_progress", batchErr.Status)
+}
+
+func TestBatchError404(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail": "not found"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		WithGatewayKey("test-key"),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.RetrieveBatch(context.Background(), "batch_abc123", "openai")
+	require.Error(t, err)
+	require.True(t, stderrors.Is(err, errors.ErrProvider))
+	require.Contains(t, err.Error(), "upgrade your gateway")
+}
+
+func TestBatchError401(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail": "invalid api key"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		WithGatewayKey("bad-key"),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.CreateBatch(context.Background(), providers.CreateBatchParams{
+		Model: "openai:gpt-4o-mini",
+		Requests: []providers.BatchRequestItem{
+			{CustomID: "req-1", Body: map[string]any{"messages": []any{}}},
+		},
+	})
+	require.Error(t, err)
+	require.True(t, stderrors.Is(err, errors.ErrAuthentication))
+}
+
+func TestBatchError422(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"detail": "unsupported provider"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		WithGatewayKey("test-key"),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.CreateBatch(context.Background(), providers.CreateBatchParams{
+		Model: "unsupported:model",
+		Requests: []providers.BatchRequestItem{
+			{CustomID: "req-1", Body: map[string]any{"messages": []any{}}},
+		},
+	})
+	require.Error(t, err)
+	require.True(t, stderrors.Is(err, errors.ErrProvider))
+	require.Contains(t, err.Error(), "unsupported provider")
+}
+
+func TestBatchError502(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"detail": "upstream timeout"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		WithGatewayKey("test-key"),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.RetrieveBatch(context.Background(), "batch_abc123", "openai")
+	require.Error(t, err)
+	require.True(t, stderrors.Is(err, errors.ErrProvider))
+	require.Contains(t, err.Error(), "upstream provider error")
+}
+
+func TestBatchError429(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"detail": "rate limit exceeded"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		WithGatewayKey("test-key"),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.ListBatches(context.Background(), "openai", providers.ListBatchesOptions{})
+	require.Error(t, err)
+	require.True(t, stderrors.Is(err, errors.ErrRateLimit))
+}
+
+// --- Helper function tests ---
+
+func TestParseBatchNotCompleteDetail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		detail     string
+		wantID     string
+		wantStatus string
+	}{
+		{
+			name:       "standard format",
+			detail:     "Batch 'batch_abc123' is not yet complete (status: in_progress)",
+			wantID:     "batch_abc123",
+			wantStatus: "in_progress",
+		},
+		{
+			name:       "lowercase batch",
+			detail:     "batch 'batch_xyz' is not yet complete (status: validating)",
+			wantID:     "batch_xyz",
+			wantStatus: "validating",
+		},
+		{
+			name:       "unrecognized format",
+			detail:     "something went wrong",
+			wantID:     "",
+			wantStatus: "unknown",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			batchID, status := parseBatchNotCompleteDetail(tc.detail)
+			require.Equal(t, tc.wantID, batchID)
+			require.Equal(t, tc.wantStatus, status)
+		})
+	}
+}
+
+// --- Integration tests ---
 
 func TestIntegrationCompletion(t *testing.T) {
 	t.Parallel()

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -1245,11 +1245,11 @@ func TestBatchError409(t *testing.T) {
 	require.Error(t, err)
 
 	// Check sentinel error.
-	require.True(t, stderrors.Is(err, errors.ErrBatchNotComplete),
+	require.True(t, stderrors.Is(err, ErrBatchNotComplete),
 		"expected error to match ErrBatchNotComplete, got %v", err)
 
 	// Check typed error with fields.
-	var batchErr *errors.BatchNotCompleteError
+	var batchErr *BatchNotCompleteError
 	require.True(t, stderrors.As(err, &batchErr))
 	require.Equal(t, "batch_xyz", batchErr.BatchID)
 	require.Equal(t, "in_progress", batchErr.Status)
@@ -1435,7 +1435,7 @@ func TestCompletionHTTPError409IsNotBatchError(t *testing.T) {
 	require.Error(t, err)
 
 	// 409 on a completion endpoint should NOT produce a BatchNotCompleteError.
-	require.False(t, stderrors.Is(err, errors.ErrBatchNotComplete),
+	require.False(t, stderrors.Is(err, ErrBatchNotComplete),
 		"completion 409 should not map to ErrBatchNotComplete, got %v", err)
 }
 
@@ -1654,6 +1654,6 @@ func TestIntegrationBatchNotComplete(t *testing.T) {
 	// Immediately requesting results should fail since the batch is not yet complete.
 	_, err = provider.RetrieveBatchResults(ctx, batch.ID, batch.Provider)
 	require.Error(t, err)
-	require.True(t, stderrors.Is(err, errors.ErrBatchNotComplete),
+	require.True(t, stderrors.Is(err, ErrBatchNotComplete),
 		"expected ErrBatchNotComplete, got %v", err)
 }

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/internal/testutil"
 	"github.com/mozilla-ai/any-llm-go/providers"
 )
 
@@ -1414,6 +1415,53 @@ func TestParseBatchNotCompleteDetail(t *testing.T) {
 	}
 }
 
+func TestCompletionHTTPError409IsNotBatchError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"detail": "conflict on completion endpoint"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(config.WithBaseURL(srv.URL))
+	require.NoError(t, err)
+
+	_, err = provider.Completion(context.Background(), providers.CompletionParams{
+		Model:    "test-model",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	require.Error(t, err)
+
+	// 409 on a completion endpoint should NOT produce a BatchNotCompleteError.
+	require.False(t, stderrors.Is(err, errors.ErrBatchNotComplete),
+		"completion 409 should not map to ErrBatchNotComplete, got %v", err)
+}
+
+func TestCompletionHTTPError404IsModelNotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail": "model not found"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(config.WithBaseURL(srv.URL))
+	require.NoError(t, err)
+
+	_, err = provider.Completion(context.Background(), providers.CompletionParams{
+		Model:    "nonexistent:model",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	require.Error(t, err)
+
+	// 404 on a completion endpoint should not contain "upgrade your gateway".
+	require.NotContains(t, err.Error(), "upgrade your gateway")
+}
+
 // --- Integration tests ---
 
 func TestIntegrationCompletion(t *testing.T) {
@@ -1540,4 +1588,72 @@ func mockCompletionResponse(content string) string {
 // environment variables. Returns empty strings if not set.
 func gatewayCredentials() (gatewayURL string, token string) {
 	return os.Getenv(envAPIBase), os.Getenv(envPlatformToken)
+}
+
+// --- Integration tests (gated by GATEWAY_API_KEY) ---
+
+func TestIntegrationCreateAndRetrieveBatch(t *testing.T) {
+	if testutil.SkipIfNoAPIKey(providerName) {
+		t.Skip("GATEWAY_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	batch, err := provider.CreateBatch(ctx, providers.CreateBatchParams{
+		Model: "openai:gpt-4o-mini",
+		Requests: []providers.BatchRequestItem{
+			{
+				CustomID: "integration-req-1",
+				Body: map[string]any{
+					"messages":   []any{map[string]any{"role": "user", "content": "Say hello"}},
+					"max_tokens": 10,
+				},
+			},
+		},
+		CompletionWindow: "24h",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, batch.ID)
+	require.Equal(t, "batch", batch.Object)
+	require.NotEmpty(t, batch.Provider)
+
+	// Retrieve the batch we just created.
+	retrieved, err := provider.RetrieveBatch(ctx, batch.ID, batch.Provider)
+	require.NoError(t, err)
+	require.Equal(t, batch.ID, retrieved.ID)
+}
+
+func TestIntegrationBatchNotComplete(t *testing.T) {
+	if testutil.SkipIfNoAPIKey(providerName) {
+		t.Skip("GATEWAY_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	batch, err := provider.CreateBatch(ctx, providers.CreateBatchParams{
+		Model: "openai:gpt-4o-mini",
+		Requests: []providers.BatchRequestItem{
+			{
+				CustomID: "integration-req-1",
+				Body: map[string]any{
+					"messages":   []any{map[string]any{"role": "user", "content": "Say hello"}},
+					"max_tokens": 10,
+				},
+			},
+		},
+		CompletionWindow: "24h",
+	})
+	require.NoError(t, err)
+
+	// Immediately requesting results should fail since the batch is not yet complete.
+	_, err = provider.RetrieveBatchResults(ctx, batch.ID, batch.Provider)
+	require.Error(t, err)
+	require.True(t, stderrors.Is(err, errors.ErrBatchNotComplete),
+		"expected ErrBatchNotComplete, got %v", err)
 }

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -1228,31 +1228,62 @@ func TestRetrieveBatchResultsSuccess(t *testing.T) {
 func TestBatchError409(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusConflict)
-		_, _ = w.Write([]byte(`{"detail": "Batch 'batch_xyz' is not yet complete (status: in_progress)"}`))
-	}))
-	t.Cleanup(srv.Close)
+	t.Run("gateway returns structured status field", func(t *testing.T) {
+		t.Parallel()
 
-	provider, err := New(
-		config.WithBaseURL(srv.URL),
-		WithGatewayKey("test-key"),
-	)
-	require.NoError(t, err)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"detail": "batch not yet complete", "status": "in_progress"}`))
+		}))
+		t.Cleanup(srv.Close)
 
-	_, err = provider.RetrieveBatchResults(context.Background(), "batch_xyz", "openai")
-	require.Error(t, err)
+		provider, err := New(
+			config.WithBaseURL(srv.URL),
+			WithGatewayKey("test-key"),
+		)
+		require.NoError(t, err)
 
-	// Check sentinel error.
-	require.True(t, stderrors.Is(err, ErrBatchNotComplete),
-		"expected error to match ErrBatchNotComplete, got %v", err)
+		_, err = provider.RetrieveBatchResults(context.Background(), "batch_xyz", "openai")
+		require.Error(t, err)
 
-	// Check typed error with fields.
-	var batchErr *BatchNotCompleteError
-	require.True(t, stderrors.As(err, &batchErr))
-	require.Equal(t, "batch_xyz", batchErr.BatchID)
-	require.Equal(t, "in_progress", batchErr.Status)
+		require.True(t, stderrors.Is(err, ErrBatchNotComplete),
+			"expected error to match ErrBatchNotComplete, got %v", err)
+
+		// Batch ID comes from the caller; status comes from the structured
+		// JSON field so we don't rely on free-text parsing.
+		var batchErr *BatchNotCompleteError
+		require.True(t, stderrors.As(err, &batchErr))
+		require.Equal(t, "batch_xyz", batchErr.BatchID)
+		require.Equal(t, "in_progress", batchErr.Status)
+	})
+
+	t.Run("gateway returns detail only", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"detail": "batch not yet complete"}`))
+		}))
+		t.Cleanup(srv.Close)
+
+		provider, err := New(
+			config.WithBaseURL(srv.URL),
+			WithGatewayKey("test-key"),
+		)
+		require.NoError(t, err)
+
+		_, err = provider.RetrieveBatchResults(context.Background(), "batch_xyz", "openai")
+		require.Error(t, err)
+
+		require.True(t, stderrors.Is(err, ErrBatchNotComplete))
+
+		var batchErr *BatchNotCompleteError
+		require.True(t, stderrors.As(err, &batchErr))
+		require.Equal(t, "batch_xyz", batchErr.BatchID)
+		require.Empty(t, batchErr.Status, "status should be empty when gateway omits it")
+	})
 }
 
 func TestBatchError404(t *testing.T) {
@@ -1374,46 +1405,6 @@ func TestBatchError429(t *testing.T) {
 }
 
 // --- Helper function tests ---
-
-func TestParseBatchNotCompleteDetail(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name       string
-		detail     string
-		wantID     string
-		wantStatus string
-	}{
-		{
-			name:       "standard format",
-			detail:     "Batch 'batch_abc123' is not yet complete (status: in_progress)",
-			wantID:     "batch_abc123",
-			wantStatus: "in_progress",
-		},
-		{
-			name:       "lowercase batch",
-			detail:     "batch 'batch_xyz' is not yet complete (status: validating)",
-			wantID:     "batch_xyz",
-			wantStatus: "validating",
-		},
-		{
-			name:       "unrecognized format",
-			detail:     "something went wrong",
-			wantID:     "",
-			wantStatus: "unknown",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			batchID, status := parseBatchNotCompleteDetail(tc.detail)
-			require.Equal(t, tc.wantID, batchID)
-			require.Equal(t, tc.wantStatus, status)
-		})
-	}
-}
 
 func TestCompletionHTTPError409IsNotBatchError(t *testing.T) {
 	t.Parallel()

--- a/providers/types.go
+++ b/providers/types.go
@@ -331,3 +331,96 @@ func (m *Message) ContentString() string {
 func (m *Message) IsMultiModal() bool {
 	return m.ContentParts() != nil
 }
+
+// Batch represents a batch job.
+type Batch struct {
+	CompletedAt      *int64              `json:"completed_at,omitempty"`
+	CompletionWindow string              `json:"completion_window"`
+	CreatedAt        int64               `json:"created_at"`
+	Endpoint         string              `json:"endpoint"`
+	ErrorFileID      string              `json:"error_file_id,omitempty"`
+	ID               string              `json:"id"`
+	InProgressAt     *int64              `json:"in_progress_at,omitempty"`
+	InputFileID      string              `json:"input_file_id,omitempty"`
+	Metadata         map[string]string   `json:"metadata,omitempty"`
+	Object           string              `json:"object"`
+	OutputFileID     string              `json:"output_file_id,omitempty"`
+	Provider         string              `json:"provider,omitempty"`
+	RequestCounts    *BatchRequestCounts `json:"request_counts,omitempty"`
+	Status           BatchStatus         `json:"status"`
+}
+
+// BatchStatus represents the status of a batch job.
+type BatchStatus string
+
+const (
+	BatchStatusValidating BatchStatus = "validating"
+	BatchStatusFailed     BatchStatus = "failed"
+	BatchStatusInProgress BatchStatus = "in_progress"
+	BatchStatusFinalizing BatchStatus = "finalizing"
+	BatchStatusCompleted  BatchStatus = "completed"
+	BatchStatusExpired    BatchStatus = "expired"
+	BatchStatusCancelling BatchStatus = "cancelling"
+	BatchStatusCancelled  BatchStatus = "cancelled"
+)
+
+// BatchRequestCounts tracks request counts for a batch job.
+type BatchRequestCounts struct {
+	Completed int `json:"completed"`
+	Failed    int `json:"failed"`
+	Total     int `json:"total"`
+}
+
+// BatchRequestItem is a single request within a batch.
+type BatchRequestItem struct {
+	Body     map[string]any `json:"body"`
+	CustomID string         `json:"custom_id"`
+}
+
+// CreateBatchParams are parameters for creating a batch job.
+type CreateBatchParams struct {
+	CompletionWindow string             `json:"completion_window,omitempty"`
+	Metadata         map[string]string  `json:"metadata,omitempty"`
+	Model            string             `json:"model"`
+	Requests         []BatchRequestItem `json:"requests"`
+}
+
+// ListBatchesOptions are options for listing batch jobs.
+type ListBatchesOptions struct {
+	After string
+	Limit *int
+}
+
+// BatchResult contains the results of a completed batch job.
+type BatchResult struct {
+	Results []BatchResultItem `json:"results"`
+}
+
+// BatchResultItem is the result of a single request within a batch.
+type BatchResultItem struct {
+	CustomID string            `json:"custom_id"`
+	Error    *BatchResultError `json:"error,omitempty"`
+	Result   *ChatCompletion   `json:"result,omitempty"`
+}
+
+// BatchResultError is an error for a single request within a batch.
+type BatchResultError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// BatchProvider is an optional interface for providers that support
+// batch operations. Use a type assertion to check if a provider
+// supports batch:
+//
+//	if bp, ok := provider.(BatchProvider); ok {
+//	    batch, err := bp.CreateBatch(ctx, params)
+//	}
+type BatchProvider interface {
+	Provider
+	CreateBatch(ctx context.Context, params CreateBatchParams) (*Batch, error)
+	RetrieveBatch(ctx context.Context, batchID string, provider string) (*Batch, error)
+	CancelBatch(ctx context.Context, batchID string, provider string) (*Batch, error)
+	ListBatches(ctx context.Context, provider string, opts ListBatchesOptions) ([]Batch, error)
+	RetrieveBatchResults(ctx context.Context, batchID string, provider string) (*BatchResult, error)
+}

--- a/providers/types.go
+++ b/providers/types.go
@@ -354,14 +354,14 @@ type Batch struct {
 type BatchStatus string
 
 const (
-	BatchStatusValidating BatchStatus = "validating"
-	BatchStatusFailed     BatchStatus = "failed"
-	BatchStatusInProgress BatchStatus = "in_progress"
-	BatchStatusFinalizing BatchStatus = "finalizing"
+	BatchStatusCancelled  BatchStatus = "cancelled"
+	BatchStatusCancelling BatchStatus = "cancelling"
 	BatchStatusCompleted  BatchStatus = "completed"
 	BatchStatusExpired    BatchStatus = "expired"
-	BatchStatusCancelling BatchStatus = "cancelling"
-	BatchStatusCancelled  BatchStatus = "cancelled"
+	BatchStatusFailed     BatchStatus = "failed"
+	BatchStatusFinalizing BatchStatus = "finalizing"
+	BatchStatusInProgress BatchStatus = "in_progress"
+	BatchStatusValidating BatchStatus = "validating"
 )
 
 // BatchRequestCounts tracks request counts for a batch job.


### PR DESCRIPTION
## Summary

Add BatchProvider interface and a new Gateway provider that implements both completions and batch operations against the any-llm gateway HTTP API.

## Changes

- Add batch types to `providers/types.go`: `Batch`, `BatchStatus`, `BatchRequestCounts`, `BatchRequestItem`, `CreateBatchParams`, `ListBatchesOptions`, `BatchResult`, `BatchResultItem`, `BatchResultError`
- Add `BatchProvider` interface following the optional-interface pattern of `EmbeddingProvider`
- Add `BatchNotCompleteError` and `ErrBatchNotComplete` sentinel to `errors/errors.go`
- Re-export all batch types, status constants, and error types from root `anyllm.go`
- Create `providers/gateway/` package with full `Provider` implementation:
  - `Completion()` and `CompletionStream()` (SSE) for chat completions
  - `CreateBatch()`, `RetrieveBatch()`, `CancelBatch()`, `ListBatches()`, `RetrieveBatchResults()` for batch operations
  - `doRequest()` helper with `X-AnyLLM-Key: Bearer <key>` auth header
  - HTTP error mapping: 401/403 → AuthenticationError, 404 → ProviderError with upgrade hint, 409 → BatchNotCompleteError, 422 → ProviderError, 429 → RateLimitError, 502 → ProviderError
  - `parseBatchNotCompleteDetail()` regex parser for extracting batch ID and status from 409 error messages
- Add `"gateway"` to `testutil` provider env key map
- Comprehensive unit tests in `providers/gateway/gateway_test.go` (933 lines):
  - Construction: `TestNewRequiresAPIBase`, `TestNewWithAPIKey`, `TestNewWithoutAPIKey`, `TestNewFromEnvVars`
  - Capabilities verification
  - Completion: success, auth header, HTTP error mapping, streaming (SSE parsing, context cancellation, error propagation)
  - Batch: create, auth header, retrieve with provider param, cancel, list with pagination, retrieve results
  - Error mapping: 409 → BatchNotCompleteError (with `errors.Is` check), 404 → upgrade hint, 401 → AuthenticationError, 422 → ProviderError, 502 → upstream error
  - `convertParamsToRequest` coverage for all CompletionParams fields
  - `parseBatchNotCompleteDetail` regex edge cases

## Testing

- All unit tests pass: `go test ./... -race -count=1`
- All tests use `httptest` fake servers with `t.Parallel()` and `require` assertions
- Integration tests gated by `testutil.SkipIfNoAPIKey("gateway")`
- No existing tests affected

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass locally (`make test`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)