### PR TITLE
fix(gemini): align current thinking controls

### DIFF
--- a/anyllm.go
+++ b/anyllm.go
@@ -53,11 +53,14 @@ const (
 
 // ReasoningEffort levels.
 const (
-	ReasoningEffortAuto   = providers.ReasoningEffortAuto
-	ReasoningEffortHigh   = providers.ReasoningEffortHigh
-	ReasoningEffortLow    = providers.ReasoningEffortLow
-	ReasoningEffortMedium = providers.ReasoningEffortMedium
-	ReasoningEffortNone   = providers.ReasoningEffortNone
+	ReasoningEffortAuto    = providers.ReasoningEffortAuto
+	ReasoningEffortHigh    = providers.ReasoningEffortHigh
+	ReasoningEffortLow     = providers.ReasoningEffortLow
+	ReasoningEffortMax     = providers.ReasoningEffortMax
+	ReasoningEffortMedium  = providers.ReasoningEffortMedium
+	ReasoningEffortMinimal = providers.ReasoningEffortMinimal
+	ReasoningEffortNone    = providers.ReasoningEffortNone
+	ReasoningEffortXHigh   = providers.ReasoningEffortXHigh
 )
 
 // Provider types.
@@ -179,17 +182,17 @@ var (
 
 // Error types.
 type (
-	AuthenticationError           = errors.AuthenticationError
-	BaseError                     = errors.BaseError
-	ContentFilterError            = errors.ContentFilterError
-	ContextLengthError            = errors.ContextLengthError
-	InsufficientFundsError        = errors.InsufficientFundsError
-	InvalidRequestError           = errors.InvalidRequestError
-	MissingAPIKeyError            = errors.MissingAPIKeyError
-	ModelNotFoundError            = errors.ModelNotFoundError
-	ProviderError                 = errors.ProviderError
-	RateLimitError                = errors.RateLimitError
-	UnsupportedOperationError     = errors.UnsupportedOperationError
-	UnsupportedParamError         = errors.UnsupportedParamError
-	UnsupportedProviderError      = errors.UnsupportedProviderError
+	AuthenticationError       = errors.AuthenticationError
+	BaseError                 = errors.BaseError
+	ContentFilterError        = errors.ContentFilterError
+	ContextLengthError        = errors.ContextLengthError
+	InsufficientFundsError    = errors.InsufficientFundsError
+	InvalidRequestError       = errors.InvalidRequestError
+	MissingAPIKeyError        = errors.MissingAPIKeyError
+	ModelNotFoundError        = errors.ModelNotFoundError
+	ProviderError             = errors.ProviderError
+	RateLimitError            = errors.RateLimitError
+	UnsupportedOperationError = errors.UnsupportedOperationError
+	UnsupportedParamError     = errors.UnsupportedParamError
+	UnsupportedProviderError  = errors.UnsupportedProviderError
 )

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -27,14 +27,6 @@ const (
 	providerName    = "gemini"
 )
 
-// Default thinking budgets for reasoning effort levels.
-// These match the Python any-llm library.
-const (
-	thinkingBudgetHigh   int32 = 24576
-	thinkingBudgetLow    int32 = 1024
-	thinkingBudgetMedium int32 = 8192
-)
-
 // Content part types.
 const (
 	contentPartTypeImageURL = "image_url"
@@ -166,7 +158,10 @@ func (p *Provider) Completion(
 	ctx context.Context,
 	params providers.CompletionParams,
 ) (*providers.ChatCompletion, error) {
-	contents, cfg := p.convertParams(params)
+	contents, cfg, err := p.convertParams(params)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := p.client.Models.GenerateContent(ctx, params.Model, contents, cfg)
 	if err != nil {
@@ -188,7 +183,14 @@ func (p *Provider) CompletionStream(
 		defer close(chunks)
 		defer close(errs)
 
-		contents, cfg := p.convertParams(params)
+		contents, cfg, err := p.convertParams(params)
+		if err != nil {
+			select {
+			case errs <- err:
+			case <-ctx.Done():
+			}
+			return
+		}
 		state, err := newStreamState(params.Model)
 		if err != nil {
 			select {
@@ -346,7 +348,9 @@ func (p *Provider) Name() string {
 }
 
 // convertParams converts providers.CompletionParams to Gemini request format.
-func (p *Provider) convertParams(params providers.CompletionParams) ([]*genai.Content, *genai.GenerateContentConfig) {
+func (p *Provider) convertParams(
+	params providers.CompletionParams,
+) ([]*genai.Content, *genai.GenerateContentConfig, error) {
 	contents, systemInstruction := convertMessages(params.Messages)
 
 	cfg := &genai.GenerateContentConfig{}
@@ -381,13 +385,15 @@ func (p *Provider) convertParams(params providers.CompletionParams) ([]*genai.Co
 		cfg.ToolConfig = convertToolChoice(params.ToolChoice)
 	}
 
-	applyThinking(cfg, params.ReasoningEffort)
+	if err := applyThinking(cfg, params.Model, params.ReasoningEffort); err != nil {
+		return nil, nil, err
+	}
 
 	if params.ResponseFormat != nil {
 		applyResponseFormat(cfg, params.ResponseFormat)
 	}
 
-	return contents, cfg
+	return contents, cfg, nil
 }
 
 // newStreamState creates a new stream state.
@@ -505,23 +511,6 @@ func applyResponseFormat(cfg *genai.GenerateContentConfig, format *providers.Res
 		cfg.ResponseJsonSchema = format.JSONSchema.Schema
 	case responseFormatJSON:
 		cfg.ResponseMIMEType = responseMIMETypeJSON
-	}
-}
-
-// applyThinking configures thinking/reasoning on the config if applicable.
-func applyThinking(cfg *genai.GenerateContentConfig, effort providers.ReasoningEffort) {
-	if effort == "" || effort == providers.ReasoningEffortNone {
-		return
-	}
-
-	budget, ok := thinkingBudget(effort)
-	if !ok {
-		return
-	}
-
-	cfg.ThinkingConfig = &genai.ThinkingConfig{
-		IncludeThoughts: true,
-		ThinkingBudget:  &budget,
 	}
 }
 
@@ -949,18 +938,4 @@ func thoughtSignatureFromExtra(extra map[string]providers.ProviderData) []byte {
 	}
 
 	return sig
-}
-
-// thinkingBudget returns the token budget for the given reasoning effort.
-func thinkingBudget(effort providers.ReasoningEffort) (int32, bool) {
-	switch effort {
-	case providers.ReasoningEffortLow:
-		return thinkingBudgetLow, true
-	case providers.ReasoningEffortMedium:
-		return thinkingBudgetMedium, true
-	case providers.ReasoningEffortHigh:
-		return thinkingBudgetHigh, true
-	default:
-		return 0, false
-	}
 }

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	stderrors "errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -525,96 +528,211 @@ func TestConvertError(t *testing.T) {
 	}
 }
 
-func TestThinkingBudget(t *testing.T) {
+func TestApplyThinkingLevels(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		effort   providers.ReasoningEffort
-		expected int32
-		ok       bool
+		name   string
+		model  string
+		effort providers.ReasoningEffort
+		wire   string
 	}{
 		{
-			name:     "low effort",
-			effort:   providers.ReasoningEffortLow,
-			expected: thinkingBudgetLow,
-			ok:       true,
+			name: "Gemini 3 minimal", model: "gemini-3-flash", effort: providers.ReasoningEffortMinimal,
+			wire: `{"includeThoughts":true,"thinkingLevel":"MINIMAL"}`,
 		},
 		{
-			name:     "medium effort",
-			effort:   providers.ReasoningEffortMedium,
-			expected: thinkingBudgetMedium,
-			ok:       true,
+			name: "Gemini 3 low", model: "gemini-3-flash", effort: providers.ReasoningEffortLow,
+			wire: `{"includeThoughts":true,"thinkingLevel":"LOW"}`,
 		},
 		{
-			name:     "high effort",
-			effort:   providers.ReasoningEffortHigh,
-			expected: thinkingBudgetHigh,
-			ok:       true,
+			name: "Gemini 3 medium", model: "gemini-3-flash", effort: providers.ReasoningEffortMedium,
+			wire: `{"includeThoughts":true,"thinkingLevel":"MEDIUM"}`,
 		},
 		{
-			name:     "none effort",
-			effort:   providers.ReasoningEffortNone,
-			expected: 0,
-			ok:       false,
+			name: "3.1 Pro uses levels", model: "models/gemini-3.1-pro", effort: providers.ReasoningEffortHigh,
+			wire: `{"includeThoughts":true,"thinkingLevel":"HIGH"}`,
 		},
 		{
-			name:     "invalid effort",
-			effort:   "invalid",
-			expected: 0,
-			ok:       false,
+			name: "Gemini 3 maximum", model: "gemini-3-flash", effort: providers.ReasoningEffortMax,
+			wire: `{"includeThoughts":true,"thinkingLevel":"HIGH"}`,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			budget, ok := thinkingBudget(tc.effort)
-			require.Equal(t, tc.ok, ok)
-			require.Equal(t, tc.expected, budget)
+			cfg := &genai.GenerateContentConfig{}
+			require.NoError(t, applyThinking(cfg, tc.model, tc.effort))
+			requireThinkingWire(t, cfg, tc.wire)
 		})
 	}
 }
 
-func TestApplyThinking(t *testing.T) {
+func TestApplyThinkingBudgets(t *testing.T) {
 	t.Parallel()
 
-	t.Run("empty effort does nothing", func(t *testing.T) {
-		t.Parallel()
+	tests := []struct {
+		name   string
+		model  string
+		effort providers.ReasoningEffort
+		wire   string
+	}{
+		{
+			name: "2.5 Flash disables", model: "gemini-2.5-flash", effort: providers.ReasoningEffortNone,
+			wire: `{"thinkingBudget":0}`,
+		},
+		{
+			name: "Flash-Lite minimum", model: "gemini-2.5-flash-lite", effort: providers.ReasoningEffortMinimal,
+			wire: `{"includeThoughts":true,"thinkingBudget":512}`,
+		},
+		{
+			name: "2.5 Flash low", model: "gemini-2.5-flash", effort: providers.ReasoningEffortLow,
+			wire: `{"includeThoughts":true,"thinkingBudget":1024}`,
+		},
+		{
+			name: "2.5 Flash medium", model: "gemini-2.5-flash", effort: providers.ReasoningEffortMedium,
+			wire: `{"includeThoughts":true,"thinkingBudget":8192}`,
+		},
+		{
+			name: "Pro maximum", model: "gemini-2.5-pro", effort: providers.ReasoningEffortMax,
+			wire: `{"includeThoughts":true,"thinkingBudget":32768}`,
+		},
+		{
+			name: "Flash maximum", model: "gemini-2.5-flash", effort: providers.ReasoningEffortXHigh,
+			wire: `{"includeThoughts":true,"thinkingBudget":24576}`,
+		},
+		{
+			name: "Robotics budget", model: "robotics-er-1.6-preview", effort: providers.ReasoningEffortHigh,
+			wire: `{"includeThoughts":true,"thinkingBudget":24576}`,
+		},
+	}
 
-		cfg := &genai.GenerateContentConfig{}
-		applyThinking(cfg, "")
-		require.Nil(t, cfg.ThinkingConfig)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &genai.GenerateContentConfig{}
+			require.NoError(t, applyThinking(cfg, tc.model, tc.effort))
+			requireThinkingWire(t, cfg, tc.wire)
+		})
+	}
+}
+
+func TestApplyThinkingPreservesDefaults(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		model  string
+		effort providers.ReasoningEffort
+	}{
+		{name: "auto keeps the Gemini 3 default", model: "gemini-3-flash", effort: providers.ReasoningEffortAuto},
+		{name: "none is omitted for 2.0", model: "gemini-2.0-flash", effort: providers.ReasoningEffortNone},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &genai.GenerateContentConfig{}
+			require.NoError(t, applyThinking(cfg, tc.model, tc.effort))
+			require.Nil(t, cfg.ThinkingConfig)
+		})
+	}
+}
+
+func TestApplyThinkingRejectsUnsupported(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		model  string
+		effort providers.ReasoningEffort
+	}{
+		{name: "Gemini 3 rejects none", model: "gemini-3-flash", effort: providers.ReasoningEffortNone},
+		{name: "2.5 Pro rejects none", model: "gemini-2.5-pro", effort: providers.ReasoningEffortNone},
+		{name: "2.0 rejects thinking", model: "gemini-2.0-flash", effort: providers.ReasoningEffortHigh},
+		{name: "invalid effort is rejected", model: "gemini-2.5-flash", effort: "invalid"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &genai.GenerateContentConfig{}
+			require.ErrorIs(t, applyThinking(cfg, tc.model, tc.effort), errors.ErrUnsupportedParam)
+			require.Nil(t, cfg.ThinkingConfig)
+		})
+	}
+}
+
+func requireThinkingWire(t *testing.T, cfg *genai.GenerateContentConfig, want string) {
+	t.Helper()
+
+	wire, err := json.Marshal(cfg.ThinkingConfig)
+	require.NoError(t, err)
+	require.JSONEq(t, want, string(wire))
+}
+
+func TestCompletionRejectsUnsupportedThinking(t *testing.T) {
+	t.Parallel()
+
+	provider, err := New(config.WithAPIKey("test-key"))
+	require.NoError(t, err)
+
+	_, err = provider.Completion(t.Context(), providers.CompletionParams{
+		Model:           "gemini-3-flash",
+		Messages:        []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
+		ReasoningEffort: providers.ReasoningEffortNone,
 	})
+	require.ErrorIs(t, err, errors.ErrUnsupportedParam)
+}
 
