### PR TITLE
Rename gateway auth header from X-AnyLLM-Key to AnyLLM-Key

### DIFF
--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -9,7 +9,7 @@
 // The gateway supports two authentication modes:
 //   - Platform mode: uses a platform token as standard Bearer auth
 //   - Non-platform mode: sends a gateway API key via a custom authentication
-//     header (X-AnyLLM-Key)
+//     header (AnyLLM-Key)
 package gateway
 
 import (
@@ -31,7 +31,7 @@ import (
 const (
 	// apiKeyHeaderName is the HTTP header that carries the gateway API key in
 	// non-platform mode.
-	apiKeyHeaderName = "X-AnyLLM-Key"
+	apiKeyHeaderName = "AnyLLM-Key"
 
 	// bearerPrefix is the Authorization scheme prefix applied to the gateway
 	// key before it is placed in the gateway header (e.g. "Bearer <key>").
@@ -250,7 +250,7 @@ func capabilities() providers.Capabilities {
 
 // WithGatewayKey sets the gateway API key for non-platform mode authentication.
 // The key is sent as a Bearer-formatted value in the gateway authentication
-// header (X-AnyLLM-Key).
+// header (AnyLLM-Key).
 func WithGatewayKey(key string) config.Option {
 	return config.WithExtra(extraKeyGatewayKey, key)
 }

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -275,7 +275,7 @@ func TestExtraValueHandling(t *testing.T) {
 		envAPIKey         string
 		apiKey            string
 		gatewayKey        string
-		wantAPIKeyHeader  string // expected X-AnyLLM-Key value; empty means the header must not be sent.
+		wantAPIKeyHeader  string // expected AnyLLM-Key value; empty means the header must not be sent.
 		wantAuthorization string // expected Authorization value.
 	}{
 		{


### PR DESCRIPTION
## Summary

Rename the gateway authentication header from `X-AnyLLM-Key` to `AnyLLM-Key` to comply with RFC 6648 (drop the `X-` prefix), aligning with the gateway rename in [gateway PR #45](https://github.com/mozilla-ai/gateway/pull/45).

## Changes

- Updated `apiKeyHeaderName` constant from `"X-AnyLLM-Key"` to `"AnyLLM-Key"` in `providers/gateway/gateway.go`
- Updated doc comments on the package and `WithGatewayKey` function to reference the new header name
- Updated test struct field comment in `providers/gateway/gateway_test.go`

## Testing

- All existing gateway provider tests pass without modification (they reference the `apiKeyHeaderName` constant, not hardcoded strings)
- Ran `go test ./providers/gateway/ -race -count=1` — all tests pass
- Ran `go build ./...` — compilation succeeds

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass locally (`make test`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)