### PR TITLE
feat(anthropic): add json_schema structured output support

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -213,15 +213,7 @@ func (p *Provider) convertParams(params providers.CompletionParams) (anthropic.M
 		req.ToolChoice = convertToolChoice(params.ToolChoice, params.ParallelToolCalls)
 	}
 
-	if params.ResponseFormat != nil &&
-		params.ResponseFormat.Type == responseFormatJSONSchema &&
-		params.ResponseFormat.JSONSchema != nil {
-		req.OutputConfig = anthropic.OutputConfigParam{
-			Format: anthropic.JSONOutputFormatParam{
-				Schema: params.ResponseFormat.JSONSchema.Schema,
-			},
-		}
-	}
+	applyResponseFormat(&req, params.ResponseFormat)
 
 	applyThinking(&req, params.ReasoningEffort, maxTokens)
 
@@ -403,6 +395,26 @@ func applyThinking(req *anthropic.MessageNewParams, effort providers.ReasoningEf
 	minTokens := budget * 2
 	if maxTokens < minTokens {
 		req.MaxTokens = minTokens
+	}
+}
+
+// applyResponseFormat configures structured output on the request if applicable.
+func applyResponseFormat(req *anthropic.MessageNewParams, format *providers.ResponseFormat) {
+	if format == nil || format.JSONSchema == nil {
+		return
+	}
+	switch format.Type {
+	case responseFormatJSONSchema:
+		// JSONOutputFormatParam only carries Schema and Type; Name, Description, and Strict
+		// from providers.JSONSchema are not supported by the Anthropic API.
+		req.OutputConfig = anthropic.OutputConfigParam{
+			Format: anthropic.JSONOutputFormatParam{
+				Schema: format.JSONSchema.Schema,
+			},
+		}
+	case responseFormatJSONObject:
+		// Anthropic requires a schema for structured output; json_object without a schema
+		// is not supported. No-op to preserve forward compatibility.
 	}
 }
 

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -68,6 +68,12 @@ const (
 	schemaFieldRequired   = "required"
 )
 
+// Response format types.
+const (
+	responseFormatJSONObject = "json_object"
+	responseFormatJSONSchema = "json_schema"
+)
+
 // Ensure Provider implements the required interfaces.
 var (
 	_ providers.CapabilityProvider = (*Provider)(nil)
@@ -205,6 +211,16 @@ func (p *Provider) convertParams(params providers.CompletionParams) (anthropic.M
 
 	if params.ToolChoice != nil {
 		req.ToolChoice = convertToolChoice(params.ToolChoice, params.ParallelToolCalls)
+	}
+
+	if params.ResponseFormat != nil &&
+		params.ResponseFormat.Type == responseFormatJSONSchema &&
+		params.ResponseFormat.JSONSchema != nil {
+		req.OutputConfig = anthropic.OutputConfigParam{
+			Format: anthropic.JSONOutputFormatParam{
+				Schema: params.ResponseFormat.JSONSchema.Schema,
+			},
+		}
 	}
 
 	applyThinking(&req, params.ReasoningEffort, maxTokens)

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -1406,6 +1406,47 @@ func TestConvertParams_ResponseFormat(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, schema, result.OutputConfig.Format.Schema)
 	})
+
+	t.Run("unsupported JSONSchema fields are not forwarded", func(t *testing.T) {
+		t.Parallel()
+
+		strict := true
+		params := baseParams()
+		params.ResponseFormat = &providers.ResponseFormat{
+			Type: responseFormatJSONSchema,
+			JSONSchema: &providers.JSONSchema{
+				Name:        "answer_schema",
+				Description: "A schema for answers",
+				Strict:      &strict,
+				Schema:      schema,
+			},
+		}
+
+		result, err := p.convertParams(params)
+		require.NoError(t, err)
+		require.Equal(t, schema, result.OutputConfig.Format.Schema)
+		// JSONOutputFormatParam only has Schema and Type fields;
+		// Name, Description, and Strict have no destination.
+		require.Equal(t, anthropic.JSONOutputFormatParam{Schema: schema}, result.OutputConfig.Format)
+	})
+
+	t.Run("streaming path also receives OutputConfig", func(t *testing.T) {
+		t.Parallel()
+
+		params := baseParams()
+		params.Stream = true
+		params.ResponseFormat = &providers.ResponseFormat{
+			Type: responseFormatJSONSchema,
+			JSONSchema: &providers.JSONSchema{
+				Name:   "answer_schema",
+				Schema: schema,
+			},
+		}
+
+		result, err := p.convertParams(params)
+		require.NoError(t, err)
+		require.Equal(t, schema, result.OutputConfig.Format.Schema)
+	})
 }
 
 // newTestAPIError creates an Anthropic API error for testing.

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/any-llm-go/config"
@@ -1213,6 +1212,52 @@ func TestIntegrationAuthenticationError(t *testing.T) {
 	require.ErrorAs(t, err, &authErr)
 }
 
