### PR TITLE
fix(anthropic): preserve independent effort controls

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -382,19 +382,15 @@ func (s *streamState) handleTextDelta(text string) *providers.ChatCompletionChun
 	return &chunk
 }
 
-// applyThinking configures the current adaptive-thinking contract.
+// applyThinking translates normalized effort without forcing adaptive thinking.
 func applyThinking(req *anthropic.MessageNewParams, effort providers.ReasoningEffort) error {
 	switch effort {
-	case "":
+	case "", providers.ReasoningEffortAuto:
 		return nil
 	case providers.ReasoningEffortNone:
 		req.Thinking = anthropic.ThinkingConfigParamUnion{
 			OfDisabled: new(anthropic.NewThinkingConfigDisabledParam()),
 		}
-
-		return nil
-	case providers.ReasoningEffortAuto:
-		req.Thinking = anthropic.ThinkingConfigParamUnion{OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{}}
 
 		return nil
 	case "minimal":
@@ -405,11 +401,9 @@ func applyThinking(req *anthropic.MessageNewParams, effort providers.ReasoningEf
 		return errors.NewUnsupportedParamError(providerName, "reasoning_effort="+string(effort))
 	}
 
-	// Anthropic's current models select adaptive thinking explicitly and control
-	// its depth through output_config.effort. max_tokens remains an independent
-	// cap on thinking plus response output, so this conversion preserves the caller's value.
-	// https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
-	req.Thinking = anthropic.ThinkingConfigParamUnion{OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{}}
+	// Effort also applies when thinking is disabled. Do not force a thinking
+	// mode or change the caller's max_tokens when setting this independent control.
+	// https://platform.claude.com/docs/en/build-with-claude/effort
 	req.OutputConfig.Effort = anthropic.OutputConfigEffort(effort)
 
 	return nil

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -216,7 +216,10 @@ func (p *Provider) convertParams(params providers.CompletionParams) (anthropic.M
 
 	applyResponseFormat(&req, params.ResponseFormat)
 
-	applyThinking(&req, params.ReasoningEffort, maxTokens)
+	err := applyThinking(&req, params.ReasoningEffort)
+	if err != nil {
+		return anthropic.MessageNewParams{}, err
+	}
 
 	return req, nil
 }
@@ -379,24 +382,37 @@ func (s *streamState) handleTextDelta(text string) *providers.ChatCompletionChun
 	return &chunk
 }
 
-// applyThinking configures thinking/reasoning on the request if applicable.
-func applyThinking(req *anthropic.MessageNewParams, effort providers.ReasoningEffort, maxTokens int64) {
-	if effort == "" || effort == providers.ReasoningEffortNone {
-		return
+// applyThinking configures the current adaptive-thinking contract.
+func applyThinking(req *anthropic.MessageNewParams, effort providers.ReasoningEffort) error {
+	switch effort {
+	case "":
+		return nil
+	case providers.ReasoningEffortNone:
+		req.Thinking = anthropic.ThinkingConfigParamUnion{
+			OfDisabled: new(anthropic.NewThinkingConfigDisabledParam()),
+		}
+
+		return nil
+	case providers.ReasoningEffortAuto:
+		req.Thinking = anthropic.ThinkingConfigParamUnion{OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{}}
+
+		return nil
+	case "minimal":
+		effort = "low"
+	case providers.ReasoningEffortLow, providers.ReasoningEffortMedium, providers.ReasoningEffortHigh,
+		"xhigh", "max":
+	default:
+		return errors.NewUnsupportedParamError(providerName, "reasoning_effort="+string(effort))
 	}
 
-	budget, ok := thinkingBudget(effort)
-	if !ok {
-		return
-	}
+	// Anthropic's current models select adaptive thinking explicitly and control
+	// its depth through output_config.effort. max_tokens remains an independent
+	// cap on thinking plus response output, so this conversion preserves the caller's value.
+	// https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
+	req.Thinking = anthropic.ThinkingConfigParamUnion{OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{}}
+	req.OutputConfig.Effort = anthropic.OutputConfigEffort(effort)
 
-	req.Thinking = anthropic.ThinkingConfigParamOfEnabled(budget)
-
-	// Increase max tokens to accommodate thinking.
-	minTokens := budget * 2
-	if maxTokens < minTokens {
-		req.MaxTokens = minTokens
-	}
+	return nil
 }
 
 // applyResponseFormat configures structured output on the request if applicable.
@@ -697,21 +713,6 @@ func convertUserMessage(msg providers.Message) *anthropic.MessageParam {
 	}
 	m := anthropic.NewUserMessage(content...)
 	return &m
-}
-
-// thinkingBudget returns the token budget for the given reasoning effort.
-// Returns the budget and true if the effort level is supported, or 0 and false otherwise.
-func thinkingBudget(effort providers.ReasoningEffort) (int64, bool) {
-	switch effort {
-	case providers.ReasoningEffortLow:
-		return 1024, true
-	case providers.ReasoningEffortMedium:
-		return 4096, true
-	case providers.ReasoningEffortHigh:
-		return 16384, true
-	default:
-		return 0, false
-	}
 }
 
 // toStringSlice converts a value to []string.

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -18,8 +18,6 @@ import (
 	"github.com/mozilla-ai/any-llm-go/providers"
 )
 
-const adaptiveThinkingJSON = `{"type":"adaptive"}`
-
 func TestNew(t *testing.T) {
 	t.Run("creates provider with API key", func(t *testing.T) {
 		provider, err := New(config.WithAPIKey("test-api-key"))
@@ -358,45 +356,38 @@ func TestApplyThinking(t *testing.T) {
 			expectedThinking: `{"type":"disabled"}`,
 		},
 		{
-			name:             "auto selects adaptive thinking without an effort",
-			effort:           providers.ReasoningEffortAuto,
-			expectedThinking: adaptiveThinkingJSON,
+			name:   "auto preserves the model default",
+			effort: providers.ReasoningEffortAuto,
 		},
 		{
-			name:             "minimal maps to the lowest Anthropic effort",
-			effort:           "minimal",
-			expectedThinking: adaptiveThinkingJSON,
-			expectedEffort:   `{"effort":"low"}`,
+			name:           "minimal maps to the lowest Anthropic effort",
+			effort:         "minimal",
+			expectedEffort: `{"effort":"low"}`,
 		},
 		{
-			name:             "low remains low",
-			effort:           providers.ReasoningEffortLow,
-			expectedThinking: adaptiveThinkingJSON,
-			expectedEffort:   `{"effort":"low"}`,
+			name:           "low remains low",
+			effort:         providers.ReasoningEffortLow,
+			expectedEffort: `{"effort":"low"}`,
 		},
 		{
-			name:             "medium remains medium",
-			effort:           providers.ReasoningEffortMedium,
-			expectedThinking: adaptiveThinkingJSON,
-			expectedEffort:   `{"effort":"medium"}`,
+			name:           "medium remains medium",
+			effort:         providers.ReasoningEffortMedium,
+			expectedEffort: `{"effort":"medium"}`,
 		},
 		{
-			name:             "high remains high",
-			effort:           providers.ReasoningEffortHigh,
-			expectedThinking: adaptiveThinkingJSON,
-			expectedEffort:   `{"effort":"high"}`,
+			name:           "high remains high",
+			effort:         providers.ReasoningEffortHigh,
+			expectedEffort: `{"effort":"high"}`,
 		},
 		{
-			name:             "xhigh remains xhigh",
-			effort:           "xhigh",
-			expectedThinking: adaptiveThinkingJSON,
-			expectedEffort:   `{"effort":"xhigh"}`,
+			name:           "xhigh remains xhigh",
+			effort:         "xhigh",
+			expectedEffort: `{"effort":"xhigh"}`,
 		},
 		{
-			name:             "max remains max",
-			effort:           "max",
-			expectedThinking: adaptiveThinkingJSON,
-			expectedEffort:   `{"effort":"max"}`,
+			name:           "max remains max",
+			effort:         "max",
+			expectedEffort: `{"effort":"max"}`,
 		},
 		{
 			name:      "unknown effort is rejected",
@@ -1387,7 +1378,7 @@ func TestConvertParams_ResponseFormat(t *testing.T) {
 		require.Equal(t, schema, result.OutputConfig.Format.Schema)
 	})
 
-	t.Run("adaptive effort preserves the structured output format", func(t *testing.T) {
+	t.Run("effort preserves the structured output format", func(t *testing.T) {
 		t.Parallel()
 
 		params := baseParams()
@@ -1404,7 +1395,7 @@ func TestConvertParams_ResponseFormat(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, schema, result.OutputConfig.Format.Schema)
 		require.Equal(t, anthropic.OutputConfigEffortHigh, result.OutputConfig.Effort)
-		require.NotNil(t, result.Thinking.OfAdaptive)
+		require.Equal(t, anthropic.ThinkingConfigParamUnion{}, result.Thinking)
 	})
 
 	t.Run("unsupported JSONSchema fields are not forwarded", func(t *testing.T) {

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/mozilla-ai/any-llm-go/providers"
 )
 
+const adaptiveThinkingJSON = `{"type":"adaptive"}`
+
 func TestNew(t *testing.T) {
 	t.Run("creates provider with API key", func(t *testing.T) {
 		provider, err := New(config.WithAPIKey("test-api-key"))
@@ -340,60 +342,66 @@ func TestApplyThinking(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name              string
-		effort            providers.ReasoningEffort
-		initialMaxTokens  int64
-		expectedMaxTokens int64
-		expectThinking    bool
+		name             string
+		effort           providers.ReasoningEffort
+		expectedThinking string
+		expectedEffort   string
+		wantError        bool
 	}{
 		{
-			name:              "empty effort does nothing",
-			effort:            "",
-			initialMaxTokens:  1000,
-			expectedMaxTokens: 1000,
-			expectThinking:    false,
+			name:   "omitted effort remains omitted",
+			effort: "",
 		},
 		{
-			name:              "ReasoningEffortNone does nothing",
-			effort:            providers.ReasoningEffortNone,
-			initialMaxTokens:  1000,
-			expectedMaxTokens: 1000,
-			expectThinking:    false,
+			name:             "none disables thinking explicitly",
+			effort:           providers.ReasoningEffortNone,
+			expectedThinking: `{"type":"disabled"}`,
 		},
 		{
-			name:              "invalid effort does nothing",
-			effort:            "invalid",
-			initialMaxTokens:  1000,
-			expectedMaxTokens: 1000,
-			expectThinking:    false,
+			name:             "auto selects adaptive thinking without an effort",
+			effort:           providers.ReasoningEffortAuto,
+			expectedThinking: adaptiveThinkingJSON,
 		},
 		{
-			name:              "low effort increases tokens when insufficient",
-			effort:            providers.ReasoningEffortLow,
-			initialMaxTokens:  1000,
-			expectedMaxTokens: 2048, // budget=1024, min=2048
-			expectThinking:    true,
+			name:             "minimal maps to the lowest Anthropic effort",
+			effort:           "minimal",
+			expectedThinking: adaptiveThinkingJSON,
+			expectedEffort:   `{"effort":"low"}`,
 		},
 		{
-			name:              "low effort preserves tokens when sufficient",
-			effort:            providers.ReasoningEffortLow,
-			initialMaxTokens:  10000,
-			expectedMaxTokens: 10000,
-			expectThinking:    true,
+			name:             "low remains low",
+			effort:           providers.ReasoningEffortLow,
+			expectedThinking: adaptiveThinkingJSON,
+			expectedEffort:   `{"effort":"low"}`,
 		},
 		{
-			name:              "medium effort increases tokens when insufficient",
-			effort:            providers.ReasoningEffortMedium,
-			initialMaxTokens:  1000,
-			expectedMaxTokens: 8192, // budget=4096, min=8192
-			expectThinking:    true,
+			name:             "medium remains medium",
+			effort:           providers.ReasoningEffortMedium,
+			expectedThinking: adaptiveThinkingJSON,
+			expectedEffort:   `{"effort":"medium"}`,
 		},
 		{
-			name:              "high effort increases tokens when insufficient",
-			effort:            providers.ReasoningEffortHigh,
-			initialMaxTokens:  1000,
-			expectedMaxTokens: 32768, // budget=16384, min=32768
-			expectThinking:    true,
+			name:             "high remains high",
+			effort:           providers.ReasoningEffortHigh,
+			expectedThinking: adaptiveThinkingJSON,
+			expectedEffort:   `{"effort":"high"}`,
+		},
+		{
+			name:             "xhigh remains xhigh",
+			effort:           "xhigh",
+			expectedThinking: adaptiveThinkingJSON,
+			expectedEffort:   `{"effort":"xhigh"}`,
+		},
+		{
+			name:             "max remains max",
+			effort:           "max",
+			expectedThinking: adaptiveThinkingJSON,
+			expectedEffort:   `{"effort":"max"}`,
+		},
+		{
+			name:      "unknown effort is rejected",
+			effort:    "invalid",
+			wantError: true,
 		},
 	}
 
@@ -401,11 +409,35 @@ func TestApplyThinking(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			req := &anthropic.MessageNewParams{MaxTokens: tc.initialMaxTokens}
-			applyThinking(req, tc.effort, tc.initialMaxTokens)
-			require.Equal(t, tc.expectedMaxTokens, req.MaxTokens)
-			if tc.expectThinking {
-				require.NotNil(t, req.Thinking)
+			req := new(anthropic.MessageNewParams)
+			req.MaxTokens = 1000
+			err := applyThinking(req, tc.effort)
+
+			if tc.wantError {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.EqualValues(t, 1000, req.MaxTokens)
+
+			body, err := json.Marshal(req)
+			require.NoError(t, err)
+
+			var wire map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(body, &wire))
+
+			if tc.expectedThinking == "" {
+				require.NotContains(t, wire, "thinking")
+			} else {
+				require.JSONEq(t, tc.expectedThinking, string(wire["thinking"]))
+			}
+
+			if tc.expectedEffort == "" {
+				require.NotContains(t, wire, "output_config")
+			} else {
+				require.JSONEq(t, tc.expectedEffort, string(wire["output_config"]))
 			}
 		})
 	}
@@ -679,58 +711,6 @@ func TestConvertTool(t *testing.T) {
 		require.Contains(t, err.Error(), "mixed_required")
 		require.Contains(t, err.Error(), "element 1")
 	})
-}
-
-func TestThinkingBudget(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		effort   providers.ReasoningEffort
-		expected int64
-		ok       bool
-	}{
-		{
-			name:     "low effort",
-			effort:   providers.ReasoningEffortLow,
-			expected: 1024,
-			ok:       true,
-		},
-		{
-			name:     "medium effort",
-			effort:   providers.ReasoningEffortMedium,
-			expected: 4096,
-			ok:       true,
-		},
-		{
-			name:     "high effort",
-			effort:   providers.ReasoningEffortHigh,
-			expected: 16384,
-			ok:       true,
-		},
-		{
-			name:     "none effort",
-			effort:   providers.ReasoningEffortNone,
-			expected: 0,
-			ok:       false,
-		},
-		{
-			name:     "invalid effort",
-			effort:   "invalid",
-			expected: 0,
-			ok:       false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			budget, ok := thinkingBudget(tc.effort)
-			require.Equal(t, tc.ok, ok)
-			require.Equal(t, tc.expected, budget)
-		})
-	}
 }
 
 func TestToStringSlice(t *testing.T) {
@@ -1405,6 +1385,26 @@ func TestConvertParams_ResponseFormat(t *testing.T) {
 		result, err := p.convertParams(params)
 		require.NoError(t, err)
 		require.Equal(t, schema, result.OutputConfig.Format.Schema)
+	})
+
+	t.Run("adaptive effort preserves the structured output format", func(t *testing.T) {
+		t.Parallel()
+
+		params := baseParams()
+		params.ReasoningEffort = providers.ReasoningEffortHigh
+		params.ResponseFormat = &providers.ResponseFormat{
+			Type: responseFormatJSONSchema,
+			JSONSchema: &providers.JSONSchema{
+				Name:   "answer_schema",
+				Schema: schema,
+			},
+		}
+
+		result, err := p.convertParams(params)
+		require.NoError(t, err)
+		require.Equal(t, schema, result.OutputConfig.Format.Schema)
+		require.Equal(t, anthropic.OutputConfigEffortHigh, result.OutputConfig.Effort)
+		require.NotNil(t, result.Thinking.OfAdaptive)
 	})
 
 	t.Run("unsupported JSONSchema fields are not forwarded", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Serialize Anthropic effort without forcing adaptive thinking or increasing the caller's token limit.

- Omitted effort and `auto` leave both controls absent.
- `none` explicitly disables thinking.
- Explicit effort sets `output_config.effort` only. The existing normalized `minimal` mapping to `low` is an adapter approximation, not an Anthropic value.
- Unknown effort strings are rejected; structured-output configuration is preserved.
- The fixed thinking-budget table and automatic token-limit increase are removed.

Anthropic documents effort as applying with or without thinking. This corrects the prior PR implementation and description that selected adaptive mode for `auto` and explicit effort.

Source: https://platform.claude.com/docs/en/build-with-claude/effort

No SDK dependency changes are needed for these request fields.

## Verification

- Updated literal-wire regressions failed against the prior implementation and passed after removing the implicit thinking assignments.
- `go test ./providers/anthropic -count=1`: passed.
- `CGO_ENABLED=1 go test -race ./providers/anthropic -count=1`: passed.
- `go test ./... -count=1`: passed.
- `go mod tidy -diff`: no diff; `go mod verify`: all modules verified.
- `git diff --check`: passed.
- Configured lint is not green: gci reports formatting in three files outside this correction (`anyllm.go`, `providers/gateway/gateway.go`, `providers/types.go`). The complete stable-rule audit remains pending.

Live Claude verification, exact-head CodeRabbit, and final provider-level consolidation remain incomplete. This PR stays Draft. Other Anthropic request, response and streaming paths are not covered by these effort tests.

## AI usage

Generated with Amp using GPT-5.6 Sol X-HIGH.
