### PR TITLE
Add moderation API support to gateway provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,44 @@ for _, model := range models.Data {
 }
 ```
 
+### Moderation
+
+The gateway provider supports OpenAI-compatible content moderation. Use
+`errors.As` with `*anyllm.UnsupportedError` (or `errors.Is` with
+`anyllm.ErrUnsupported`) to detect providers that do not support moderation.
+
+```go
+import (
+    stderrors "errors"
+
+    anyllm "github.com/mozilla-ai/any-llm-go"
+    "github.com/mozilla-ai/any-llm-go/config"
+    "github.com/mozilla-ai/any-llm-go/providers/gateway"
+)
+
+provider, err := gateway.New(config.WithBaseURL("https://gw.example.com"))
+if err != nil {
+    log.Fatal(err)
+}
+
+resp, err := provider.Moderation(ctx, anyllm.ModerationParams{
+    Model: "openai:omni-moderation-latest",
+    Input: "I want to hurt someone",
+})
+if err != nil {
+    var unsup *anyllm.UnsupportedError
+    if stderrors.As(err, &unsup) {
+        // Provider does not support moderation; pick another model.
+        log.Printf("%s cannot do %s", unsup.Provider, unsup.Operation)
+        return
+    }
+    log.Fatal(err)
+}
+if resp.Results[0].Flagged {
+    // Handle flagged content.
+}
+```
+
 ### Error Handling
 
 All provider errors are normalized to common error types:

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ for _, model := range models.Data {
 ### Moderation
 
 The gateway provider supports OpenAI-compatible content moderation. Use
-`errors.As` with `*anyllm.UnsupportedError` (or `errors.Is` with
+`errors.As` with `*anyllm.UnsupportedOperationError` (or `errors.Is` with
 `anyllm.ErrUnsupported`) to detect providers that do not support moderation.
 
 ```go
