### PR TITLE
feat(anthropic): add opt-in prompt caching via cache_control

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -90,13 +90,15 @@ type Provider struct {
 // streamState tracks accumulated state during streaming.
 // Note: Only accessed from a single goroutine, so no synchronization needed.
 type streamState struct {
-	messageID      string
-	model          string
-	content        strings.Builder
-	reasoning      strings.Builder
-	toolCalls      []providers.ToolCall
-	currentToolIdx int
-	inputUsage     int64
+	messageID       string
+	model           string
+	content         strings.Builder
+	reasoning       strings.Builder
+	toolCalls       []providers.ToolCall
+	currentToolIdx  int
+	inputUsage      int64
+	cacheReadUsage  int64
+	cacheWriteUsage int64
 }
 
 // New creates a new Anthropic provider.
@@ -216,6 +218,10 @@ func (p *Provider) convertParams(params providers.CompletionParams) (anthropic.M
 	applyResponseFormat(&req, params.ResponseFormat)
 
 	applyThinking(&req, params.ReasoningEffort, maxTokens)
+
+	if params.CachePrompt {
+		applyPromptCaching(&req)
+	}
 
 	return req, nil
 }
@@ -349,6 +355,8 @@ func (s *streamState) handleMessageDelta(event anthropic.MessageDeltaEvent) prov
 		PromptTokens:     int(s.inputUsage),
 		CompletionTokens: int(event.Usage.OutputTokens),
 		TotalTokens:      int(s.inputUsage + event.Usage.OutputTokens),
+		CacheReadTokens:  int(s.cacheReadUsage),
+		CacheWriteTokens: int(s.cacheWriteUsage),
 	}
 	return chunk
 }
@@ -358,6 +366,8 @@ func (s *streamState) handleMessageStart(event anthropic.MessageStartEvent) prov
 	s.messageID = event.Message.ID
 	s.model = string(event.Message.Model)
 	s.inputUsage = event.Message.Usage.InputTokens
+	s.cacheReadUsage = event.Message.Usage.CacheReadInputTokens
+	s.cacheWriteUsage = event.Message.Usage.CacheCreationInputTokens
 
 	return s.chunk(providers.ChunkDelta{Role: providers.RoleAssistant})
 }
@@ -376,6 +386,22 @@ func (s *streamState) handleTextDelta(text string) *providers.ChatCompletionChun
 	s.content.WriteString(text)
 	chunk := s.chunk(providers.ChunkDelta{Content: text})
 	return &chunk
+}
+
+// applyPromptCaching marks the stable prompt prefix with ephemeral
+// cache_control breakpoints so Anthropic reuses it across requests. The
+// breakpoint on the last tool caches the tools block; the breakpoint on the
+// last system block caches the tools+system prefix. Both are no-ops below the
+// model's minimum cacheable length, so this is always safe to set.
+func applyPromptCaching(req *anthropic.MessageNewParams) {
+	if n := len(req.Tools); n > 0 {
+		if t := req.Tools[n-1].OfTool; t != nil {
+			t.CacheControl = anthropic.NewCacheControlEphemeralParam()
+		}
+	}
+	if n := len(req.System); n > 0 {
+		req.System[n-1].CacheControl = anthropic.NewCacheControlEphemeralParam()
+	}
 }
 
 // applyThinking configures thinking/reasoning on the request if applicable.
@@ -548,6 +574,8 @@ func convertResponse(resp *anthropic.Message) *providers.ChatCompletion {
 			PromptTokens:     int(resp.Usage.InputTokens),
 			CompletionTokens: int(resp.Usage.OutputTokens),
 			TotalTokens:      int(resp.Usage.InputTokens + resp.Usage.OutputTokens),
+			CacheReadTokens:  int(resp.Usage.CacheReadInputTokens),
+			CacheWriteTokens: int(resp.Usage.CacheCreationInputTokens),
 		},
 	}
 }

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -1462,3 +1462,99 @@ func newTestAPIError(t *testing.T, statusCode int) *anthropic.Error {
 		Response:   &http.Response{StatusCode: statusCode},
 	}
 }