+func TestIntegrationCompletionWithStructuredOutput(t *testing.T) {
+	t.Parallel()
+
+	if testutil.SkipIfNoAPIKey("anthropic") {
+		t.Skip("ANTHROPIC_API_KEY not set")
+	}
+
+	provider, err := New()
+	require.NoError(t, err)
+
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"answer": map[string]any{"type": "string"},
+		},
+		"required": []any{"answer"},
+	}
+
+	ctx := context.Background()
+	result, err := provider.Completion(ctx, providers.CompletionParams{
+		Model: testutil.TestModel("anthropic"),
+		Messages: []providers.Message{
+			{Role: providers.RoleUser, Content: "What is 2+2? Respond using the provided schema."},
+		},
+		ResponseFormat: &providers.ResponseFormat{
+			Type: responseFormatJSONSchema,
+			JSONSchema: &providers.JSONSchema{
+				Name:   "answer_schema",
+				Schema: schema,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.ID)
+	require.Len(t, result.Choices, 1)
+	require.NotEmpty(t, result.Choices[0].Message.Content)
+
+	contentStr, ok := result.Choices[0].Message.Content.(string)
+	require.True(t, ok, "expected string content")
+
+	var response map[string]any
+	err = json.Unmarshal([]byte(contentStr), &response)
+	require.NoError(t, err, "response should be valid JSON")
+	require.Contains(t, response, "answer", "response should contain 'answer' key")
+}
+
 func TestConvertError(t *testing.T) {
 	t.Parallel()
 
@@ -1320,7 +1365,7 @@ func TestConvertParams_ResponseFormat(t *testing.T) {
 
 		result, err := p.convertParams(params)
 		require.NoError(t, err)
-		assert.Equal(t, anthropic.OutputConfigParam{}, result.OutputConfig)
+		require.Equal(t, anthropic.OutputConfigParam{}, result.OutputConfig)
 	})
 
 	t.Run("json_object type is no-op", func(t *testing.T) {
@@ -1331,7 +1376,7 @@ func TestConvertParams_ResponseFormat(t *testing.T) {
 
 		result, err := p.convertParams(params)
 		require.NoError(t, err)
-		assert.Equal(t, anthropic.OutputConfigParam{}, result.OutputConfig)
+		require.Equal(t, anthropic.OutputConfigParam{}, result.OutputConfig)
 	})
 
 	t.Run("json_schema with nil JSONSchema is no-op", func(t *testing.T) {
@@ -1342,7 +1387,7 @@ func TestConvertParams_ResponseFormat(t *testing.T) {
 
 		result, err := p.convertParams(params)
 		require.NoError(t, err)
-		assert.Equal(t, anthropic.OutputConfigParam{}, result.OutputConfig)
+		require.Equal(t, anthropic.OutputConfigParam{}, result.OutputConfig)
 	})
 
 	t.Run("json_schema with valid schema sets OutputConfig", func(t *testing.T) {
@@ -1359,7 +1404,7 @@ func TestConvertParams_ResponseFormat(t *testing.T) {
 
 		result, err := p.convertParams(params)
 		require.NoError(t, err)
-		assert.Equal(t, schema, result.OutputConfig.Format.Schema)
+		require.Equal(t, schema, result.OutputConfig.Format.Schema)
 	})
 }
 

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/any-llm-go/config"
@@ -1286,6 +1287,80 @@ func TestConvertError(t *testing.T) {
 			require.Contains(t, result.Error(), "["+providerName+"]")
 		})
 	}
+}
+
+func TestConvertParams_ResponseFormat(t *testing.T) {
+	t.Parallel()
+
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"answer": map[string]any{"type": "string"},
+		},
+		"required": []any{"answer"},
+	}
+
+	p, err := New(config.WithAPIKey("test-key"))
+	require.NoError(t, err)
+
+	baseParams := func() providers.CompletionParams {
+		return providers.CompletionParams{
+			Model: "claude-3-5-haiku-20241022",
+			Messages: []providers.Message{
+				{Role: providers.RoleUser, Content: []providers.ContentPart{{Text: "hello"}}},
+			},
+		}
+	}
+
+	t.Run("nil ResponseFormat leaves OutputConfig unset", func(t *testing.T) {
+		t.Parallel()
+
+		params := baseParams()
+		params.ResponseFormat = nil
+
+		result, err := p.convertParams(params)
+		require.NoError(t, err)
+		assert.Equal(t, anthropic.OutputConfigParam{}, result.OutputConfig)
+	})
+
+	t.Run("json_object type is no-op", func(t *testing.T) {
+		t.Parallel()
+
+		params := baseParams()
+		params.ResponseFormat = &providers.ResponseFormat{Type: responseFormatJSONObject}
+
+		result, err := p.convertParams(params)
+		require.NoError(t, err)
+		assert.Equal(t, anthropic.OutputConfigParam{}, result.OutputConfig)
+	})
+
+	t.Run("json_schema with nil JSONSchema is no-op", func(t *testing.T) {
+		t.Parallel()
+
+		params := baseParams()
+		params.ResponseFormat = &providers.ResponseFormat{Type: responseFormatJSONSchema, JSONSchema: nil}
+
+		result, err := p.convertParams(params)
+		require.NoError(t, err)
+		assert.Equal(t, anthropic.OutputConfigParam{}, result.OutputConfig)
+	})
+
+	t.Run("json_schema with valid schema sets OutputConfig", func(t *testing.T) {
+		t.Parallel()
+
+		params := baseParams()
+		params.ResponseFormat = &providers.ResponseFormat{
+			Type: responseFormatJSONSchema,
+			JSONSchema: &providers.JSONSchema{
+				Name:   "answer_schema",
+				Schema: schema,
+			},
+		}
+
+		result, err := p.convertParams(params)
+		require.NoError(t, err)
+		assert.Equal(t, schema, result.OutputConfig.Format.Schema)
+	})
 }
 
 // newTestAPIError creates an Anthropic API error for testing.