@@ -286,7 +286,7 @@ resp, err := provider.Moderation(ctx, anyllm.ModerationParams{
     Input: "I want to hurt someone",
 })
 if err != nil {
-    var unsup *anyllm.UnsupportedError
+    var unsup *anyllm.UnsupportedOperationError
     if stderrors.As(err, &unsup) {
         // Provider does not support moderation; pick another model.
         log.Printf("%s cannot do %s", unsup.Provider, unsup.Operation)

--- a/anyllm.go
+++ b/anyllm.go
@@ -188,7 +188,7 @@ type (
 	ModelNotFoundError       = errors.ModelNotFoundError
 	ProviderError            = errors.ProviderError
 	RateLimitError           = errors.RateLimitError
-	UnsupportedError         = errors.UnsupportedError
+	UnsupportedOperationError         = errors.UnsupportedOperationError
 	UnsupportedParamError    = errors.UnsupportedParamError
 	UnsupportedProviderError = errors.UnsupportedProviderError
 )

--- a/anyllm.go
+++ b/anyllm.go
@@ -67,6 +67,7 @@ type (
 	CapabilityProvider = providers.CapabilityProvider
 	EmbeddingProvider  = providers.EmbeddingProvider
 	ModelLister        = providers.ModelLister
+	ModerationProvider = providers.ModerationProvider
 	Provider           = providers.Provider
 	RerankProvider     = providers.RerankProvider
 )
@@ -94,6 +95,9 @@ type (
 	EmbeddingParams     = providers.EmbeddingParams
 	EmbeddingResponse   = providers.EmbeddingResponse
 	ModelsResponse      = providers.ModelsResponse
+	ModerationParams    = providers.ModerationParams
+	ModerationResponse  = providers.ModerationResponse
+	ModerationResult    = providers.ModerationResult
 )
 
 // Message types.
@@ -167,6 +171,7 @@ var (
 	ErrModelNotFound       = errors.ErrModelNotFound
 	ErrProvider            = errors.ErrProvider
 	ErrRateLimit           = errors.ErrRateLimit
+	ErrUnsupported         = errors.ErrUnsupported
 	ErrUnsupportedParam    = errors.ErrUnsupportedParam
 	ErrUnsupportedProvider = errors.ErrUnsupportedProvider
 )
@@ -183,6 +188,7 @@ type (
 	ModelNotFoundError       = errors.ModelNotFoundError
 	ProviderError            = errors.ProviderError
 	RateLimitError           = errors.RateLimitError
+	UnsupportedError         = errors.UnsupportedError
 	UnsupportedParamError    = errors.UnsupportedParamError
 	UnsupportedProviderError = errors.UnsupportedProviderError
 )

--- a/anyllm.go
+++ b/anyllm.go
@@ -178,17 +178,17 @@ var (
 
 // Error types.
 type (
-	AuthenticationError      = errors.AuthenticationError
-	BaseError                = errors.BaseError
-	ContentFilterError       = errors.ContentFilterError
-	ContextLengthError       = errors.ContextLengthError
-	InsufficientFundsError   = errors.InsufficientFundsError
-	InvalidRequestError      = errors.InvalidRequestError
-	MissingAPIKeyError       = errors.MissingAPIKeyError
-	ModelNotFoundError       = errors.ModelNotFoundError
-	ProviderError            = errors.ProviderError
-	RateLimitError           = errors.RateLimitError
-	UnsupportedOperationError         = errors.UnsupportedOperationError
-	UnsupportedParamError    = errors.UnsupportedParamError
-	UnsupportedProviderError = errors.UnsupportedProviderError
+	AuthenticationError           = errors.AuthenticationError
+	BaseError                     = errors.BaseError
+	ContentFilterError            = errors.ContentFilterError
+	ContextLengthError            = errors.ContextLengthError
+	InsufficientFundsError        = errors.InsufficientFundsError
+	InvalidRequestError           = errors.InvalidRequestError
+	MissingAPIKeyError            = errors.MissingAPIKeyError
+	ModelNotFoundError            = errors.ModelNotFoundError
+	ProviderError                 = errors.ProviderError
+	RateLimitError                = errors.RateLimitError
+	UnsupportedOperationError     = errors.UnsupportedOperationError
+	UnsupportedParamError         = errors.UnsupportedParamError
+	UnsupportedProviderError      = errors.UnsupportedProviderError
 )

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -18,6 +18,7 @@ const (
 	CodeUnsupportedProvider = "unsupported_provider"
 	CodeUnsupportedParam    = "unsupported_parameter"
 	CodeInsufficientFunds   = "insufficient_funds"
+	CodeUnsupported         = "unsupported"
 )
 
 // Sentinel errors for type checking with errors.Is().
@@ -33,6 +34,7 @@ var (
 	ErrUnsupportedProvider = stderrors.New("unsupported provider")
 	ErrUnsupportedParam    = stderrors.New("unsupported parameter")
 	ErrInsufficientFunds   = stderrors.New("insufficient funds")
+	ErrUnsupported         = stderrors.New("operation not supported by provider")
 )
 
 // BaseError is the base error type for all any-llm errors.
@@ -154,6 +156,22 @@ type UnsupportedParamError struct {
 // InsufficientFundsError is returned when the account has insufficient funds (HTTP 402).
 type InsufficientFundsError struct {
 	BaseError
+}
+
+// UnsupportedError indicates a provider does not support a given operation
+// (e.g. moderation). Use errors.As to detect:
+//
+//	var unsup *errors.UnsupportedError
+//	if errors.As(err, &unsup) {
+//	    // unsup.Operation, unsup.Provider ...
+//	}
+//
+// Also matches errors.Is(err, ErrUnsupported).
+type UnsupportedError struct {
+	BaseError
+	// Operation names the unsupported capability (e.g. "moderation",
+	// "multimodal_moderation").
+	Operation string
 }
 
 // NewRateLimitError creates a new RateLimitError.
@@ -290,5 +308,14 @@ func NewInsufficientFundsError(provider string, err error) *InsufficientFundsErr
 			Err:      err,
 			sentinel: ErrInsufficientFunds,
 		},
+	}
+}
+
+// NewUnsupportedError creates a new UnsupportedError for the given provider
+// and operation (e.g. "moderation").
+func NewUnsupportedError(provider, operation string, err error) *UnsupportedError {
+	return &UnsupportedError{
+		BaseError: New(CodeUnsupported, provider, err, ErrUnsupported),
+		Operation: operation,
 	}
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -158,16 +158,16 @@ type InsufficientFundsError struct {
 	BaseError
 }
 
-// UnsupportedError indicates a provider does not support a given operation
+// UnsupportedOperationError indicates a provider does not support a given operation
 // (e.g. moderation). Use errors.As to detect:
 //
-//	var unsup *errors.UnsupportedError
+//	var unsup *errors.UnsupportedOperationError
 //	if errors.As(err, &unsup) {
 //	    // unsup.Operation, unsup.Provider ...
 //	}
 //
 // Also matches errors.Is(err, ErrUnsupported).
-type UnsupportedError struct {
+type UnsupportedOperationError struct {
 	BaseError
 	// Operation names the unsupported capability (e.g. "moderation",
 	// "multimodal_moderation").
@@ -311,10 +311,10 @@ func NewInsufficientFundsError(provider string, err error) *InsufficientFundsErr
 	}
 }
 
-// NewUnsupportedError creates a new UnsupportedError for the given provider
+// NewUnsupportedOperationError creates a new UnsupportedOperationError for the given provider
 // and operation (e.g. "moderation").
-func NewUnsupportedError(provider, operation string, err error) *UnsupportedError {
-	return &UnsupportedError{
+func NewUnsupportedOperationError(provider, operation string, err error) *UnsupportedOperationError {
+	return &UnsupportedOperationError{
 		BaseError: New(CodeUnsupported, provider, err, ErrUnsupported),
 		Operation: operation,
 	}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -97,14 +97,14 @@ func TestErrorIs(t *testing.T) {
 			wantMatch: false,
 		},
 		{
-			name:      "UnsupportedError matches ErrUnsupported",
-			err:       NewUnsupportedError("anthropic", "moderation", originalErr),
+			name:      "UnsupportedOperationError matches ErrUnsupported",
+			err:       NewUnsupportedOperationError("anthropic", "moderation", originalErr),
 			target:    ErrUnsupported,
 			wantMatch: true,
 		},
 		{
-			name:      "UnsupportedError does not match ErrUnsupportedProvider",
-			err:       NewUnsupportedError("anthropic", "moderation", originalErr),
+			name:      "UnsupportedOperationError does not match ErrUnsupportedProvider",
+			err:       NewUnsupportedOperationError("anthropic", "moderation", originalErr),
 			target:    ErrUnsupportedProvider,
 			wantMatch: false,
 		},
@@ -243,9 +243,9 @@ func TestErrorCodes(t *testing.T) {
 		require.Equal(t, CodeInsufficientFunds, err.Code)
 	})
 
-	t.Run("UnsupportedError has correct code", func(t *testing.T) {
+	t.Run("UnsupportedOperationError has correct code", func(t *testing.T) {
 		t.Parallel()
-		err := NewUnsupportedError("anthropic", "moderation", nil)
+		err := NewUnsupportedOperationError("anthropic", "moderation", nil)
 		require.Equal(t, CodeUnsupported, err.Code)
 	})
 }
@@ -297,12 +297,12 @@ func TestErrorAs(t *testing.T) {
 		require.Equal(t, "gateway", fundsErr.Provider)
 	})
 
-	t.Run("can extract UnsupportedError with Operation", func(t *testing.T) {
+	t.Run("can extract UnsupportedOperationError with Operation", func(t *testing.T) {
 		t.Parallel()
 
-		err := NewUnsupportedError("anthropic", "moderation", stderrors.New("not supported"))
+		err := NewUnsupportedOperationError("anthropic", "moderation", stderrors.New("not supported"))
 
-		var unsup *UnsupportedError
+		var unsup *UnsupportedOperationError
 		require.True(t, stderrors.As(err, &unsup))
 		require.Equal(t, "anthropic", unsup.Provider)
 		require.Equal(t, "moderation", unsup.Operation)

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -96,6 +96,18 @@ func TestErrorIs(t *testing.T) {
 			target:    ErrAuthentication,
 			wantMatch: false,
 		},
+		{
+			name:      "UnsupportedError matches ErrUnsupported",
+			err:       NewUnsupportedError("anthropic", "moderation", originalErr),
+			target:    ErrUnsupported,
+			wantMatch: true,
+		},
+		{
+			name:      "UnsupportedError does not match ErrUnsupportedProvider",
+			err:       NewUnsupportedError("anthropic", "moderation", originalErr),
+			target:    ErrUnsupportedProvider,
+			wantMatch: false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -230,6 +242,12 @@ func TestErrorCodes(t *testing.T) {
 		err := NewInsufficientFundsError("gateway", nil)
 		require.Equal(t, CodeInsufficientFunds, err.Code)
 	})
+
+	t.Run("UnsupportedError has correct code", func(t *testing.T) {
+		t.Parallel()
+		err := NewUnsupportedError("anthropic", "moderation", nil)
+		require.Equal(t, CodeUnsupported, err.Code)
+	})
 }
 
 func TestErrorAs(t *testing.T) {
@@ -277,5 +295,17 @@ func TestErrorAs(t *testing.T) {
 		var fundsErr *InsufficientFundsError
 		require.True(t, stderrors.As(err, &fundsErr))
 		require.Equal(t, "gateway", fundsErr.Provider)
+	})
+
+	t.Run("can extract UnsupportedError with Operation", func(t *testing.T) {
+		t.Parallel()
+
+		err := NewUnsupportedError("anthropic", "moderation", stderrors.New("not supported"))
+
+		var unsup *UnsupportedError
+		require.True(t, stderrors.As(err, &unsup))
+		require.Equal(t, "anthropic", unsup.Provider)
+		require.Equal(t, "moderation", unsup.Operation)
+		require.True(t, stderrors.Is(err, ErrUnsupported))
 	})
 }

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -558,7 +558,12 @@ func (p *Provider) Moderation(
 func (p *Provider) convertHTTPModerationError(statusCode int, body []byte) error {
 	detail := extractDetail(body)
 
-	if statusCode == http.StatusBadRequest && strings.Contains(detail, "does not support moderation") {
+	// Locked phrasings from the gateway:
+	//   "Provider <name> does not support moderation"
+	//   "Provider <name> does not support multimodal moderation input"
+	if statusCode == http.StatusBadRequest &&
+		strings.Contains(detail, "does not support") &&
+		strings.Contains(detail, "moderation") {
 		providerID := parseUnsupportedProvider(detail)
 		operation := "moderation"
 		if strings.Contains(detail, "multimodal") {

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -498,9 +498,9 @@ func (p *Provider) Embedding(
 // The openai-go SDK exposes a moderations resource, but we issue the HTTP
 // call directly here to control the include_raw query parameter and the
 // gateway-specific error shape (notably the "does not support moderation"
-// 400 that maps to *errors.UnsupportedError).
+// 400 that maps to *errors.UnsupportedOperationError).
 //
-// Returns an *errors.UnsupportedError (matching errors.ErrUnsupported) when
+// Returns an *errors.UnsupportedOperationError (matching errors.ErrUnsupported) when
 // the gateway reports that the chosen backend provider does not support
 // moderation.
 func (p *Provider) Moderation(
@@ -554,7 +554,7 @@ func (p *Provider) Moderation(
 
 // convertHTTPModerationError maps a non-200 response from /v1/moderations to
 // a typed error. 400 bodies containing "does not support moderation" are
-// converted to *errors.UnsupportedError; other statuses go through the
+// converted to *errors.UnsupportedOperationError; other statuses go through the
 // existing ConvertError path.
 func (p *Provider) convertHTTPModerationError(statusCode int, body []byte) error {
 	parsed := parseModerationError(body)
@@ -573,7 +573,7 @@ func (p *Provider) convertHTTPModerationError(statusCode int, body []byte) error
 		if strings.Contains(parsed.Detail, "multimodal") {
 			operation = "multimodal_moderation"
 		}
-		return errors.NewUnsupportedError(providerID, operation, stderrors.New(parsed.Detail))
+		return errors.NewUnsupportedOperationError(providerID, operation, stderrors.New(parsed.Detail))
 	}
 
 	// Delegate to the existing gateway ConvertError for other statuses by

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -595,14 +595,6 @@ type moderationError struct {
 	parseErr error
 }
 
-// message returns the best human-readable description of the error body.
-func (e moderationError) message() string {
-	if e.Detail != "" {
-		return e.Detail
-	}
-	return e.raw
-}
-
 // parseModerationError parses a gateway error response. Non-JSON bodies are
 // preserved via the raw field so callers can still surface the server's text
 // in the typed error. parseErr is set when the body cannot be decoded as

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -507,10 +507,11 @@ func (p *Provider) Moderation(
 	ctx context.Context,
 	params providers.ModerationParams,
 ) (*providers.ModerationResponse, error) {
-	endpoint := p.baseURL + "/v1/moderations"
+	u := &url.URL{Path: "/v1/moderations"}
 	if params.IncludeRaw {
-		endpoint += "?include_raw=true"
+		u.RawQuery = url.Values{"include_raw": {"true"}}.Encode()
 	}
+	endpoint := p.baseURL + u.RequestURI()
 
 	body, err := json.Marshal(params)
 	if err != nil {
@@ -556,20 +557,23 @@ func (p *Provider) Moderation(
 // converted to *errors.UnsupportedError; other statuses go through the
 // existing ConvertError path.
 func (p *Provider) convertHTTPModerationError(statusCode int, body []byte) error {
-	detail := extractDetail(body)
+	parsed := parseModerationError(body)
 
 	// Locked phrasings from the gateway:
 	//   "Provider <name> does not support moderation"
 	//   "Provider <name> does not support multimodal moderation input"
-	if statusCode == http.StatusBadRequest &&
-		strings.Contains(detail, "does not support") &&
-		strings.Contains(detail, "moderation") {
-		providerID := parseUnsupportedProvider(detail)
+	// The 400/unsupported check depends on the Detail field being present;
+	// if the body failed to parse, skip this branch and fall through to the
+	// generic ConvertError path so we don't silently misclassify the error.
+	if statusCode == http.StatusBadRequest && parsed.parseErr == nil &&
+		strings.Contains(parsed.Detail, "does not support") &&
+		strings.Contains(parsed.Detail, "moderation") {
+		providerID := parseUnsupportedProvider(parsed.Detail)
 		operation := "moderation"
-		if strings.Contains(detail, "multimodal") {
+		if strings.Contains(parsed.Detail, "multimodal") {
 			operation = "multimodal_moderation"
 		}
-		return errors.NewUnsupportedError(providerID, operation, stderrors.New(detail))
+		return errors.NewUnsupportedError(providerID, operation, stderrors.New(parsed.Detail))
 	}
 
 	// Delegate to the existing gateway ConvertError for other statuses by
@@ -581,16 +585,41 @@ func (p *Provider) convertHTTPModerationError(statusCode int, body []byte) error
 	})
 }
 
-// extractDetail reads the "detail" field from a JSON-encoded error body and
-// falls back to the raw body if the payload is not in that shape.
-func extractDetail(body []byte) string {
+// moderationError holds the parsed fields from a gateway error response body.
+// parseErr is non-nil when the body was not valid JSON or did not contain
+// the expected "detail" field, so callers can decide per-status whether a
+// parse failure is tolerable.
+type moderationError struct {
+	Detail   string
+	raw      string
+	parseErr error
+}
+
+// message returns the best human-readable description of the error body.
+func (e moderationError) message() string {
+	if e.Detail != "" {
+		return e.Detail
+	}
+	return e.raw
+}
+
+// parseModerationError parses a gateway error response. Non-JSON bodies are
+// preserved via the raw field so callers can still surface the server's text
+// in the typed error. parseErr is set when the body cannot be decoded as
+// JSON or when the "detail" field is empty, so callers that depend on
+// structured fields (e.g. the "does not support" check) can detect drift.
+func parseModerationError(body []byte) moderationError {
+	raw := string(body)
 	var wrapper struct {
 		Detail string `json:"detail"`
 	}
-	if err := json.Unmarshal(body, &wrapper); err == nil && wrapper.Detail != "" {
-		return wrapper.Detail
+	if err := json.Unmarshal(body, &wrapper); err != nil {
+		return moderationError{raw: raw, parseErr: fmt.Errorf("unmarshal error body: %w", err)}
 	}
-	return string(body)
+	if wrapper.Detail == "" {
+		return moderationError{raw: raw, parseErr: stderrors.New("error body missing \"detail\" field")}
+	}
+	return moderationError{Detail: wrapper.Detail, raw: raw}
 }
 
 // parseUnsupportedProvider extracts the provider name from the locked error

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -129,6 +129,7 @@ var (
 	_ providers.EmbeddingProvider  = (*Provider)(nil)
 	_ providers.ErrorConverter     = (*Provider)(nil)
 	_ providers.ModelLister        = (*Provider)(nil)
+	_ providers.ModerationProvider = (*Provider)(nil)
 	_ providers.Provider           = (*Provider)(nil)
 	_ providers.RerankProvider     = (*Provider)(nil)
 )
@@ -188,14 +189,19 @@ type Provider struct {
 	// OpenAI SDK.
 	apiKey string
 
-	// baseURL is the resolved gateway base URL without a trailing /v1 suffix.
-	// Used by Rerank to construct the /v1/rerank endpoint URL.
+	// baseURL is the resolved gateway base URL used to address endpoints
+	// handled directly by this package (e.g. /v1/moderations, /v1/rerank).
 	baseURL string
 
-	// httpClient is the HTTP client used for raw HTTP calls (e.g. rerank,
-	// batch API) that bypass the OpenAI SDK. In non-platform mode this is
-	// the header-injecting client so gateway auth is preserved.
+	// httpClient is the HTTP client used for endpoints the embedded
+	// openai-go SDK does not expose (e.g. /v1/moderations, rerank, batch).
+	// In non-platform mode this is the header-injecting client so gateway
+	// auth is preserved.
 	httpClient *http.Client
+
+	// platformToken is the Bearer token to set on requests we issue
+	// directly in platform mode; empty in non-platform mode.
+	platformToken string
 
 	// platformMode indicates whether the provider is operating in platform
 	// mode (using platform token for Bearer auth) or non-platform mode
@@ -297,6 +303,9 @@ func New(opts ...config.Option) (*Provider, error) {
 	// so NewCompatible sees the already-resolved, trimmed URL and does not
 	// re-run ResolveBaseURL.
 	compatOpts := slices.Clone(opts)
+	// httpClient is the client the embedded openai-go SDK and our direct
+	// HTTP calls will both use. Defaults to cfg.HTTPClient(); non-platform
+	// mode wraps it to inject the gateway auth header.
 	httpClient := cfg.HTTPClient()
 	if platformMode {
 		compatOpts = append(compatOpts, config.WithAPIKey(platformToken))
@@ -309,7 +318,7 @@ func New(opts ...config.Option) (*Provider, error) {
 		// Real auth, if any, is carried by the gateway header below.
 		compatOpts = append(compatOpts, config.WithAPIKey(placeholderAPIKey))
 		if gatewayKey != "" {
-			httpClient = newHeaderClient(cfg.HTTPClient(), bearerPrefix+gatewayKey)
+			httpClient = newHeaderClient(httpClient, bearerPrefix+gatewayKey)
 			compatOpts = append(compatOpts, config.WithHTTPClient(httpClient))
 		}
 	}
@@ -349,6 +358,7 @@ func New(opts ...config.Option) (*Provider, error) {
 		baseURL:            rawBaseURL,
 		httpClient:         httpClient,
 		platformMode:       platformMode,
+		platformToken:      platformToken,
 	}, nil
 }
 
@@ -367,6 +377,7 @@ func capabilities() providers.Capabilities {
 		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
+		Moderation:          true,
 		Rerank:              true,
 	}
 }
@@ -480,6 +491,117 @@ func (p *Provider) Embedding(
 	}
 
 	return resp, nil
+}
+
+// Moderation runs a content moderation check via POST /v1/moderations.
+//
+// The openai-go SDK exposes a moderations resource, but we issue the HTTP
+// call directly here to control the include_raw query parameter and the
+// gateway-specific error shape (notably the "does not support moderation"
+// 400 that maps to *errors.UnsupportedError).
+//
+// Returns an *errors.UnsupportedError (matching errors.ErrUnsupported) when
+// the gateway reports that the chosen backend provider does not support
+// moderation.
+func (p *Provider) Moderation(
+	ctx context.Context,
+	params providers.ModerationParams,
+) (*providers.ModerationResponse, error) {
+	endpoint := p.baseURL + "/v1/moderations"
+	if params.IncludeRaw {
+		endpoint += "?include_raw=true"
+	}
+
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: marshal moderation params: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("gateway: build moderation request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if p.platformMode && p.platformToken != "" {
+		// Platform mode: replicate the Bearer auth that the embedded
+		// openai-go SDK adds for its own requests. Non-platform mode
+		// relies on headerTransport, which is wired into p.httpClient.
+		req.Header.Set("Authorization", bearerPrefix+p.platformToken)
+	}
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, p.ConvertError(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: read moderation response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, p.convertHTTPModerationError(resp.StatusCode, bodyBytes)
+	}
+
+	var out providers.ModerationResponse
+	if err := json.Unmarshal(bodyBytes, &out); err != nil {
+		return nil, fmt.Errorf("gateway: unmarshal moderation response: %w", err)
+	}
+	return &out, nil
+}
+
+// convertHTTPModerationError maps a non-200 response from /v1/moderations to
+// a typed error. 400 bodies containing "does not support moderation" are
+// converted to *errors.UnsupportedError; other statuses go through the
+// existing ConvertError path.
+func (p *Provider) convertHTTPModerationError(statusCode int, body []byte) error {
+	detail := extractDetail(body)
+
+	if statusCode == http.StatusBadRequest && strings.Contains(detail, "does not support moderation") {
+		providerID := parseUnsupportedProvider(detail)
+		operation := "moderation"
+		if strings.Contains(detail, "multimodal") {
+			operation = "multimodal_moderation"
+		}
+		return errors.NewUnsupportedError(providerID, operation, stderrors.New(detail))
+	}
+
+	// Delegate to the existing gateway ConvertError for other statuses by
+	// synthesizing an openai.Error that ConvertError understands.
+	return p.ConvertError(&openai.Error{
+		StatusCode: statusCode,
+		// Message is exposed through openai.Error.Error(); keeping the
+		// server-provided detail makes the wrapped error readable.
+	})
+}
+
+// extractDetail reads the "detail" field from a JSON-encoded error body and
+// falls back to the raw body if the payload is not in that shape.
+func extractDetail(body []byte) string {
+	var wrapper struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.Unmarshal(body, &wrapper); err == nil && wrapper.Detail != "" {
+		return wrapper.Detail
+	}
+	return string(body)
+}
+
+// parseUnsupportedProvider extracts the provider name from the locked error
+// phrasing "Provider <name> does not support ..." and returns "unknown" on
+// any parse failure.
+func parseUnsupportedProvider(detail string) string {
+	const prefix = "Provider "
+	rest, ok := strings.CutPrefix(detail, prefix)
+	if !ok {
+		return "unknown"
+	}
+	end := strings.Index(rest, " does not")
+	if end <= 0 {
+		return "unknown"
+	}
+	return rest[:end]
 }
 
 // ListModels returns a list of available models from the gateway.

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -215,6 +215,7 @@ func TestCapabilities(t *testing.T) {
 	require.True(t, caps.CompletionTools)
 	require.True(t, caps.Embedding)
 	require.True(t, caps.ListModels)
+	require.True(t, caps.Moderation)
 	require.True(t, caps.Rerank)
 }
 

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -1838,6 +1838,320 @@ func TestIntegrationCompletionStream(t *testing.T) {
 	t.Logf("Content: %s", content.String())
 }
 
+// Moderation tests.
+
+func TestModeration(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu          sync.Mutex
+		capturedReq map[string]any
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v1/moderations", r.URL.Path)
+
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		mu.Lock()
+		_ = json.Unmarshal(raw, &capturedReq)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "modr-abc",
+			"model": "omni-moderation-latest",
+			"results": [{
+				"flagged": true,
+				"categories": {"violence": true},
+				"category_scores": {"violence": 0.93}
+			}]
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(config.WithBaseURL(srv.URL))
+	require.NoError(t, err)
+
+	resp, err := provider.Moderation(context.Background(), providers.ModerationParams{
+		Model: "openai:omni-moderation-latest",
+		Input: "hurt someone",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "modr-abc", resp.ID)
+	require.Len(t, resp.Results, 1)
+	require.True(t, resp.Results[0].Flagged)
+	require.True(t, resp.Results[0].Categories["violence"])
+	require.InDelta(t, 0.93, resp.Results[0].CategoryScores["violence"], 0.001)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, "openai:omni-moderation-latest", capturedReq["model"])
+	require.Equal(t, "hurt someone", capturedReq["input"])
+	// IncludeRaw must not leak into the JSON body; it is a query param only.
+	_, hasIncludeRaw := capturedReq["IncludeRaw"]
+	require.False(t, hasIncludeRaw)
+	_, hasIncludeRawSnake := capturedReq["include_raw"]
+	require.False(t, hasIncludeRawSnake)
+}
+
+func TestModerationIncludeRawAddsQuery(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu          sync.Mutex
+		capturedURL string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		capturedURL = r.URL.String()
+		mu.Unlock()
+
+		require.Equal(t, "true", r.URL.Query().Get("include_raw"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"m","model":"x","results":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(config.WithBaseURL(srv.URL))
+	require.NoError(t, err)
+
+	_, err = provider.Moderation(context.Background(), providers.ModerationParams{
+		Model:      "openai:omni-moderation-latest",
+		Input:      "x",
+		IncludeRaw: true,
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Contains(t, capturedURL, "include_raw=true")
+}
+
+func TestModerationUnsupportedProvider(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"detail":"Provider anthropic does not support moderation"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(config.WithBaseURL(srv.URL))
+	require.NoError(t, err)
+
+	_, err = provider.Moderation(context.Background(), providers.ModerationParams{
+		Model: "anthropic:claude-3-haiku",
+		Input: "x",
+	})
+	require.Error(t, err)
+
+	var unsup *errors.UnsupportedError
+	require.True(t, stderrors.As(err, &unsup), "expected *UnsupportedError, got %T", err)
+	require.Equal(t, "anthropic", unsup.Provider)
+	require.Equal(t, "moderation", unsup.Operation)
+	require.True(t, stderrors.Is(err, errors.ErrUnsupported))
+}
+
+func TestModerationUnsupportedMultimodal(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(
+			[]byte(`{"detail":"Provider mistral does not support multimodal moderation input"}`),
+		)
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(config.WithBaseURL(srv.URL))
+	require.NoError(t, err)
+
+	_, err = provider.Moderation(context.Background(), providers.ModerationParams{
+		Model: "mistral:mistral-moderation-latest",
+		Input: []providers.ContentPart{
+			{Type: "text", Text: "hi"},
+			{Type: "image_url", ImageURL: &providers.ImageURL{URL: "https://example.com/a.png"}},
+		},
+	})
+	require.Error(t, err)
+
+	var unsup *errors.UnsupportedError
+	require.True(t, stderrors.As(err, &unsup), "expected *UnsupportedError, got %T", err)
+	require.Equal(t, "mistral", unsup.Provider)
+	require.Equal(t, "multimodal_moderation", unsup.Operation)
+	require.True(t, stderrors.Is(err, errors.ErrUnsupported))
+}
+
+func TestModerationErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    error
+	}{
+		{
+			name:       "401 auth",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"detail":"unauthorized"}`,
+			wantErr:    errors.ErrAuthentication,
+		},
+		{
+			name:       "402 funds",
+			statusCode: http.StatusPaymentRequired,
+			body:       `{"detail":"over budget"}`,
+			wantErr:    errors.ErrInsufficientFunds,
+		},
+		{
+			name:       "429 rate",
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"detail":"slow down"}`,
+			wantErr:    errors.ErrRateLimit,
+		},
+		{
+			name:       "502 upstream",
+			statusCode: http.StatusBadGateway,
+			body:       `{"detail":"bad gateway"}`,
+			wantErr:    ErrUpstreamProvider,
+		},
+		{
+			name:       "504 timeout",
+			statusCode: http.StatusGatewayTimeout,
+			body:       `{"detail":"timeout"}`,
+			wantErr:    ErrTimeout,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			t.Cleanup(srv.Close)
+
+			provider, err := New(config.WithBaseURL(srv.URL))
+			require.NoError(t, err)
+
+			_, err = provider.Moderation(context.Background(), providers.ModerationParams{
+				Model: "openai:omni-moderation-latest",
+				Input: "x",
+			})
+			require.Error(t, err)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+// TestModerationAuthPlatformMode verifies platform-mode Bearer auth is
+// attached to the direct HTTP call we make from Moderation (the embedded
+// openai-go SDK is not involved here).
+func TestModerationAuthPlatformMode(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu              sync.Mutex
+		capturedHeaders http.Header
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		capturedHeaders = r.Header.Clone()
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"m","model":"x","results":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		config.WithAPIKey("tk_platform_token"),
+		WithPlatformMode(),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.Moderation(context.Background(), providers.ModerationParams{
+		Model: "openai:omni-moderation-latest",
+		Input: "x",
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, bearerPrefix+"tk_platform_token", capturedHeaders.Get("Authorization"))
+}
+
+// TestModerationAuthNonPlatformMode verifies the gateway key header is
+// attached (via headerTransport) on the direct HTTP call.
+func TestModerationAuthNonPlatformMode(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu              sync.Mutex
+		capturedHeaders http.Header
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		capturedHeaders = r.Header.Clone()
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"m","model":"x","results":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := New(
+		config.WithBaseURL(srv.URL),
+		WithGatewayKey("gw_test_key"),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.Moderation(context.Background(), providers.ModerationParams{
+		Model: "openai:omni-moderation-latest",
+		Input: "x",
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, bearerPrefix+"gw_test_key", capturedHeaders.Get(apiKeyHeaderName))
+}
+
+func TestIntegrationModeration(t *testing.T) {
+	t.Parallel()
+
+	gatewayURL, token := gatewayCredentials()
+	if gatewayURL == "" || token == "" {
+		t.Skip("GATEWAY_API_BASE and GATEWAY_PLATFORM_TOKEN not set")
+	}
+
+	provider, err := New(
+		config.WithBaseURL(gatewayURL),
+		config.WithAPIKey(token),
+		WithPlatformMode(),
+	)
+	require.NoError(t, err)
+
+	resp, err := provider.Moderation(context.Background(), providers.ModerationParams{
+		Model: "openai:omni-moderation-latest",
+		Input: "I want to hurt someone",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Results)
+
+	t.Logf("Moderation response: flagged=%v", resp.Results[0].Flagged)
+}
+
 // Test helpers.
 
 // mockRoundTripper records whether it was called and delegates to a base transport.

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -1950,8 +1950,8 @@ func TestModerationUnsupportedProvider(t *testing.T) {
 	})
 	require.Error(t, err)
 
-	var unsup *errors.UnsupportedError
-	require.True(t, stderrors.As(err, &unsup), "expected *UnsupportedError, got %T", err)
+	var unsup *errors.UnsupportedOperationError
+	require.True(t, stderrors.As(err, &unsup), "expected *UnsupportedOperationError, got %T", err)
 	require.Equal(t, "anthropic", unsup.Provider)
 	require.Equal(t, "moderation", unsup.Operation)
 	require.True(t, stderrors.Is(err, errors.ErrUnsupported))
@@ -1981,8 +1981,8 @@ func TestModerationUnsupportedMultimodal(t *testing.T) {
 	})
 	require.Error(t, err)
 
-	var unsup *errors.UnsupportedError
-	require.True(t, stderrors.As(err, &unsup), "expected *UnsupportedError, got %T", err)
+	var unsup *errors.UnsupportedOperationError
+	require.True(t, stderrors.As(err, &unsup), "expected *UnsupportedOperationError, got %T", err)
 	require.Equal(t, "mistral", unsup.Provider)
 	require.Equal(t, "multimodal_moderation", unsup.Operation)
 	require.True(t, stderrors.Is(err, errors.ErrUnsupported))

--- a/providers/types.go
+++ b/providers/types.go
@@ -44,7 +44,7 @@ type EmbeddingProvider interface {
 }
 
 // ModerationProvider is an optional interface for providers that support
-// content moderation. Use errors.As with *errors.UnsupportedError to detect
+// content moderation. Use errors.As with *errors.UnsupportedOperationError to detect
 // providers that do not support moderation.
 type ModerationProvider interface {
 	Provider

--- a/providers/types.go
+++ b/providers/types.go
@@ -43,6 +43,14 @@ type EmbeddingProvider interface {
 	Embedding(ctx context.Context, params EmbeddingParams) (*EmbeddingResponse, error)
 }
 
+// ModerationProvider is an optional interface for providers that support
+// content moderation. Use errors.As with *errors.UnsupportedError to detect
+// providers that do not support moderation.
+type ModerationProvider interface {
+	Provider
+	Moderation(ctx context.Context, params ModerationParams) (*ModerationResponse, error)
+}
+
 // ErrorConverter converts provider-specific SDK errors to unified error types.
 // This interface ensures all providers implement consistent error handling.
 type ErrorConverter interface {
@@ -91,6 +99,7 @@ type Capabilities struct {
 	CompletionTools     bool
 	Embedding           bool
 	ListModels          bool
+	Moderation          bool
 	Rerank              bool
 }
 
@@ -193,6 +202,33 @@ type EmbeddingResponse struct {
 type EmbeddingUsage struct {
 	PromptTokens int `json:"prompt_tokens"`
 	TotalTokens  int `json:"total_tokens"`
+}
+
+// ModerationParams is the request payload for POST /v1/moderations.
+// Input accepts string | []string | []ContentPart.
+type ModerationParams struct {
+	// IncludeRaw is sent as a ?include_raw=true query param; it is
+	// intentionally excluded from the JSON body.
+	IncludeRaw bool   `json:"-"`
+	Input      any    `json:"input"`
+	Model      string `json:"model"`
+	User       string `json:"user,omitempty"`
+}
+
+// ModerationResult is one result entry in a moderation response.
+type ModerationResult struct {
+	CategoryAppliedInputTypes map[string][]string `json:"category_applied_input_types,omitempty"`
+	CategoryScores            map[string]float64  `json:"category_scores,omitempty"`
+	Categories                map[string]bool     `json:"categories,omitempty"`
+	Flagged                   bool                `json:"flagged"`
+	ProviderRaw               json.RawMessage     `json:"provider_raw,omitempty"`
+}
+
+// ModerationResponse is the OpenAI-compatible moderation response.
+type ModerationResponse struct {
+	ID      string             `json:"id"`
+	Model   string             `json:"model"`
+	Results []ModerationResult `json:"results"`
 }
 
 // RerankMeta contains provider-specific billing metadata.


### PR DESCRIPTION
## Summary

Adds content moderation support to the Go SDK's gateway provider, exposing the gateway's `POST /v1/moderations` endpoint through a new `ModerationProvider` interface. Introduces `*errors.UnsupportedError` so callers can cleanly detect backends (e.g. Anthropic) that do not offer moderation.

## Changes

- Add `ModerationParams`, `ModerationResult`, `ModerationResponse`, `ContentPart`, `ImageURL` and the optional `ModerationProvider` interface in `providers/types.go`; add `Moderation bool` to `providers.Capabilities`.
- Add `UnsupportedError`, `ErrUnsupported` sentinel, `CodeUnsupported` constant, and `NewUnsupportedError` constructor in `errors/errors.go` to distinguish "provider does not support this operation" from the existing "provider not registered" case.
- Re-export the new types, interface, and sentinel from the root `anyllm` package to match the existing alias pattern.
- Implement `Moderation` on `*gateway.Provider` by calling `POST /v1/moderations` directly with the captured `*http.Client`, so `IncludeRaw` can be forwarded as `?include_raw=true` and the gateway's locked `"does not support moderation"` / `"multimodal moderation"` 400 phrasing can be mapped to `*UnsupportedError`. Capture `baseURL`, `httpClient` and the platform token on `Provider` at construction so direct HTTP calls share the same auth as the embedded openai-go SDK. Advertise `Moderation: true` in `capabilities()` and add the `providers.ModerationProvider` interface assertion.
- Add `httptest`-based tests covering the happy path, the `include_raw` query parameter, both unsupported phrasings (moderation / multimodal) mapping to `*UnsupportedError`, status-code mapping for 401/402/429/502/504, platform and non-platform auth on the direct HTTP call, and an env-gated integration test.
- Add a README snippet showing the gateway provider's `Moderation` method and how to branch on `UnsupportedError`.

## Testing

- `go test ./errors ./providers/gateway -race -count=1` (targeted to packages changed)
- Integration test `TestIntegrationModeration` is env-gated on `GATEWAY_API_BASE` / `GATEWAY_PLATFORM_TOKEN` and skips when unset.
- Full suite runs in CI.

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass locally (`make test`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)