### PR TITLE
feat: add Azure OpenAI, Responses API, and Gemini thinking parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ if errors.As(err, &rateLimitErr) {
 |  Provider  | Completion  |  Streaming  |  Tools |  Reasoning  |  Embeddings  |
 |:----------:|:-----------:|:-----------:|:------:|:-----------:|:------------:|
 | Anthropic  |      ✅      |      ✅      |      ✅ |      ✅      |      ❌       |
+| Azure OpenAI |    ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
 |  DeepSeek  |      ✅      |      ✅      |      ✅ |      ✅      |      ❌       |
 |   Gemini   |      ✅      |      ✅      |      ✅ |      ✅      |      ✅       |
 |    Groq    |      ✅      |      ✅      |      ✅ |      ❌      |      ❌       |

--- a/anyllm.go
+++ b/anyllm.go
@@ -53,11 +53,14 @@ const (
 
 // ReasoningEffort levels.
 const (
-	ReasoningEffortAuto   = providers.ReasoningEffortAuto
-	ReasoningEffortHigh   = providers.ReasoningEffortHigh
-	ReasoningEffortLow    = providers.ReasoningEffortLow
-	ReasoningEffortMedium = providers.ReasoningEffortMedium
-	ReasoningEffortNone   = providers.ReasoningEffortNone
+	ReasoningEffortAuto    = providers.ReasoningEffortAuto
+	ReasoningEffortHigh    = providers.ReasoningEffortHigh
+	ReasoningEffortLow     = providers.ReasoningEffortLow
+	ReasoningEffortMax     = providers.ReasoningEffortMax
+	ReasoningEffortMedium  = providers.ReasoningEffortMedium
+	ReasoningEffortMinimal = providers.ReasoningEffortMinimal
+	ReasoningEffortNone    = providers.ReasoningEffortNone
+	ReasoningEffortXHigh   = providers.ReasoningEffortXHigh
 )
 
 // Provider types.
@@ -70,6 +73,7 @@ type (
 	ModerationProvider = providers.ModerationProvider
 	Provider           = providers.Provider
 	RerankProvider     = providers.RerankProvider
+	ResponsesProvider  = providers.ResponsesProvider
 )
 
 // Batch types.
@@ -98,6 +102,9 @@ type (
 	ModerationParams    = providers.ModerationParams
 	ModerationResponse  = providers.ModerationResponse
 	ModerationResult    = providers.ModerationResult
+	ResponsesInputItem  = providers.ResponsesInputItem
+	ResponsesParams     = providers.ResponsesParams
+	ResponsesResult     = providers.ResponsesResult
 )
 
 // Message types.
@@ -178,17 +185,17 @@ var (
 
 // Error types.
 type (
-	AuthenticationError           = errors.AuthenticationError
-	BaseError                     = errors.BaseError
-	ContentFilterError            = errors.ContentFilterError
-	ContextLengthError            = errors.ContextLengthError
-	InsufficientFundsError        = errors.InsufficientFundsError
-	InvalidRequestError           = errors.InvalidRequestError
-	MissingAPIKeyError            = errors.MissingAPIKeyError
-	ModelNotFoundError            = errors.ModelNotFoundError
-	ProviderError                 = errors.ProviderError
-	RateLimitError                = errors.RateLimitError
-	UnsupportedOperationError     = errors.UnsupportedOperationError
-	UnsupportedParamError         = errors.UnsupportedParamError
-	UnsupportedProviderError      = errors.UnsupportedProviderError
+	AuthenticationError       = errors.AuthenticationError
+	BaseError                 = errors.BaseError
+	ContentFilterError        = errors.ContentFilterError
+	ContextLengthError        = errors.ContextLengthError
+	InsufficientFundsError    = errors.InsufficientFundsError
+	InvalidRequestError       = errors.InvalidRequestError
+	MissingAPIKeyError        = errors.MissingAPIKeyError
+	ModelNotFoundError        = errors.ModelNotFoundError
+	ProviderError             = errors.ProviderError
+	RateLimitError            = errors.RateLimitError
+	UnsupportedOperationError = errors.UnsupportedOperationError
+	UnsupportedParamError     = errors.UnsupportedParamError
+	UnsupportedProviderError  = errors.UnsupportedProviderError
 )

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -6,9 +6,10 @@ any-llm-go supports multiple LLM providers through a unified interface. Each pro
 
 | Provider                | ID          | Completion | Streaming | Tools | Reasoning | Embeddings | List Models |
 |-------------------------|:------------|:----------:|:---------:|:-----:|:---------:|:----------:|:-----------:|
-| [Anthropic](#anthropic) | `anthropic` |     ✅      |     ✅     |   ✅   |     ✅     |     ❌      |      ❌      |
-| [DeepSeek](#deepseek)   | `deepseek`  |     ✅      |     ✅     |   ✅   |     ✅     |     ❌      |      ✅      |
-| [Gemini](#gemini)       | `gemini`    |     ✅      |     ✅     |   ✅   |     ✅     |     ✅      |      ✅      |
+| [Anthropic](#anthropic)     | `anthropic`    |     ✅      |     ✅     |   ✅   |     ✅     |     ❌      |      ❌      |
+| [Azure OpenAI](#azure-openai) | `azureopenai` |     ✅      |     ✅     |   ✅   |     ✅     |     ✅      |      ✅      |
+| [DeepSeek](#deepseek)       | `deepseek`     |     ✅      |     ✅     |   ✅   |     ✅     |     ❌      |      ✅      |
+| [Gemini](#gemini)           | `gemini`       |     ✅      |     ✅     |   ✅   |     ✅     |     ✅      |      ✅      |
 | [Groq](#groq)           | `groq`      |     ✅      |     ✅     |   ✅   |     ❌     |     ❌      |      ✅      |
 | [llama.cpp](#llamacpp)   | `llamacpp`  |     ✅      |     ✅     |   ✅   |     ❌     |     ✅      |      ✅      |
 | [Llamafile](#llamafile) | `llamafile` |     ✅      |     ✅     |   ✅   |     ❌     |     ✅      |      ✅      |
@@ -27,6 +28,29 @@ any-llm-go supports multiple LLM providers through a unified interface. Each pro
 - **List Models** - API to list available models
 
 ## Provider Details
+
+### Azure OpenAI
+
+```go
+import (
+    anyllm "github.com/mozilla-ai/any-llm-go"
+    "github.com/mozilla-ai/any-llm-go/providers/azureopenai"
+)
+
+provider, err := azureopenai.New(
+    anyllm.WithAPIKey("your-azure-openai-key"),
+    anyllm.WithBaseURL("https://example.openai.azure.com"),
+)
+```
+
+**Environment Variables:** `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`
+
+Optional:
+
+- `AZURE_OPENAI_API_VERSION` (default `preview`)
+- `anyllm.WithExtra("api_version", "2025-04-01-preview")`
+
+The `Model` field is the Azure deployment name. Azure OpenAI also supports the Responses API through `ResponsesProvider`.
 
 ### Anthropic
 
@@ -126,6 +150,8 @@ provider, err := gemini.New(anyllm.WithAPIKey("your-key"))
 
 **Environment Variables:** `GEMINI_API_KEY` or `GOOGLE_API_KEY`
 
+Optional base URL: `GOOGLE_GEMINI_BASE_URL` or `anyllm.WithBaseURL(...)`.
+
 **Popular Models:**
 - `gemini-2.5-flash` - Fast and cost-effective
 - `gemini-2.5-pro` - Most capable model
@@ -142,7 +168,7 @@ Gemini models support extended thinking for complex reasoning tasks:
 response, err := provider.Completion(ctx, anyllm.CompletionParams{
     Model: "gemini-3-flash-preview",
     Messages: messages,
-    ReasoningEffort: anyllm.ReasoningEffortMedium, // low, medium, or high
+    ReasoningEffort: anyllm.ReasoningEffortMedium, // minimal, low, medium, high, xhigh, or max
 })
 
 // Access the thinking content.
@@ -440,14 +466,16 @@ provider, err := openai.New()
 // Or with explicit API key.
 provider, err := openai.New(anyllm.WithAPIKey("sk-..."))
 
-// Or with custom base URL (for Azure, proxies, etc.).
+// Or with a custom base URL (proxies or OpenAI-compatible endpoints).
 provider, err := openai.New(
     anyllm.WithAPIKey("your-key"),
-    anyllm.WithBaseURL("https://your-endpoint.openai.azure.com"),
+    anyllm.WithBaseURL("https://openai-proxy.example/v1"),
 )
 ```
 
 **Environment Variable:** `OPENAI_API_KEY`
+
+OpenAI also implements `ResponsesProvider` for the Responses API.
 
 **Popular Models:**
 - `gpt-4o` - Most capable model
@@ -507,7 +535,6 @@ The following providers are planned for future releases:
 | Cohere       | Planned                                           |
 | Together AI  | Planned                                           |
 | AWS Bedrock  | Planned                                           |
-| Azure OpenAI | Planned (use OpenAI with custom base URL for now) |
 
 ## Adding a New Provider
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mozilla-ai/any-llm-go
 go 1.26.0
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0
 	github.com/anthropics/anthropic-sdk-go v1.41.0
 	github.com/google/uuid v1.6.0
 	github.com/mozilla-ai/any-llm-platform-client-go v0.0.1
@@ -16,6 +17,7 @@ require (
 	cloud.google.com/go v0.116.0 // indirect
 	cloud.google.com/go/auth v0.9.3 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -25,10 +27,10 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
-	github.com/kr/pretty v0.3.0 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rogpeppe/go-internal v1.8.0 // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20260427160145-3afa6683f8b2 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,10 @@ cloud.google.com/go/auth v0.9.3 h1:VOEUIAADkkLtyfr3BLa3R8Ed/j6w1jTBmARx+wb5w5U=
 cloud.google.com/go/auth v0.9.3/go.mod h1:7z6VY+7h3KUdRov5F1i8NDP5ZzWKYmEPO842BgCsmTk=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0 h1:g0EZJwz7xkXQiZAI5xi9f3WWFYBlX1CPTrR+NDToRkQ=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0/go.mod h1:XCW7KnZet0Opnr7HccfUw1PLc4CjHqpcaxW8DHklNkQ=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 h1:ywEEhmNahHBihViHepv3xPBn1663uRv2t2q/ESv9seY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0/go.mod h1:iZDifYGJTIgIIkYRNWPENUnqx6bJ2xnSDFI2tjwZNuY=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/anthropics/anthropic-sdk-go v1.41.0 h1:D//vDxQMAmWOcOV3QtgESOneIxJOfWxGIHsmJgGGGp4=
 github.com/anthropics/anthropic-sdk-go v1.41.0/go.mod h1:UgnI27pSnfj2Ux2iE6Dkq9o/3MZn0jdalFdQIdWMS+Q=
@@ -71,6 +75,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -90,6 +95,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20260427160145-3afa6683f8b2 h1:q/QNlQMqBFYT7z9zt8vjbh0XvbcTXhN4Q+gi7aEBvkY=
 github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20260427160145-3afa6683f8b2/go.mod h1:L1MQhA6x4dn9r007T033lsaZMv9EmBAdXyU/+EF40fo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/providers/azureopenai/azureopenai.go
+++ b/providers/azureopenai/azureopenai.go
@@ -1,0 +1,117 @@
+// Package azureopenai provides an Azure OpenAI provider implementation for any-llm.
+package azureopenai
+
+import (
+	"fmt"
+
+	"github.com/openai/openai-go/azure"
+	"github.com/openai/openai-go/option"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	"github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
+	anyopenai "github.com/mozilla-ai/any-llm-go/providers/openai"
+)
+
+// Provider configuration constants.
+const (
+	defaultAPIVersion = "preview"
+	envAPIKey         = "AZURE_OPENAI_API_KEY"
+	envAPIVersion     = "AZURE_OPENAI_API_VERSION"
+	envBaseURL        = "AZURE_OPENAI_ENDPOINT"
+	extraAPIVersion   = "api_version"
+	providerName      = "azureopenai"
+)
+
+// Ensure Provider implements the required interfaces.
+var (
+	_ providers.CapabilityProvider = (*Provider)(nil)
+	_ providers.EmbeddingProvider  = (*Provider)(nil)
+	_ providers.ErrorConverter     = (*Provider)(nil)
+	_ providers.ModelLister        = (*Provider)(nil)
+	_ providers.Provider           = (*Provider)(nil)
+	_ providers.ResponsesProvider  = (*Provider)(nil)
+)
+
+// Provider implements the providers.Provider interface for Azure OpenAI.
+type Provider struct {
+	*anyopenai.CompatibleProvider
+}
+
+// New creates a new Azure OpenAI provider.
+func New(opts ...config.Option) (*Provider, error) {
+	cfg, err := config.New(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("invalid options: %w", err)
+	}
+
+	apiKey := cfg.ResolveAPIKey(envAPIKey)
+	if apiKey == "" {
+		return nil, errors.NewMissingAPIKeyError(providerName, envAPIKey)
+	}
+
+	endpoint, err := cfg.ResolveBaseURL(envBaseURL, "")
+	if err != nil {
+		return nil, err
+	}
+	if endpoint == "" {
+		return nil, fmt.Errorf(
+			"%s endpoint is required (set via WithBaseURL option or %q env var)",
+			providerName,
+			envBaseURL,
+		)
+	}
+
+	apiVersion := resolveAPIVersion(cfg)
+	clientOpts := []option.RequestOption{
+		azure.WithEndpoint(endpoint, apiVersion),
+		azure.WithAPIKey(apiKey),
+		option.WithHTTPClient(cfg.HTTPClient()),
+	}
+
+	base, err := anyopenai.NewCompatible(anyopenai.CompatibleConfig{
+		APIKeyEnvVar:   envAPIKey,
+		BaseURLEnvVar:  envBaseURL,
+		Capabilities:   capabilities(),
+		ClientOptions:  clientOpts,
+		DefaultAPIKey:  "",
+		DefaultBaseURL: "",
+		Name:           providerName,
+		RequireAPIKey:  true,
+		RequireBaseURL: true,
+	}, config.WithAPIKey(apiKey), config.WithBaseURL(endpoint), config.WithHTTPClient(cfg.HTTPClient()))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Provider{CompatibleProvider: base}, nil
+}
+
+// capabilities returns the capabilities for Azure OpenAI.
+func capabilities() providers.Capabilities {
+	return providers.Capabilities{
+		Completion:          true,
+		CompletionImage:     true,
+		CompletionPDF:       false,
+		CompletionReasoning: true,
+		CompletionStreaming: true,
+		CompletionTools:     true,
+		Embedding:           true,
+		ListModels:          true,
+		Responses:           true,
+	}
+}
+
+// resolveAPIVersion returns the Azure OpenAI API version from extra config, then
+// AZURE_OPENAI_API_VERSION, then the default.
+func resolveAPIVersion(cfg *config.Config) string {
+	if v, ok := cfg.ExtraValue(extraAPIVersion); ok {
+		if s, ok := v.(string); ok && s != "" {
+			return s
+		}
+	}
+	if v := cfg.ResolveEnv(envAPIVersion); v != "" {
+		return v
+	}
+	return defaultAPIVersion
+}

--- a/providers/azureopenai/azureopenai_test.go
+++ b/providers/azureopenai/azureopenai_test.go
@@ -1,0 +1,101 @@
+package azureopenai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	"github.com/mozilla-ai/any-llm-go/errors"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("creates provider with API key and endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		provider, err := New(
+			config.WithAPIKey("test-key"),
+			config.WithBaseURL("https://example.openai.azure.com"),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+		require.Equal(t, providerName, provider.Name())
+	})
+
+	t.Run("creates provider from environment variables", func(t *testing.T) {
+		t.Setenv(envAPIKey, "env-key")
+		t.Setenv(envBaseURL, "https://example.openai.azure.com")
+
+		provider, err := New()
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+	})
+
+	t.Run("returns error when API key is missing", func(t *testing.T) {
+		t.Setenv(envAPIKey, "")
+
+		provider, err := New(config.WithBaseURL("https://example.openai.azure.com"))
+		require.Nil(t, provider)
+		require.Error(t, err)
+
+		var missingKeyErr *errors.MissingAPIKeyError
+		require.ErrorAs(t, err, &missingKeyErr)
+		require.Equal(t, providerName, missingKeyErr.Provider)
+		require.Equal(t, envAPIKey, missingKeyErr.EnvVar)
+	})
+
+	t.Run("returns error when endpoint is missing", func(t *testing.T) {
+		t.Setenv(envAPIKey, "")
+		t.Setenv(envBaseURL, "")
+
+		provider, err := New(config.WithAPIKey("test-key"))
+		require.Nil(t, provider)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "endpoint is required")
+	})
+}
+
+func TestCapabilities(t *testing.T) {
+	t.Parallel()
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL("https://example.openai.azure.com"),
+	)
+	require.NoError(t, err)
+
+	caps := provider.Capabilities()
+	require.True(t, caps.Completion)
+	require.True(t, caps.CompletionReasoning)
+	require.True(t, caps.CompletionStreaming)
+	require.True(t, caps.CompletionTools)
+	require.True(t, caps.Embedding)
+	require.True(t, caps.ListModels)
+	require.True(t, caps.Responses)
+}
+
+func TestResolveAPIVersion(t *testing.T) {
+	t.Run("defaults to preview", func(t *testing.T) {
+		t.Setenv(envAPIVersion, "")
+
+		cfg, err := config.New()
+		require.NoError(t, err)
+		require.Equal(t, defaultAPIVersion, resolveAPIVersion(cfg))
+	})
+
+	t.Run("uses environment variable", func(t *testing.T) {
+		t.Setenv(envAPIVersion, "2025-04-01-preview")
+
+		cfg, err := config.New()
+		require.NoError(t, err)
+		require.Equal(t, "2025-04-01-preview", resolveAPIVersion(cfg))
+	})
+
+	t.Run("uses extra config over environment", func(t *testing.T) {
+		t.Setenv(envAPIVersion, "2024-10-21")
+
+		cfg, err := config.New(config.WithExtra(extraAPIVersion, "2025-04-01-preview"))
+		require.NoError(t, err)
+		require.Equal(t, "2025-04-01-preview", resolveAPIVersion(cfg))
+	})
+}

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -24,15 +24,19 @@ import (
 const (
 	envAPIKey       = "GEMINI_API_KEY"
 	envAPIKeyGoogle = "GOOGLE_API_KEY"
+	envBaseURL      = "GOOGLE_GEMINI_BASE_URL"
 	providerName    = "gemini"
 )
 
 // Default thinking budgets for reasoning effort levels.
 // These match the Python any-llm library.
 const (
-	thinkingBudgetHigh   int32 = 24576
-	thinkingBudgetLow    int32 = 1024
-	thinkingBudgetMedium int32 = 8192
+	thinkingBudgetHigh    int32 = 24576
+	thinkingBudgetLow     int32 = 1024
+	thinkingBudgetMax     int32 = 32768
+	thinkingBudgetMedium  int32 = 8192
+	thinkingBudgetMinimal int32 = 256
+	thinkingBudgetXHigh   int32 = 32768
 )
 
 // Content part types.
@@ -132,11 +136,21 @@ func New(opts ...config.Option) (*Provider, error) {
 		return nil, errors.NewMissingAPIKeyError(providerName, envAPIKey)
 	}
 
-	client, err := genai.NewClient(context.Background(), &genai.ClientConfig{
+	baseURL, err := cfg.ResolveBaseURL(envBaseURL, "")
+	if err != nil {
+		return nil, err
+	}
+
+	clientCfg := &genai.ClientConfig{
 		APIKey:     apiKey,
 		Backend:    genai.BackendGeminiAPI,
 		HTTPClient: cfg.HTTPClient(),
-	})
+	}
+	if baseURL != "" {
+		clientCfg.HTTPOptions.BaseURL = baseURL
+	}
+
+	client, err := genai.NewClient(context.Background(), clientCfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating Gemini client: %w", err)
 	}
@@ -381,7 +395,7 @@ func (p *Provider) convertParams(params providers.CompletionParams) ([]*genai.Co
 		cfg.ToolConfig = convertToolChoice(params.ToolChoice)
 	}
 
-	applyThinking(cfg, params.ReasoningEffort)
+	applyThinking(cfg, params.Model, params.ReasoningEffort)
 
 	if params.ResponseFormat != nil {
 		applyResponseFormat(cfg, params.ResponseFormat)
@@ -509,8 +523,20 @@ func applyResponseFormat(cfg *genai.GenerateContentConfig, format *providers.Res
 }
 
 // applyThinking configures thinking/reasoning on the config if applicable.
-func applyThinking(cfg *genai.GenerateContentConfig, effort providers.ReasoningEffort) {
+func applyThinking(cfg *genai.GenerateContentConfig, model string, effort providers.ReasoningEffort) {
 	if effort == "" || effort == providers.ReasoningEffortNone {
+		return
+	}
+
+	if usesThinkingLevel(model) {
+		level, ok := thinkingLevel(effort)
+		if !ok {
+			return
+		}
+		cfg.ThinkingConfig = &genai.ThinkingConfig{
+			IncludeThoughts: true,
+			ThinkingLevel:   level,
+		}
 		return
 	}
 
@@ -954,13 +980,78 @@ func thoughtSignatureFromExtra(extra map[string]providers.ProviderData) []byte {
 // thinkingBudget returns the token budget for the given reasoning effort.
 func thinkingBudget(effort providers.ReasoningEffort) (int32, bool) {
 	switch effort {
+	case providers.ReasoningEffortMinimal:
+		return thinkingBudgetMinimal, true
 	case providers.ReasoningEffortLow:
 		return thinkingBudgetLow, true
 	case providers.ReasoningEffortMedium:
 		return thinkingBudgetMedium, true
 	case providers.ReasoningEffortHigh:
 		return thinkingBudgetHigh, true
+	case providers.ReasoningEffortXHigh:
+		return thinkingBudgetXHigh, true
+	case providers.ReasoningEffortMax:
+		return thinkingBudgetMax, true
 	default:
 		return 0, false
 	}
+}
+
+// thinkingLevel returns the Gemini thinking_level for the given reasoning effort.
+func thinkingLevel(effort providers.ReasoningEffort) (genai.ThinkingLevel, bool) {
+	switch effort {
+	case providers.ReasoningEffortMinimal:
+		return genai.ThinkingLevelMinimal, true
+	case providers.ReasoningEffortLow:
+		return genai.ThinkingLevelLow, true
+	case providers.ReasoningEffortMedium:
+		return genai.ThinkingLevelMedium, true
+	case providers.ReasoningEffortHigh, providers.ReasoningEffortXHigh, providers.ReasoningEffortMax:
+		return genai.ThinkingLevelHigh, true
+	default:
+		return "", false
+	}
+}
+
+// usesThinkingLevel reports whether the model expects thinking_level instead of
+// thinking_budget. Gemini 3.5 and newer reject thinking_budget.
+func usesThinkingLevel(modelID string) bool {
+	major, minor, ok := parseGeminiVersion(modelID)
+	if !ok {
+		return false
+	}
+	return major > 3 || (major == 3 && minor >= 5)
+}
+
+// parseGeminiVersion extracts the major and minor version from a Gemini model ID.
+func parseGeminiVersion(modelID string) (int, int, bool) {
+	lower := strings.ToLower(modelID)
+	idx := strings.Index(lower, "gemini-")
+	if idx < 0 {
+		return 0, 0, false
+	}
+	rest := lower[idx+len("gemini-"):]
+	if rest == "" || rest[0] < '0' || rest[0] > '9' {
+		return 0, 0, false
+	}
+
+	major := 0
+	i := 0
+	for i < len(rest) && rest[i] >= '0' && rest[i] <= '9' {
+		major = major*10 + int(rest[i]-'0')
+		i++
+	}
+	if i >= len(rest) || rest[i] != '.' {
+		return major, 0, true
+	}
+	i++
+	minor := 0
+	if i >= len(rest) || rest[i] < '0' || rest[i] > '9' {
+		return major, 0, true
+	}
+	for i < len(rest) && rest[i] >= '0' && rest[i] <= '9' {
+		minor = minor*10 + int(rest[i]-'0')
+		i++
+	}
+	return major, minor, true
 }

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -55,6 +55,17 @@ func TestNew(t *testing.T) {
 		require.Equal(t, providerName, missingKeyErr.Provider)
 		require.Equal(t, envAPIKey, missingKeyErr.EnvVar)
 	})
+
+	t.Run("creates provider with custom base URL", func(t *testing.T) {
+		t.Parallel()
+
+		provider, err := New(
+			config.WithAPIKey("test-api-key"),
+			config.WithBaseURL("https://gemini-proxy.example"),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, provider)
+	})
 }
 
 func TestCapabilities(t *testing.T) {
@@ -535,6 +546,12 @@ func TestThinkingBudget(t *testing.T) {
 		ok       bool
 	}{
 		{
+			name:     "minimal effort",
+			effort:   providers.ReasoningEffortMinimal,
+			expected: thinkingBudgetMinimal,
+			ok:       true,
+		},
+		{
 			name:     "low effort",
 			effort:   providers.ReasoningEffortLow,
 			expected: thinkingBudgetLow,
@@ -550,6 +567,18 @@ func TestThinkingBudget(t *testing.T) {
 			name:     "high effort",
 			effort:   providers.ReasoningEffortHigh,
 			expected: thinkingBudgetHigh,
+			ok:       true,
+		},
+		{
+			name:     "xhigh effort",
+			effort:   providers.ReasoningEffortXHigh,
+			expected: thinkingBudgetXHigh,
+			ok:       true,
+		},
+		{
+			name:     "max effort",
+			effort:   providers.ReasoningEffortMax,
+			expected: thinkingBudgetMax,
 			ok:       true,
 		},
 		{
@@ -584,7 +613,7 @@ func TestApplyThinking(t *testing.T) {
 		t.Parallel()
 
 		cfg := &genai.GenerateContentConfig{}
-		applyThinking(cfg, "")
+		applyThinking(cfg, "gemini-2.5-flash", "")
 		require.Nil(t, cfg.ThinkingConfig)
 	})
 
@@ -592,29 +621,73 @@ func TestApplyThinking(t *testing.T) {
 		t.Parallel()
 
 		cfg := &genai.GenerateContentConfig{}
-		applyThinking(cfg, providers.ReasoningEffortNone)
+		applyThinking(cfg, "gemini-2.5-flash", providers.ReasoningEffortNone)
 		require.Nil(t, cfg.ThinkingConfig)
 	})
 
-	t.Run("low effort sets thinking config", func(t *testing.T) {
+	t.Run("low effort sets thinking budget", func(t *testing.T) {
 		t.Parallel()
 
 		cfg := &genai.GenerateContentConfig{}
-		applyThinking(cfg, providers.ReasoningEffortLow)
+		applyThinking(cfg, "gemini-2.5-flash", providers.ReasoningEffortLow)
 		require.NotNil(t, cfg.ThinkingConfig)
 		require.True(t, cfg.ThinkingConfig.IncludeThoughts)
 		require.Equal(t, thinkingBudgetLow, *cfg.ThinkingConfig.ThinkingBudget)
+		require.Empty(t, cfg.ThinkingConfig.ThinkingLevel)
+	})
+
+	t.Run("minimal effort sets thinking budget", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &genai.GenerateContentConfig{}
+		applyThinking(cfg, "gemini-2.5-flash", providers.ReasoningEffortMinimal)
+		require.NotNil(t, cfg.ThinkingConfig)
+		require.Equal(t, thinkingBudgetMinimal, *cfg.ThinkingConfig.ThinkingBudget)
 	})
 
 	t.Run("high effort sets thinking config", func(t *testing.T) {
 		t.Parallel()
 
 		cfg := &genai.GenerateContentConfig{}
-		applyThinking(cfg, providers.ReasoningEffortHigh)
+		applyThinking(cfg, "gemini-2.5-flash", providers.ReasoningEffortHigh)
 		require.NotNil(t, cfg.ThinkingConfig)
 		require.True(t, cfg.ThinkingConfig.IncludeThoughts)
 		require.Equal(t, thinkingBudgetHigh, *cfg.ThinkingConfig.ThinkingBudget)
 	})
+
+	t.Run("gemini 3.5 uses thinking level", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &genai.GenerateContentConfig{}
+		applyThinking(cfg, "gemini-3.5-flash", providers.ReasoningEffortMinimal)
+		require.NotNil(t, cfg.ThinkingConfig)
+		require.True(t, cfg.ThinkingConfig.IncludeThoughts)
+		require.Equal(t, genai.ThinkingLevelMinimal, cfg.ThinkingConfig.ThinkingLevel)
+		require.Nil(t, cfg.ThinkingConfig.ThinkingBudget)
+	})
+}
+
+func TestUsesThinkingLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		{name: "2.5 flash", model: "gemini-2.5-flash", want: false},
+		{name: "3 flash", model: "gemini-3-flash-preview", want: false},
+		{name: "3.5 flash", model: "gemini-3.5-flash", want: true},
+		{name: "4 pro", model: "models/gemini-4-pro", want: true},
+		{name: "unrelated", model: "gpt-4o", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, usesThinkingLevel(tc.model))
+		})
+	}
 }
 
 func TestConvertImagePart(t *testing.T) {

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -76,6 +76,11 @@ type CompatibleConfig struct {
 	// function must not retain it beyond the call. Nil means no transformation.
 	ChatCompletionRequestTransform func(*openai.ChatCompletionNewParams)
 
+	// ClientOptions replaces the default client construction (API key, HTTP
+	// client, and base URL) when non-nil. Used by Azure OpenAI for Api-Key
+	// authentication and api-version query routing.
+	ClientOptions []option.RequestOption
+
 	// RequireAPIKey indicates whether an API key is required.
 	RequireAPIKey bool
 
@@ -142,13 +147,15 @@ func NewCompatible(compatCfg CompatibleConfig, opts ...config.Option) (*Compatib
 		apiKey = compatCfg.DefaultAPIKey
 	}
 
-	clientOpts := []option.RequestOption{
-		option.WithAPIKey(apiKey),
-		option.WithHTTPClient(cfg.HTTPClient()),
-	}
-
-	if baseURL != "" {
-		clientOpts = append(clientOpts, option.WithBaseURL(baseURL))
+	clientOpts := compatCfg.ClientOptions
+	if clientOpts == nil {
+		clientOpts = []option.RequestOption{
+			option.WithAPIKey(apiKey),
+			option.WithHTTPClient(cfg.HTTPClient()),
+		}
+		if baseURL != "" {
+			clientOpts = append(clientOpts, option.WithBaseURL(baseURL))
+		}
 	}
 
 	return &CompatibleProvider{

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -19,6 +19,7 @@ var (
 	_ providers.ErrorConverter     = (*Provider)(nil)
 	_ providers.ModelLister        = (*Provider)(nil)
 	_ providers.Provider           = (*Provider)(nil)
+	_ providers.ResponsesProvider  = (*Provider)(nil)
 )
 
 // Provider implements the providers.Provider interface for OpenAI.
@@ -54,5 +55,6 @@ func capabilities() providers.Capabilities {
 		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
+		Responses:           true,
 	}
 }

--- a/providers/openai/responses.go
+++ b/providers/openai/responses.go
@@ -1,0 +1,107 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/responses"
+	"github.com/openai/openai-go/shared"
+
+	"github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+// Responses calls the OpenAI Responses API.
+func (p *CompatibleProvider) Responses(
+	ctx context.Context,
+	params providers.ResponsesParams,
+) (*providers.ResponsesResult, error) {
+	if err := validateResponsesParams(params); err != nil {
+		return nil, err
+	}
+
+	req, err := convertResponsesParams(params)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := p.client.Responses.New(ctx, req)
+	if err != nil {
+		return nil, p.ConvertError(err)
+	}
+
+	output := resp.OutputText()
+	if output == "" {
+		return nil, errors.NewInvalidRequestError(p.Name(), fmt.Errorf("empty output text returned from Responses API"))
+	}
+
+	return &providers.ResponsesResult{
+		ID:     resp.ID,
+		Model:  string(resp.Model),
+		Output: output,
+	}, nil
+}
+
+// convertResponsesParams converts providers.ResponsesParams to an OpenAI Responses request.
+func convertResponsesParams(params providers.ResponsesParams) (responses.ResponseNewParams, error) {
+	items := make(responses.ResponseInputParam, 0, len(params.Input))
+	for _, item := range params.Input {
+		role, err := responsesRole(item.Role)
+		if err != nil {
+			return responses.ResponseNewParams{}, err
+		}
+		items = append(items, responses.ResponseInputItemParamOfMessage(item.Content, role))
+	}
+
+	req := responses.ResponseNewParams{
+		Model: shared.ResponsesModel(params.Model),
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: items,
+		},
+	}
+
+	if params.Instructions != "" {
+		req.Instructions = openai.String(params.Instructions)
+	}
+	if params.MaxTokens != nil {
+		req.MaxOutputTokens = openai.Int(int64(*params.MaxTokens))
+	}
+	if params.Reasoning != "" && params.Reasoning != providers.ReasoningEffortNone {
+		req.Reasoning = shared.ReasoningParam{
+			Effort: shared.ReasoningEffort(params.Reasoning),
+		}
+	}
+
+	return req, nil
+}
+
+// responsesRole maps a normalized role onto a Responses API role.
+func responsesRole(role string) (responses.EasyInputMessageRole, error) {
+	switch role {
+	case providers.RoleUser:
+		return responses.EasyInputMessageRoleUser, nil
+	case providers.RoleAssistant:
+		return responses.EasyInputMessageRoleAssistant, nil
+	case providers.RoleSystem:
+		return responses.EasyInputMessageRoleSystem, nil
+	default:
+		return "", fmt.Errorf("unsupported responses role %q", role)
+	}
+}
+
+// validateResponsesParams validates Responses API parameters.
+func validateResponsesParams(params providers.ResponsesParams) error {
+	if params.Model == "" {
+		return errors.NewInvalidRequestError("", fmt.Errorf("model is required"))
+	}
+	if len(params.Input) == 0 {
+		return errors.NewInvalidRequestError("", fmt.Errorf("at least one input item is required"))
+	}
+	for _, item := range params.Input {
+		if _, err := responsesRole(item.Role); err != nil {
+			return errors.NewInvalidRequestError("", err)
+		}
+	}
+	return nil
+}

--- a/providers/openai/responses_test.go
+++ b/providers/openai/responses_test.go
@@ -1,0 +1,92 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+func TestConvertResponsesParams(t *testing.T) {
+	t.Parallel()
+
+	t.Run("converts input items and instructions", func(t *testing.T) {
+		t.Parallel()
+
+		params := providers.ResponsesParams{
+			Model:        "gpt-4o-mini",
+			Instructions: "you are a shell assistant",
+			Input: []providers.ResponsesInputItem{
+				{Role: providers.RoleUser, Content: "list files"},
+				{Role: providers.RoleAssistant, Content: "=ls"},
+			},
+		}
+
+		req, err := convertResponsesParams(params)
+		require.NoError(t, err)
+		require.Equal(t, "gpt-4o-mini", string(req.Model))
+		require.Equal(t, "you are a shell assistant", req.Instructions.Value)
+		require.Len(t, req.Input.OfInputItemList, 2)
+	})
+
+	t.Run("sets reasoning effort", func(t *testing.T) {
+		t.Parallel()
+
+		params := providers.ResponsesParams{
+			Model:     "o3-mini",
+			Reasoning: providers.ReasoningEffortMedium,
+			Input: []providers.ResponsesInputItem{
+				{Role: providers.RoleUser, Content: "think"},
+			},
+		}
+
+		req, err := convertResponsesParams(params)
+		require.NoError(t, err)
+		require.Equal(t, "medium", string(req.Reasoning.Effort))
+	})
+
+	t.Run("rejects unknown roles", func(t *testing.T) {
+		t.Parallel()
+
+		params := providers.ResponsesParams{
+			Model: "gpt-4o-mini",
+			Input: []providers.ResponsesInputItem{
+				{Role: "moderator", Content: "nope"},
+			},
+		}
+
+		_, err := convertResponsesParams(params)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported responses role")
+	})
+}
+
+func TestValidateResponsesParams(t *testing.T) {
+	t.Parallel()
+
+	t.Run("requires model", func(t *testing.T) {
+		t.Parallel()
+		err := validateResponsesParams(providers.ResponsesParams{
+			Input: []providers.ResponsesInputItem{{Role: providers.RoleUser, Content: "hi"}},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "model is required")
+	})
+
+	t.Run("requires input", func(t *testing.T) {
+		t.Parallel()
+		err := validateResponsesParams(providers.ResponsesParams{Model: "gpt-4o-mini"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "at least one input item is required")
+	})
+}
+
+func TestCapabilitiesIncludesResponses(t *testing.T) {
+	t.Parallel()
+
+	provider, err := New(config.WithAPIKey("test-key"))
+	require.NoError(t, err)
+	require.True(t, provider.Capabilities().Responses)
+}

--- a/providers/types.go
+++ b/providers/types.go
@@ -16,11 +16,14 @@ const (
 
 // Reasoning effort levels for extended thinking.
 const (
-	ReasoningEffortAuto   ReasoningEffort = "auto"
-	ReasoningEffortHigh   ReasoningEffort = "high"
-	ReasoningEffortLow    ReasoningEffort = "low"
-	ReasoningEffortMedium ReasoningEffort = "medium"
-	ReasoningEffortNone   ReasoningEffort = "none"
+	ReasoningEffortAuto    ReasoningEffort = "auto"
+	ReasoningEffortHigh    ReasoningEffort = "high"
+	ReasoningEffortLow     ReasoningEffort = "low"
+	ReasoningEffortMax     ReasoningEffort = "max"
+	ReasoningEffortMedium  ReasoningEffort = "medium"
+	ReasoningEffortMinimal ReasoningEffort = "minimal"
+	ReasoningEffortNone    ReasoningEffort = "none"
+	ReasoningEffortXHigh   ReasoningEffort = "xhigh"
 )
 
 // Message roles.
@@ -71,6 +74,13 @@ type RerankProvider interface {
 	Rerank(ctx context.Context, params RerankParams) (*RerankResponse, error)
 }
 
+// ResponsesProvider is an optional interface for providers that support the
+// OpenAI Responses API.
+type ResponsesProvider interface {
+	Provider
+	Responses(ctx context.Context, params ResponsesParams) (*ResponsesResult, error)
+}
+
 // Provider is the core interface that all LLM providers must implement.
 type Provider interface {
 	// Name returns the provider's identifier (e.g., "openai", "anthropic").
@@ -95,12 +105,13 @@ type Capabilities struct {
 	CompletionImage     bool
 	CompletionPDF       bool
 	CompletionReasoning bool
-	CompletionStreaming  bool
+	CompletionStreaming bool
 	CompletionTools     bool
 	Embedding           bool
 	ListModels          bool
 	Moderation          bool
 	Rerank              bool
+	Responses           bool
 }
 
 // ChatCompletion represents a chat completion response in OpenAI format.
@@ -245,6 +256,28 @@ type RerankParams struct {
 	Query           string   `json:"query"`
 	TopN            *int     `json:"top_n,omitempty"`
 	User            string   `json:"user,omitempty"`
+}
+
+// ResponsesInputItem is a single Responses API input item.
+type ResponsesInputItem struct {
+	Content string `json:"content"`
+	Role    string `json:"role"`
+}
+
+// ResponsesParams represents normalized parameters for the OpenAI Responses API.
+type ResponsesParams struct {
+	Input        []ResponsesInputItem `json:"input"`
+	Instructions string               `json:"instructions,omitempty"`
+	MaxTokens    *int                 `json:"max_output_tokens,omitempty"`
+	Model        string               `json:"model"`
+	Reasoning    ReasoningEffort      `json:"reasoning_effort,omitempty"`
+}
+
+// ResponsesResult is a normalized Responses API result.
+type ResponsesResult struct {
+	ID     string `json:"id"`
+	Model  string `json:"model"`
+	Output string `json:"output"`
 }
 
 // RerankResponse represents a rerank response.


### PR DESCRIPTION
## What changed

Bring any-llm-go closer to the Python any-llm coverage for three gaps:

- Add an `azureopenai` provider that uses the official Azure OpenAI SDK options (`Api-Key`, `api-version`, deployment routing).
- Add a `ResponsesProvider` interface and implement it on the OpenAI-compatible client, including Azure OpenAI.
- Map Gemini `ReasoningEffort` the same way Python does: `minimal`/`xhigh`/`max`, `thinking_budget` for older models, and `thinking_level` for Gemini 3.5+. Honor `WithBaseURL` / `GOOGLE_GEMINI_BASE_URL`.

## Why

Python any-llm already supports Azure OpenAI, the Responses API, and Gemini thinking levels. The Go port currently drops those paths, so callers such as smart-suggestion cannot migrate without keeping vendor SDKs for those cases.

## Test plan

- `go test ./providers/openai ./providers/azureopenai ./providers/gemini ./providers`