### PR DESCRIPTION
## Summary

- Adds `json_schema` structured output support to the Anthropic provider by mapping `CompletionParams.ResponseFormat` to `anthropic.MessageNewParams.OutputConfig.Format` via the stable (non-beta) Anthropic SDK API
- Extracts an `applyResponseFormat` helper following the same pattern as `applyThinking` and sibling providers (OpenAI, Gemini, Ollama, Deepseek)
- Adds `responseFormatJSONObject` / `responseFormatJSONSchema` constants matching the naming convention in other providers

## Behavior

| Input | Result |
|---|---|
| `ResponseFormat = nil` | No change (existing behavior) |
| `Type = "json_object"` | No-op — Anthropic requires a schema; documented in code |
| `Type = "json_schema"`, `JSONSchema = nil` | No-op |
| `Type = "json_schema"`, valid schema | `OutputConfig.Format.Schema` set |

`Name`, `Description`, and `Strict` fields from `JSONSchema` are not forwarded — `anthropic.JSONOutputFormatParam` only accepts `Schema` and `Type`.

The feature works for both `Completion` and `CompletionStream` via the shared `convertParams`.

## Test Plan

- [x] 4 unit tests covering all input cases (`TestConvertParams_ResponseFormat`)
- [x] Integration test skipped without `ANTHROPIC_API_KEY` (`TestIntegrationCompletionWithStructuredOutput`)
- [x] Full test suite (`go test ./...`) passes with no regressions