+
+func TestConvertParams_CachePrompt(t *testing.T) {
+	t.Parallel()
+
+	p, err := New(config.WithAPIKey("test-key"))
+	require.NoError(t, err)
+
+	baseParams := func() providers.CompletionParams {
+		return providers.CompletionParams{
+			Model: "claude-3-5-haiku-20241022",
+			Messages: []providers.Message{
+				{Role: providers.RoleSystem, Content: "you are helpful"},
+				{Role: providers.RoleUser, Content: []providers.ContentPart{{Text: "hi"}}},
+			},
+			Tools: []providers.Tool{
+				{Function: providers.Function{Name: "get_time", Description: "get the time"}},
+			},
+		}
+	}
+
+	marshal := func(t *testing.T, req anthropic.MessageNewParams) string {
+		t.Helper()
+		b, err := json.Marshal(req)
+		require.NoError(t, err)
+		return string(b)
+	}
+
+	t.Run("CachePrompt false adds no cache_control", func(t *testing.T) {
+		t.Parallel()
+
+		params := baseParams()
+		params.CachePrompt = false
+
+		req, err := p.convertParams(params)
+		require.NoError(t, err)
+		require.NotContains(t, marshal(t, req), "cache_control")
+	})
+
+	t.Run("CachePrompt true marks last system block and last tool", func(t *testing.T) {
+		t.Parallel()
+
+		params := baseParams()
+		params.CachePrompt = true
+
+		req, err := p.convertParams(params)
+		require.NoError(t, err)
+
+		require.Len(t, req.System, 1)
+		require.Equal(t, "ephemeral", string(req.System[0].CacheControl.Type))
+
+		require.Len(t, req.Tools, 1)
+		require.NotNil(t, req.Tools[0].OfTool)
+		require.Equal(t, "ephemeral", string(req.Tools[0].OfTool.CacheControl.Type))
+	})
+
+	t.Run("CachePrompt true with tools but no system marks the tool only", func(t *testing.T) {
+		t.Parallel()
+
+		params := baseParams()
+		params.CachePrompt = true
+		params.Messages = []providers.Message{
+			{Role: providers.RoleUser, Content: []providers.ContentPart{{Text: "hi"}}},
+		}
+
+		req, err := p.convertParams(params)
+		require.NoError(t, err)
+		require.Empty(t, req.System)
+		require.Len(t, req.Tools, 1)
+		require.Equal(t, "ephemeral", string(req.Tools[0].OfTool.CacheControl.Type))
+	})
+}
+
+func TestStreamStateCacheUsage(t *testing.T) {
+	t.Parallel()
+
+	s := newStreamState()
+	s.handleMessageStart(anthropic.MessageStartEvent{
+		Message: anthropic.Message{
+			Usage: anthropic.Usage{
+				InputTokens:              10,
+				CacheReadInputTokens:     1000,
+				CacheCreationInputTokens: 200,
+			},
+		},
+	})
+
+	chunk := s.handleMessageDelta(anthropic.MessageDeltaEvent{
+		Usage: anthropic.MessageDeltaUsage{OutputTokens: 5},
+	})
+
+	require.NotNil(t, chunk.Usage)
+	require.Equal(t, 10, chunk.Usage.PromptTokens)
+	require.Equal(t, 5, chunk.Usage.CompletionTokens)
+	require.Equal(t, 1000, chunk.Usage.CacheReadTokens)
+	require.Equal(t, 200, chunk.Usage.CacheWriteTokens)
+}

--- a/providers/types.go
+++ b/providers/types.go
@@ -95,7 +95,7 @@ type Capabilities struct {
 	CompletionImage     bool
 	CompletionPDF       bool
 	CompletionReasoning bool
-	CompletionStreaming  bool
+	CompletionStreaming bool
 	CompletionTools     bool
 	Embedding           bool
 	ListModels          bool
@@ -164,7 +164,12 @@ type CompletionParams struct {
 	ReasoningEffort   ReasoningEffort `json:"reasoning_effort,omitempty"`
 	Seed              *int            `json:"seed,omitempty"`
 	User              string          `json:"user,omitempty"`
-	Extra             map[string]any  `json:"-"`
+	// CachePrompt hints that the stable prompt prefix (tools + system) should
+	// be cached for reuse across requests. Honored by providers that support
+	// manual prompt caching (e.g. Anthropic via cache_control); ignored by
+	// providers that cache automatically or not at all.
+	CachePrompt bool           `json:"cache_prompt,omitempty"`
+	Extra       map[string]any `json:"-"`
 }
 
 // ContentPart represents a part of a multi-modal message.
@@ -367,6 +372,13 @@ type Usage struct {
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
 	ReasoningTokens  int `json:"reasoning_tokens,omitempty"`
+	// CacheReadTokens is the number of prompt tokens served from a provider
+	// prompt cache (billed at a reduced rate). Populated by providers that
+	// report cache usage (e.g. Anthropic).
+	CacheReadTokens int `json:"cache_read_tokens,omitempty"`
+	// CacheWriteTokens is the number of prompt tokens written to a provider
+	// prompt cache on this request (may be billed at a premium).
+	CacheWriteTokens int `json:"cache_write_tokens,omitempty"`
 }
 
 // ContentParts extracts content parts from a message.


### PR DESCRIPTION
## Summary
Adds opt-in Anthropic prompt caching. The Anthropic SDK already exposes `CacheControl` on `TextBlockParam`/`ToolParam` and reports cache tokens in `Usage`, but the provider never set/surfaced them. This wires it up behind a new `CompletionParams.CachePrompt` hint (mirroring the existing `ReasoningEffort` hint pattern).

For agentic loops that re-send a large, stable `system`+`tools` prefix on every iteration, this is a big cost win — cached reads bill at ~10% of the input rate.

## Changes
- `providers/types.go`: add `CompletionParams.CachePrompt bool` (hint; honored by providers that support manual prompt caching, ignored otherwise) and `Usage.CacheReadTokens` / `Usage.CacheWriteTokens`.
- `providers/anthropic/anthropic.go`: when `CachePrompt` is set, mark the last tool (caches the tools block) and the last system block (caches the tools+system prefix) with `anthropic.NewCacheControlEphemeralParam()`. Surface `cache_read_input_tokens` / `cache_creation_input_tokens` on `Usage` in both the non-streaming and streaming paths.
- Tests: `TestConvertParams_CachePrompt` (breakpoints set only when enabled; system+tools / tools-only cases) and `TestStreamStateCacheUsage` (cache token mapping).

Both breakpoints are no-ops below the model's minimum cacheable length, so enabling the hint is always safe.

## Testing
`make test-unit` passes; `go vet ./...` clean; `gofmt` clean on changed files. (No API key needed — the new tests are unit-level.)

## Checklist
- [x] Tests pass locally
- [x] `go vet` / `gofmt` clean
- [ ] Documentation updated (happy to add a docs/providers.md note + a `Capabilities.PromptCaching` flag in a follow-up — deferred here to keep the change focused, given the open Capabilities-semantics discussion in #84)