### PR TITLE
Add RerankProvider interface and gateway implementation

### DIFF
--- a/anyllm.go
+++ b/anyllm.go
@@ -68,6 +68,7 @@ type (
 	EmbeddingProvider  = providers.EmbeddingProvider
 	ModelLister        = providers.ModelLister
 	Provider           = providers.Provider
+	RerankProvider     = providers.RerankProvider
 )
 
 // Batch types.
@@ -118,6 +119,15 @@ type (
 	JSONSchema     = providers.JSONSchema
 	ResponseFormat = providers.ResponseFormat
 	StreamOptions  = providers.StreamOptions
+)
+
+// Rerank types.
+type (
+	RerankMeta     = providers.RerankMeta
+	RerankParams   = providers.RerankParams
+	RerankResponse = providers.RerankResponse
+	RerankResult   = providers.RerankResult
+	RerankUsage    = providers.RerankUsage
 )
 
 // Usage and model types.

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -522,7 +522,7 @@ func (p *Provider) Rerank(ctx context.Context, params providers.RerankParams) (*
 	if err != nil {
 		return nil, p.ConvertError(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, p.handleRerankErrorResponse(resp)

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -130,6 +130,7 @@ var (
 	_ providers.ErrorConverter     = (*Provider)(nil)
 	_ providers.ModelLister        = (*Provider)(nil)
 	_ providers.Provider           = (*Provider)(nil)
+	_ providers.RerankProvider     = (*Provider)(nil)
 )
 
 // BatchNotCompleteError is returned when RetrieveBatchResults is called on
@@ -187,7 +188,13 @@ type Provider struct {
 	// OpenAI SDK.
 	apiKey string
 
-	// httpClient is used for batch API calls that bypass the OpenAI SDK.
+	// baseURL is the resolved gateway base URL without a trailing /v1 suffix.
+	// Used by Rerank to construct the /v1/rerank endpoint URL.
+	baseURL string
+
+	// httpClient is the HTTP client used for raw HTTP calls (e.g. rerank,
+	// batch API) that bypass the OpenAI SDK. In non-platform mode this is
+	// the header-injecting client so gateway auth is preserved.
 	httpClient *http.Client
 
 	// platformMode indicates whether the provider is operating in platform
@@ -290,6 +297,7 @@ func New(opts ...config.Option) (*Provider, error) {
 	// so NewCompatible sees the already-resolved, trimmed URL and does not
 	// re-run ResolveBaseURL.
 	compatOpts := slices.Clone(opts)
+	httpClient := cfg.HTTPClient()
 	if platformMode {
 		compatOpts = append(compatOpts, config.WithAPIKey(platformToken))
 	} else {
@@ -298,8 +306,8 @@ func New(opts ...config.Option) (*Provider, error) {
 		// Real auth, if any, is carried by the gateway header below.
 		compatOpts = append(compatOpts, config.WithAPIKey(placeholderAPIKey))
 		if gatewayKey != "" {
-			client := newHeaderClient(cfg.HTTPClient(), bearerPrefix+gatewayKey)
-			compatOpts = append(compatOpts, config.WithHTTPClient(client))
+			httpClient = newHeaderClient(cfg.HTTPClient(), bearerPrefix+gatewayKey)
+			compatOpts = append(compatOpts, config.WithHTTPClient(httpClient))
 		}
 	}
 	compatOpts = append(compatOpts, config.WithBaseURL(apiBase))
@@ -326,11 +334,17 @@ func New(opts ...config.Option) (*Provider, error) {
 		batchAPIKey = gatewayKey
 	}
 
+	// rawBaseURL strips any trailing /v1 suffix so that raw HTTP endpoints
+	// (e.g. /v1/rerank) can prepend the version prefix themselves.
+	rawBaseURL := strings.TrimSuffix(apiBase, "/v1")
+	rawBaseURL = strings.TrimSuffix(rawBaseURL, "/v1/")
+
 	return &Provider{
 		CompatibleProvider: base,
 		apiBase:            apiBase,
 		apiKey:             batchAPIKey,
-		httpClient:         cfg.HTTPClient(),
+		baseURL:            rawBaseURL,
+		httpClient:         httpClient,
 		platformMode:       platformMode,
 	}, nil
 }
@@ -346,10 +360,11 @@ func capabilities() providers.Capabilities {
 		CompletionImage:     true,
 		CompletionPDF:       true,
 		CompletionReasoning: true,
-		CompletionStreaming: true,
+		CompletionStreaming:  true,
 		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
+		Rerank:              true,
 	}
 }
 
@@ -473,6 +488,70 @@ func (p *Provider) ListModels(ctx context.Context) (*providers.ModelsResponse, e
 	}
 
 	return resp, nil
+}
+
+// Rerank reranks documents by relevance to a query via the gateway's /v1/rerank endpoint.
+// The response contains results sorted by relevance_score in descending order.
+func (p *Provider) Rerank(ctx context.Context, params providers.RerankParams) (*providers.RerankResponse, error) {
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling rerank request: %w", err)
+	}
+
+	reqURL := p.baseURL + "/v1/rerank"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating rerank request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, p.ConvertError(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, p.handleRerankErrorResponse(resp)
+	}
+
+	var result providers.RerankResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding rerank response: %w", err)
+	}
+	return &result, nil
+}
+
+// handleRerankErrorResponse parses an HTTP error response from the /v1/rerank
+// endpoint and returns a typed error.
+func (p *Provider) handleRerankErrorResponse(resp *http.Response) error {
+	body, _ := io.ReadAll(resp.Body)
+	msg := fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(body))
+
+	// Try to parse structured error JSON.
+	var errResp struct {
+		Detail string `json:"detail"`
+	}
+	if json.Unmarshal(body, &errResp) == nil && errResp.Detail != "" {
+		msg = errResp.Detail
+	}
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return errors.NewAuthenticationError(providerName, fmt.Errorf("%s", msg))
+	case http.StatusNotFound:
+		return errors.NewModelNotFoundError(providerName, fmt.Errorf("%s", msg))
+	case http.StatusPaymentRequired:
+		return errors.NewInsufficientFundsError(providerName, fmt.Errorf("%s", msg))
+	case http.StatusTooManyRequests:
+		return errors.NewRateLimitError(providerName, fmt.Errorf("%s", msg))
+	case http.StatusBadGateway:
+		return &UpstreamProviderError{BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider)}
+	case http.StatusGatewayTimeout:
+		return &TimeoutError{BaseError: errors.New(errCodeTimeout, providerName, fmt.Errorf("%s", msg), ErrTimeout)}
+	default:
+		return errors.NewProviderError(providerName, fmt.Errorf("%s", msg))
+	}
 }
 
 // RoundTrip implements http.RoundTripper by cloning the request and injecting

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -300,6 +300,9 @@ func New(opts ...config.Option) (*Provider, error) {
 	httpClient := cfg.HTTPClient()
 	if platformMode {
 		compatOpts = append(compatOpts, config.WithAPIKey(platformToken))
+		// Wrap the HTTP client so raw HTTP calls (e.g. Rerank) that bypass
+		// the OpenAI SDK also carry the platform Bearer token.
+		httpClient = newBearerClient(httpClient, platformToken)
 	} else {
 		// Non-platform mode: override any user-supplied API key with the
 		// placeholder so secrets can't leak via the Authorization header.
@@ -560,6 +563,24 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	clone := req.Clone(req.Context())
 	clone.Header.Set(t.header, t.value)
 	return t.base.RoundTrip(clone)
+}
+
+// newBearerClient wraps the given HTTP client's transport to inject a standard
+// Authorization: Bearer <token> header into every request. Used in platform
+// mode for raw HTTP calls (e.g. Rerank) that bypass the OpenAI SDK.
+func newBearerClient(base *http.Client, token string) *http.Client {
+	transport := base.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	return &http.Client{
+		Timeout: base.Timeout,
+		Transport: &headerTransport{
+			base:   transport,
+			header: "Authorization",
+			value:  bearerPrefix + token,
+		},
+	}
 }
 
 // newHeaderClient wraps the given HTTP client's transport to inject the

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -496,6 +496,16 @@ func (p *Provider) ListModels(ctx context.Context) (*providers.ModelsResponse, e
 // Rerank reranks documents by relevance to a query via the gateway's /v1/rerank endpoint.
 // The response contains results sorted by relevance_score in descending order.
 func (p *Provider) Rerank(ctx context.Context, params providers.RerankParams) (*providers.RerankResponse, error) {
+	if params.Model == "" {
+		return nil, errors.NewInvalidRequestError(providerName, fmt.Errorf("model is required"))
+	}
+	if params.Query == "" {
+		return nil, errors.NewInvalidRequestError(providerName, fmt.Errorf("query is required"))
+	}
+	if len(params.Documents) == 0 {
+		return nil, errors.NewInvalidRequestError(providerName, fmt.Errorf("at least one document is required"))
+	}
+
 	body, err := json.Marshal(params)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling rerank request: %w", err)

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -538,16 +538,12 @@ func (p *Provider) Rerank(ctx context.Context, params providers.RerankParams) (*
 // handleRerankErrorResponse parses an HTTP error response from the /v1/rerank
 // endpoint and returns a typed error.
 func (p *Provider) handleRerankErrorResponse(resp *http.Response) error {
+	// ReadAll error is ignored: if reading fails, we fall back to an empty
+	// body and still produce a typed error based on the status code.
 	body, _ := io.ReadAll(resp.Body)
-	msg := fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(body))
 
-	// Try to parse structured error JSON.
-	var errResp struct {
-		Detail string `json:"detail"`
-	}
-	if json.Unmarshal(body, &errResp) == nil && errResp.Detail != "" {
-		msg = errResp.Detail
-	}
+	parsed := parseRerankError(body)
+	msg := parsed.message()
 
 	switch resp.StatusCode {
 	case http.StatusUnauthorized, http.StatusForbidden:
@@ -565,6 +561,43 @@ func (p *Provider) handleRerankErrorResponse(resp *http.Response) error {
 	default:
 		return errors.NewProviderError(providerName, fmt.Errorf("%s", msg))
 	}
+}
+
+// rerankError holds the parsed fields from a gateway rerank error response.
+// parseErr is non-nil when the body was not valid JSON or did not contain
+// the expected "detail" field, so callers can detect drift in the gateway
+// error shape.
+type rerankError struct {
+	Detail   string
+	raw      string
+	parseErr error
+}
+
+// message returns the best human-readable description of the error body.
+func (e rerankError) message() string {
+	if e.Detail != "" {
+		return e.Detail
+	}
+	return e.raw
+}
+
+// parseRerankError parses a gateway rerank error response. Non-JSON bodies
+// are preserved via the raw field so callers can still surface the server's
+// text in the typed error. parseErr is set when the body cannot be decoded
+// as JSON or when the "detail" field is empty, making any future callers
+// that depend on structured fields aware of format drift.
+func parseRerankError(body []byte) rerankError {
+	raw := string(body)
+	var wrapper struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.Unmarshal(body, &wrapper); err != nil {
+		return rerankError{raw: raw, parseErr: fmt.Errorf("unmarshal error body: %w", err)}
+	}
+	if wrapper.Detail == "" {
+		return rerankError{raw: raw, parseErr: stderrors.New("error body missing \"detail\" field")}
+	}
+	return rerankError{Detail: wrapper.Detail, raw: raw}
 }
 
 // RoundTrip implements http.RoundTripper by cloning the request and injecting

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -1554,12 +1554,30 @@ func TestRerankError(t *testing.T) {
 			},
 		},
 		{
+			name:       "402 → InsufficientFundsError",
+			statusCode: http.StatusPaymentRequired,
+			body:       `{"detail": "Payment required"}`,
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				require.ErrorIs(t, err, errors.ErrInsufficientFunds)
+			},
+		},
+		{
 			name:       "500 → ProviderError",
 			statusCode: http.StatusInternalServerError,
 			body:       `{"detail": "Internal server error"}`,
 			checkErr: func(t *testing.T, err error) {
 				t.Helper()
 				require.ErrorIs(t, err, errors.ErrProvider)
+			},
+		},
+		{
+			name:       "502 → UpstreamProviderError",
+			statusCode: http.StatusBadGateway,
+			body:       `{"detail": "Bad gateway"}`,
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				require.ErrorIs(t, err, ErrUpstreamProvider)
 			},
 		},
 		{

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -1623,16 +1623,6 @@ func TestRerankError(t *testing.T) {
 	}
 }
 
-func TestCapabilitiesIncludesRerank(t *testing.T) {
-	t.Parallel()
-
-	provider, err := New(config.WithBaseURL("http://localhost:8000/v1"))
-	require.NoError(t, err)
-
-	caps := provider.Capabilities()
-	require.True(t, caps.Rerank)
-}
-
 func TestRerankSendsGatewayHeader(t *testing.T) {
 	t.Parallel()
 

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -1657,6 +1657,51 @@ func TestRerankSendsGatewayHeader(t *testing.T) {
 	require.Equal(t, bearerPrefix+"gw_rerank_key", capturedHeaders.Get(apiKeyHeaderName))
 }
 
+func TestRerankValidation(t *testing.T) {
+	t.Parallel()
+
+	provider, err := New(config.WithBaseURL("http://localhost:9999/v1"))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("empty model returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := provider.Rerank(ctx, providers.RerankParams{
+			Query:     "test",
+			Documents: []string{"doc1"},
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, errors.ErrInvalidRequest)
+		require.Contains(t, err.Error(), "model is required")
+	})
+
+	t.Run("empty query returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := provider.Rerank(ctx, providers.RerankParams{
+			Model:     "cohere:rerank-v3.5",
+			Documents: []string{"doc1"},
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, errors.ErrInvalidRequest)
+		require.Contains(t, err.Error(), "query is required")
+	})
+
+	t.Run("empty documents returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := provider.Rerank(ctx, providers.RerankParams{
+			Model: "cohere:rerank-v3.5",
+			Query: "test",
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, errors.ErrInvalidRequest)
+		require.Contains(t, err.Error(), "at least one document is required")
+	})
+}
+
 func TestRerankSendsPlatformBearerAuth(t *testing.T) {
 	t.Parallel()
 

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -1657,6 +1657,51 @@ func TestRerankSendsGatewayHeader(t *testing.T) {
 	require.Equal(t, bearerPrefix+"gw_rerank_key", capturedHeaders.Get(apiKeyHeaderName))
 }
 
+func TestRerankSendsPlatformBearerAuth(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu              sync.Mutex
+		capturedHeaders http.Header
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/rerank" {
+			mu.Lock()
+			capturedHeaders = r.Header.Clone()
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"r-1","results":[]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data": [], "object": "list"}`))
+	}))
+	defer server.Close()
+
+	provider, err := New(
+		config.WithBaseURL(server.URL),
+		config.WithAPIKey("tk_platform_rerank"),
+		WithPlatformMode(),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.Rerank(context.Background(), providers.RerankParams{
+		Model:     "cohere:rerank-v3.5",
+		Query:     "test",
+		Documents: []string{"doc1"},
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Platform mode: Bearer auth sent via standard Authorization header.
+	require.Equal(t, bearerPrefix+"tk_platform_rerank", capturedHeaders.Get("Authorization"))
+	// Platform mode should not send gateway key header.
+	require.Empty(t, capturedHeaders.Get(apiKeyHeaderName))
+}
+
 // --- Integration tests ---
 
 func TestIntegrationCompletion(t *testing.T) {

--- a/providers/gateway/gateway_test.go
+++ b/providers/gateway/gateway_test.go
@@ -215,6 +215,7 @@ func TestCapabilities(t *testing.T) {
 	require.True(t, caps.CompletionTools)
 	require.True(t, caps.Embedding)
 	require.True(t, caps.ListModels)
+	require.True(t, caps.Rerank)
 }
 
 func TestPlatformModeDetection(t *testing.T) {
@@ -1451,6 +1452,209 @@ func TestCompletionHTTPError404IsModelNotFound(t *testing.T) {
 
 	// 404 on a completion endpoint should not contain "upgrade your gateway".
 	require.NotContains(t, err.Error(), "upgrade your gateway")
+}
+
+// --- Rerank tests ---
+
+func TestRerank(t *testing.T) {
+	t.Parallel()
+
+	responseJSON := `{
+		"id": "rerank-test-123",
+		"results": [
+			{"index": 0, "relevance_score": 0.95},
+			{"index": 2, "relevance_score": 0.80},
+			{"index": 1, "relevance_score": 0.30}
+		],
+		"meta": {
+			"billed_units": {"search_units": 1.0},
+			"tokens": {"input_tokens": 100}
+		},
+		"usage": {"total_tokens": 100}
+	}`
+
+	var capturedBody []byte
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/rerank" && r.Method == http.MethodPost {
+			mu.Lock()
+			capturedBody, _ = io.ReadAll(r.Body)
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(responseJSON))
+			return
+		}
+		// Handle OpenAI SDK model list or other calls.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data": [], "object": "list"}`))
+	}))
+	defer server.Close()
+
+	provider, err := New(
+		config.WithBaseURL(server.URL),
+		WithGatewayKey("test-key"),
+	)
+	require.NoError(t, err)
+
+	rerankProvider, ok := any(provider).(providers.RerankProvider)
+	require.True(t, ok, "gateway should implement RerankProvider")
+
+	topN := 2
+	resp, err := rerankProvider.Rerank(context.Background(), providers.RerankParams{
+		Model:     "cohere:rerank-v3.5",
+		Query:     "test query",
+		Documents: []string{"doc1", "doc2", "doc3"},
+		TopN:      &topN,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "rerank-test-123", resp.ID)
+	require.Len(t, resp.Results, 3)
+	require.Equal(t, 0.95, resp.Results[0].RelevanceScore)
+	require.NotNil(t, resp.Usage)
+	require.Equal(t, 100, *resp.Usage.TotalTokens)
+
+	// Verify request body.
+	mu.Lock()
+	defer mu.Unlock()
+	var sent providers.RerankParams
+	require.NoError(t, json.Unmarshal(capturedBody, &sent))
+	require.Equal(t, "cohere:rerank-v3.5", sent.Model)
+	require.Equal(t, "test query", sent.Query)
+	require.Equal(t, []string{"doc1", "doc2", "doc3"}, sent.Documents)
+	require.Equal(t, 2, *sent.TopN)
+}
+
+func TestRerankError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		checkErr   func(t *testing.T, err error)
+	}{
+		{
+			name:       "401 → AuthenticationError",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"detail": "Invalid API key"}`,
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				require.ErrorIs(t, err, errors.ErrAuthentication)
+			},
+		},
+		{
+			name:       "429 → RateLimitError",
+			statusCode: http.StatusTooManyRequests,
+			body:       `{"detail": "Rate limit exceeded"}`,
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				require.ErrorIs(t, err, errors.ErrRateLimit)
+			},
+		},
+		{
+			name:       "500 → ProviderError",
+			statusCode: http.StatusInternalServerError,
+			body:       `{"detail": "Internal server error"}`,
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				require.ErrorIs(t, err, errors.ErrProvider)
+			},
+		},
+		{
+			name:       "504 → TimeoutError",
+			statusCode: http.StatusGatewayTimeout,
+			body:       `{"detail": "Gateway timeout"}`,
+			checkErr: func(t *testing.T, err error) {
+				t.Helper()
+				require.ErrorIs(t, err, ErrTimeout)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v1/rerank" {
+					w.WriteHeader(tc.statusCode)
+					_, _ = w.Write([]byte(tc.body))
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data": [], "object": "list"}`))
+			}))
+			defer server.Close()
+
+			provider, err := New(
+				config.WithBaseURL(server.URL),
+				WithGatewayKey("test-key"),
+			)
+			require.NoError(t, err)
+
+			_, err = provider.Rerank(context.Background(), providers.RerankParams{
+				Model:     "cohere:rerank-v3.5",
+				Query:     "test",
+				Documents: []string{"doc1"},
+			})
+			require.Error(t, err)
+			tc.checkErr(t, err)
+		})
+	}
+}
+
+func TestCapabilitiesIncludesRerank(t *testing.T) {
+	t.Parallel()
+
+	provider, err := New(config.WithBaseURL("http://localhost:8000/v1"))
+	require.NoError(t, err)
+
+	caps := provider.Capabilities()
+	require.True(t, caps.Rerank)
+}
+
+func TestRerankSendsGatewayHeader(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu              sync.Mutex
+		capturedHeaders http.Header
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/rerank" {
+			mu.Lock()
+			capturedHeaders = r.Header.Clone()
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"r-1","results":[]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data": [], "object": "list"}`))
+	}))
+	defer server.Close()
+
+	provider, err := New(
+		config.WithBaseURL(server.URL),
+		WithGatewayKey("gw_rerank_key"),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.Rerank(context.Background(), providers.RerankParams{
+		Model:     "cohere:rerank-v3.5",
+		Query:     "test",
+		Documents: []string{"doc1"},
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Non-platform mode: gateway key sent via custom header.
+	require.Equal(t, bearerPrefix+"gw_rerank_key", capturedHeaders.Get(apiKeyHeaderName))
 }
 
 // --- Integration tests ---

--- a/providers/types.go
+++ b/providers/types.go
@@ -57,6 +57,12 @@ type ModelLister interface {
 	ListModels(ctx context.Context) (*ModelsResponse, error)
 }
 
+// RerankProvider is an optional interface for providers that support document reranking.
+type RerankProvider interface {
+	Provider
+	Rerank(ctx context.Context, params RerankParams) (*RerankResponse, error)
+}
+
 // Provider is the core interface that all LLM providers must implement.
 type Provider interface {
 	// Name returns the provider's identifier (e.g., "openai", "anthropic").
@@ -81,10 +87,11 @@ type Capabilities struct {
 	CompletionImage     bool
 	CompletionPDF       bool
 	CompletionReasoning bool
-	CompletionStreaming bool
+	CompletionStreaming  bool
 	CompletionTools     bool
 	Embedding           bool
 	ListModels          bool
+	Rerank              bool
 }
 
 // ChatCompletion represents a chat completion response in OpenAI format.
@@ -186,6 +193,41 @@ type EmbeddingResponse struct {
 type EmbeddingUsage struct {
 	PromptTokens int `json:"prompt_tokens"`
 	TotalTokens  int `json:"total_tokens"`
+}
+
+// RerankMeta contains provider-specific billing metadata.
+type RerankMeta struct {
+	BilledUnits map[string]float64 `json:"billed_units,omitempty"`
+	Tokens      map[string]int     `json:"tokens,omitempty"`
+}
+
+// RerankParams represents parameters for a rerank request.
+type RerankParams struct {
+	Documents       []string `json:"documents"`
+	MaxTokensPerDoc *int     `json:"max_tokens_per_doc,omitempty"`
+	Model           string   `json:"model"`
+	Query           string   `json:"query"`
+	TopN            *int     `json:"top_n,omitempty"`
+	User            string   `json:"user,omitempty"`
+}
+
+// RerankResponse represents a rerank response.
+type RerankResponse struct {
+	ID      string         `json:"id"`
+	Meta    *RerankMeta    `json:"meta,omitempty"`
+	Results []RerankResult `json:"results"`
+	Usage   *RerankUsage   `json:"usage,omitempty"`
+}
+
+// RerankResult represents a single reranked document score.
+type RerankResult struct {
+	Index          int     `json:"index"`
+	RelevanceScore float64 `json:"relevance_score"`
+}
+
+// RerankUsage contains normalized token usage.
+type RerankUsage struct {
+	TotalTokens *int `json:"total_tokens,omitempty"`
 }
 
 // Function represents a function definition for tool calling.

--- a/providers/types_test.go
+++ b/providers/types_test.go
@@ -7,6 +7,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRerankTypesJSON(t *testing.T) {
+	t.Parallel()
+
+	topN := 3
+	params := RerankParams{
+		Model:     "cohere:rerank-v3.5",
+		Query:     "test query",
+		Documents: []string{"doc1", "doc2"},
+		TopN:      &topN,
+	}
+
+	data, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	var decoded RerankParams
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, params.Model, decoded.Model)
+	require.Equal(t, params.Query, decoded.Query)
+	require.Equal(t, params.Documents, decoded.Documents)
+	require.Equal(t, *params.TopN, *decoded.TopN)
+}
+
+func TestRerankResponseJSON(t *testing.T) {
+	t.Parallel()
+
+	totalTokens := 100
+	resp := RerankResponse{
+		ID: "rerank-123",
+		Results: []RerankResult{
+			{Index: 0, RelevanceScore: 0.95},
+			{Index: 2, RelevanceScore: 0.80},
+		},
+		Meta: &RerankMeta{
+			BilledUnits: map[string]float64{"search_units": 1.0},
+			Tokens:      map[string]int{"input_tokens": 100},
+		},
+		Usage: &RerankUsage{TotalTokens: &totalTokens},
+	}
+
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	var decoded RerankResponse
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, resp.ID, decoded.ID)
+	require.Len(t, decoded.Results, 2)
+	require.Equal(t, 0.95, decoded.Results[0].RelevanceScore)
+	require.NotNil(t, decoded.Usage)
+	require.Equal(t, 100, *decoded.Usage.TotalTokens)
+}
+
 func TestToolCallExtraExcludedFromJSON(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Add document reranking support via a new `RerankProvider` optional interface and implement it on the gateway provider. The gateway sends raw HTTP POST requests to `/v1/rerank`, bypassing the OpenAI SDK which has no rerank resource.

## Changes

- Add `RerankProvider` optional interface to `providers/types.go` following the established pattern (`EmbeddingProvider`, `ModelLister`)
- Add rerank request/response types: `RerankParams`, `RerankResponse`, `RerankResult`, `RerankMeta`, `RerankUsage`
- Add `Rerank` field to `Capabilities` struct
- Implement `Rerank()` on gateway provider using direct HTTP calls with `handleRerankErrorResponse()` for error mapping
- Add `httpClient` and `baseURL` fields to gateway `Provider` for raw HTTP calls that bypass the OpenAI SDK
- Add `newBearerClient()` to support platform-mode auth on raw HTTP endpoints
- Add re-exports for all new types in `anyllm.go`
- Add input validation for model, query, and documents parameters

## Testing

- Unit tests for rerank type JSON serialization/deserialization (`providers/types_test.go`)
- Gateway `TestRerank`: end-to-end happy path with mock server, verifies request body and response parsing
- Gateway `TestRerankError`: table-driven tests covering 401, 402, 429, 500, 502, 504 status code mappings to typed errors
- Gateway `TestRerankValidation`: validates empty model, query, and documents are rejected
- Gateway `TestRerankSendsGatewayHeader`: verifies non-platform mode sends `AnyLLM-Key` header
- Gateway `TestRerankSendsPlatformBearerAuth`: verifies platform mode sends `Authorization: Bearer` header
- Gateway `TestCapabilities` updated to assert `Rerank: true`

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass locally (`make test`)
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in summary)