-	t.Run("none effort does nothing", func(t *testing.T) {
-		t.Parallel()
+func TestCompletionStreamRejectsUnsupportedThinking(t *testing.T) {
+	t.Parallel()
 
-		cfg := &genai.GenerateContentConfig{}
-		applyThinking(cfg, providers.ReasoningEffortNone)
-		require.Nil(t, cfg.ThinkingConfig)
+	provider, err := New(config.WithAPIKey("test-key"))
+	require.NoError(t, err)
+
+	chunks, errs := provider.CompletionStream(t.Context(), providers.CompletionParams{
+		Model:           "gemini-3-flash",
+		Messages:        []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
+		ReasoningEffort: providers.ReasoningEffortNone,
 	})
+	_, ok := <-chunks
+	require.False(t, ok)
+	require.ErrorIs(t, <-errs, errors.ErrUnsupportedParam)
+}
 
-	t.Run("low effort sets thinking config", func(t *testing.T) {
-		t.Parallel()
+func TestCompletionThinkingWireContract(t *testing.T) {
+	body := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		body <- payload
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}]}`))
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("GOOGLE_GEMINI_BASE_URL", server.URL)
 
-		cfg := &genai.GenerateContentConfig{}
-		applyThinking(cfg, providers.ReasoningEffortLow)
-		require.NotNil(t, cfg.ThinkingConfig)
-		require.True(t, cfg.ThinkingConfig.IncludeThoughts)
-		require.Equal(t, thinkingBudgetLow, *cfg.ThinkingConfig.ThinkingBudget)
+	provider, err := New(config.WithAPIKey("test-key"))
+	require.NoError(t, err)
+	_, err = provider.Completion(t.Context(), providers.CompletionParams{
+		Model:           "gemini-3-flash",
+		Messages:        []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
+		ReasoningEffort: providers.ReasoningEffortHigh,
 	})
+	require.NoError(t, err)
 
-	t.Run("high effort sets thinking config", func(t *testing.T) {
-		t.Parallel()
-
-		cfg := &genai.GenerateContentConfig{}
-		applyThinking(cfg, providers.ReasoningEffortHigh)
-		require.NotNil(t, cfg.ThinkingConfig)
-		require.True(t, cfg.ThinkingConfig.IncludeThoughts)
-		require.Equal(t, thinkingBudgetHigh, *cfg.ThinkingConfig.ThinkingBudget)
-	})
+	var request struct {
+		GenerationConfig struct {
+			ThinkingConfig json.RawMessage `json:"thinkingConfig"`
+		} `json:"generationConfig"`
+	}
+	require.NoError(t, json.Unmarshal(<-body, &request))
+	require.JSONEq(
+		t,
+		`{"includeThoughts":true,"thinkingLevel":"HIGH"}`,
+		string(request.GenerationConfig.ThinkingConfig),
+	)
 }
 
 func TestConvertImagePart(t *testing.T) {
@@ -1203,13 +1321,14 @@ func TestConvertParams(t *testing.T) {
 	t.Run("json_object sets mime type", func(t *testing.T) {
 		t.Parallel()
 
-		_, cfg := provider.convertParams(providers.CompletionParams{
+		_, cfg, err := provider.convertParams(providers.CompletionParams{
 			Model:    "gemini-2.0-flash",
 			Messages: []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
 			ResponseFormat: &providers.ResponseFormat{
 				Type: responseFormatJSON,
 			},
 		})
+		require.NoError(t, err)
 
 		require.Equal(t, responseMIMETypeJSON, cfg.ResponseMIMEType)
 		require.Nil(t, cfg.ResponseJsonSchema)
@@ -1227,7 +1346,7 @@ func TestConvertParams(t *testing.T) {
 			"required": []string{"name", "population"},
 		}
 
-		_, cfg := provider.convertParams(providers.CompletionParams{
+		_, cfg, err := provider.convertParams(providers.CompletionParams{
 			Model:    "gemini-2.0-flash",
 			Messages: []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
 			ResponseFormat: &providers.ResponseFormat{
@@ -1238,6 +1357,7 @@ func TestConvertParams(t *testing.T) {
 				},
 			},
 		})
+		require.NoError(t, err)
 
 		require.Equal(t, responseMIMETypeJSON, cfg.ResponseMIMEType)
 		require.Equal(t, schema, cfg.ResponseJsonSchema)
@@ -1246,10 +1366,11 @@ func TestConvertParams(t *testing.T) {
 	t.Run("nil response format leaves config unchanged", func(t *testing.T) {
 		t.Parallel()
 
-		_, cfg := provider.convertParams(providers.CompletionParams{
+		_, cfg, err := provider.convertParams(providers.CompletionParams{
 			Model:    "gemini-2.0-flash",
 			Messages: []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
 		})
+		require.NoError(t, err)
 
 		require.Empty(t, cfg.ResponseMIMEType)
 		require.Nil(t, cfg.ResponseJsonSchema)

--- a/providers/gemini/thinking.go
+++ b/providers/gemini/thinking.go
@@ -1,0 +1,141 @@
+package gemini
+
+import (
+	"strings"
+
+	"google.golang.org/genai"
+
+	"github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+const (
+	// Gemini 2.5 exposes token ranges rather than named efforts. These values
+	// preserve the adapter's low/medium/high policy while respecting each
+	// model family's documented minimum and maximum.
+	thinkingBudgetHigh        int32 = 24576
+	thinkingBudgetLow         int32 = 1024
+	thinkingBudgetMax         int32 = 32768
+	thinkingBudgetMedium      int32 = 8192
+	thinkingBudgetMinimal     int32 = 256
+	thinkingBudgetMinimalLite int32 = 512
+	thinkingBudgetProMinimal  int32 = 128
+)
+
+// applyThinking uses thinkingLevel for Gemini 3 and thinkingBudget for the
+// documented budget-based models. The service validates each Gemini 3 model's
+// supported levels so a hard-coded catalog cannot reject new models or go stale.
+// https://ai.google.dev/gemini-api/docs/generate-content/thinking
+func applyThinking(
+	cfg *genai.GenerateContentConfig,
+	model string,
+	effort providers.ReasoningEffort,
+) error {
+	if effort == "" || effort == providers.ReasoningEffortAuto {
+		return nil
+	}
+
+	if usesThinkingLevel(model) {
+		level, ok := thinkingLevel(effort)
+		if !ok {
+			return errors.NewUnsupportedParamError(providerName, "reasoning_effort")
+		}
+		cfg.ThinkingConfig = &genai.ThinkingConfig{
+			IncludeThoughts: true,
+			ThinkingLevel:   level,
+		}
+		return nil
+	}
+
+	if !usesThinkingBudget(model) {
+		if effort == providers.ReasoningEffortNone {
+			return nil
+		}
+		return errors.NewUnsupportedParamError(providerName, "reasoning_effort")
+	}
+
+	budget, ok := thinkingBudget(model, effort)
+	if !ok {
+		return errors.NewUnsupportedParamError(providerName, "reasoning_effort")
+	}
+	cfg.ThinkingConfig = &genai.ThinkingConfig{
+		IncludeThoughts: effort != providers.ReasoningEffortNone,
+		ThinkingBudget:  &budget,
+	}
+	return nil
+}
+
+func thinkingLevel(effort providers.ReasoningEffort) (genai.ThinkingLevel, bool) {
+	switch effort {
+	case providers.ReasoningEffortAuto, providers.ReasoningEffortNone:
+		return "", false
+	case providers.ReasoningEffortMinimal:
+		return genai.ThinkingLevelMinimal, true
+	case providers.ReasoningEffortLow:
+		return genai.ThinkingLevelLow, true
+	case providers.ReasoningEffortMedium:
+		return genai.ThinkingLevelMedium, true
+	// Gemini's highest documented level is high, so the normalized maxima
+	// collapse to high instead of sending values the API does not accept.
+	case providers.ReasoningEffortHigh, providers.ReasoningEffortXHigh, providers.ReasoningEffortMax:
+		return genai.ThinkingLevelHigh, true
+	default:
+		return "", false
+	}
+}
+
+func thinkingBudget(model string, effort providers.ReasoningEffort) (int32, bool) {
+	model = geminiModelName(model)
+	switch effort {
+	case providers.ReasoningEffortAuto:
+		return 0, false
+	case providers.ReasoningEffortNone:
+		return 0, !strings.Contains(model, "pro")
+	case providers.ReasoningEffortMinimal:
+		return minimalThinkingBudget(model), true
+	case providers.ReasoningEffortLow:
+		return thinkingBudgetLow, true
+	case providers.ReasoningEffortMedium:
+		return thinkingBudgetMedium, true
+	case providers.ReasoningEffortHigh:
+		return thinkingBudgetHigh, true
+	case providers.ReasoningEffortXHigh, providers.ReasoningEffortMax:
+		return maximalThinkingBudget(model), true
+	default:
+		return 0, false
+	}
+}
+
+func minimalThinkingBudget(model string) int32 {
+	switch {
+	case strings.Contains(model, "flash-lite"):
+		return thinkingBudgetMinimalLite
+	case strings.Contains(model, "pro"):
+		return thinkingBudgetProMinimal
+	default:
+		return thinkingBudgetMinimal
+	}
+}
+
+func maximalThinkingBudget(model string) int32 {
+	if strings.Contains(model, "pro") {
+		return thinkingBudgetMax
+	}
+	return thinkingBudgetHigh
+}
+
+func usesThinkingLevel(model string) bool {
+	return strings.HasPrefix(geminiModelName(model), "gemini-3")
+}
+
+func usesThinkingBudget(model string) bool {
+	model = geminiModelName(model)
+	return strings.HasPrefix(model, "gemini-2.5") || strings.HasPrefix(model, "robotics-er-1.6")
+}
+
+func geminiModelName(model string) string {
+	if slash := strings.LastIndexByte(model, '/'); slash >= 0 {
+		model = model[slash+1:]
+	}
+	return strings.ToLower(model)
+}

--- a/providers/types.go
+++ b/providers/types.go
@@ -16,11 +16,14 @@ const (
 
 // Reasoning effort levels for extended thinking.
 const (
-	ReasoningEffortAuto   ReasoningEffort = "auto"
-	ReasoningEffortHigh   ReasoningEffort = "high"
-	ReasoningEffortLow    ReasoningEffort = "low"
-	ReasoningEffortMedium ReasoningEffort = "medium"
-	ReasoningEffortNone   ReasoningEffort = "none"
+	ReasoningEffortAuto    ReasoningEffort = "auto"
+	ReasoningEffortHigh    ReasoningEffort = "high"
+	ReasoningEffortLow     ReasoningEffort = "low"
+	ReasoningEffortMax     ReasoningEffort = "max"
+	ReasoningEffortMedium  ReasoningEffort = "medium"
+	ReasoningEffortMinimal ReasoningEffort = "minimal"
+	ReasoningEffortNone    ReasoningEffort = "none"
+	ReasoningEffortXHigh   ReasoningEffort = "xhigh"
 )
 
 // Message roles.
@@ -95,7 +98,7 @@ type Capabilities struct {
 	CompletionImage     bool
 	CompletionPDF       bool
 	CompletionReasoning bool
-	CompletionStreaming  bool
+	CompletionStreaming bool
 	CompletionTools     bool
 	Embedding           bool
 	ListModels          bool


### PR DESCRIPTION
## Summary

- use `thinkingLevel` for Gemini 3 and documented token budgets for Gemini 2.5 and Robotics
- preserve provider defaults for `auto`, send an explicit zero where thinking can be disabled, and reject unsupported combinations before transport
- expose the normalized `minimal` effort and verify the generated SDK request with an independent HTTP wire test

## Contract sources

- [Gemini thinking guide](https://ai.google.dev/gemini-api/docs/generate-content/thinking), updated 2026-08-17
- [go-genai v1.71.0 `ThinkingConfig`](https://github.com/googleapis/go-genai/blob/v1.71.0/types.go#L2735-L2744)
- [go-genai v1.71.0 Gemini request converter](https://github.com/googleapis/go-genai/blob/v1.71.0/models.go#L1295-L1298)

The current dependency remains `google.golang.org/genai v1.56.0`. All four current thinking levels entered the SDK in v1.40.0, so this change does not require a dependency upgrade. A temporary modfile test against the latest formal release, v1.71.0, also passes.

## Review boundary

This PR contains five files and three signed commits. Its diff is `+368/-125`: production `+190/-68`, direct contract tests `+178/-57`. It does not contain Interactions, Batch, embeddings, file/PDF handling, base URL changes, response capture, or general stream rewrites.

The model service validates each Gemini 3 model's supported subset of `minimal`, `low`, `medium`, and `high`. Keeping that catalog in the binding would duplicate server validation and become stale when Google adds models.

## Verification

Base: upstream `ef366a4218ed67ad82156742c985829fc389df3d`. Exact head: `4d0ef23ffd6ef8def7c63759da3157f45ab2c467`.

```text
go test ./... -count=1                                      PASS
CGO_ENABLED=1 go test -race ./... -count=1                  PASS
go mod tidy -diff                                            no diff
go mod verify                                                all modules verified
golangci-lint run --fix=false . ./providers/gemini/...      0 issues
git diff --check                                            PASS
```

`golangci-lint run --fix=false ./providers/gemini/...` reports `0 issues.`. The full repository still reports two formatter findings in unchanged `providers/gateway/gateway.go`; #141 owns those fixes because it modifies that shared SDK consumer. They remain absent from this standalone Gemini PR.

The generated SDK HTTP golden captures a real `GenerateContent` request and checks the documented `generationConfig.thinkingConfig` wire object. No upstream code or fixture was copied.

Live Gemini verification remains incomplete because no Gemini credential was available. The PR remains Draft until its rebased exact head passes CodeRabbit and live smoke tests where credentials are available.

AI tools were used to research the current official contracts, implement the changes, and run the tests. Every cited behavior was checked against the linked documentation or immutable SDK source.