### PR TITLE
fix(openai): preserve embedding input variants

### DIFF
--- a/anyllm.go
+++ b/anyllm.go
@@ -53,11 +53,14 @@ const (
 
 // ReasoningEffort levels.
 const (
-	ReasoningEffortAuto   = providers.ReasoningEffortAuto
-	ReasoningEffortHigh   = providers.ReasoningEffortHigh
-	ReasoningEffortLow    = providers.ReasoningEffortLow
-	ReasoningEffortMedium = providers.ReasoningEffortMedium
-	ReasoningEffortNone   = providers.ReasoningEffortNone
+	ReasoningEffortAuto    = providers.ReasoningEffortAuto
+	ReasoningEffortHigh    = providers.ReasoningEffortHigh
+	ReasoningEffortLow     = providers.ReasoningEffortLow
+	ReasoningEffortMax     = providers.ReasoningEffortMax
+	ReasoningEffortMedium  = providers.ReasoningEffortMedium
+	ReasoningEffortMinimal = providers.ReasoningEffortMinimal
+	ReasoningEffortNone    = providers.ReasoningEffortNone
+	ReasoningEffortXHigh   = providers.ReasoningEffortXHigh
 )
 
 // Provider types.
@@ -179,17 +182,17 @@ var (
 
 // Error types.
 type (
-	AuthenticationError           = errors.AuthenticationError
-	BaseError                     = errors.BaseError
-	ContentFilterError            = errors.ContentFilterError
-	ContextLengthError            = errors.ContextLengthError
-	InsufficientFundsError        = errors.InsufficientFundsError
-	InvalidRequestError           = errors.InvalidRequestError
-	MissingAPIKeyError            = errors.MissingAPIKeyError
-	ModelNotFoundError            = errors.ModelNotFoundError
-	ProviderError                 = errors.ProviderError
-	RateLimitError                = errors.RateLimitError
-	UnsupportedOperationError     = errors.UnsupportedOperationError
-	UnsupportedParamError         = errors.UnsupportedParamError
-	UnsupportedProviderError      = errors.UnsupportedProviderError
+	AuthenticationError       = errors.AuthenticationError
+	BaseError                 = errors.BaseError
+	ContentFilterError        = errors.ContentFilterError
+	ContextLengthError        = errors.ContextLengthError
+	InsufficientFundsError    = errors.InsufficientFundsError
+	InvalidRequestError       = errors.InvalidRequestError
+	MissingAPIKeyError        = errors.MissingAPIKeyError
+	ModelNotFoundError        = errors.ModelNotFoundError
+	ProviderError             = errors.ProviderError
+	RateLimitError            = errors.RateLimitError
+	UnsupportedOperationError = errors.UnsupportedOperationError
+	UnsupportedParamError     = errors.UnsupportedParamError
+	UnsupportedProviderError  = errors.UnsupportedProviderError
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/mozilla-ai/any-llm-platform-client-go v0.0.1
 	github.com/ollama/ollama v0.32.5
-	github.com/openai/openai-go v1.12.0
+	github.com/openai/openai-go/v3 v3.42.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/genai v1.66.0
 )

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/mozilla-ai/any-llm-platform-client-go v0.0.1 h1:AXmEYxIEIESUt2LyB6GFD
 github.com/mozilla-ai/any-llm-platform-client-go v0.0.1/go.mod h1:bqmvllQOUir9G2bmglRQDEgsfHCF6jAC339JGWkzH4U=
 github.com/ollama/ollama v0.32.5 h1:5jeKnTJmDTR+xgB8qh68szdXM9zwnMBMtGl890frdzo=
 github.com/ollama/ollama v0.32.5/go.mod h1:b1ydCt2oVg0VAg22WWDgCbwW0AyOaRKAFzlS91NI4OY=
-github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
-github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
+github.com/openai/openai-go/v3 v3.42.0 h1:16Skv1hpEhSm3imZpPGSeEBDUgVJJA9cHryKGGsVYI8=
+github.com/openai/openai-go/v3 v3.42.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"slices"
 
-	oaisdk "github.com/openai/openai-go"
-	"github.com/openai/openai-go/packages/param"
+	oaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
@@ -160,17 +160,12 @@ func preprocessParams(params providers.CompletionParams) providers.CompletionPar
 	}
 }
 
-// transformRequest adjusts the OpenAI SDK request for DeepSeek's API.
-// DeepSeek uses max_tokens, not max_completion_tokens.
-// If both are set, MaxCompletionTokens takes precedence over MaxTokens.
-// See: https://api-docs.deepseek.com/api/create-chat-completion
+// transformRequest maps the shared token limit to DeepSeek's max_tokens field.
+// https://api-docs.deepseek.com/api/create-chat-completion
 func transformRequest(req *oaisdk.ChatCompletionNewParams) {
 	if req.MaxCompletionTokens.Valid() {
-		// Set max_tokens using max_completion_tokens value.
 		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
 	}
-
-	// Clear unsupported fields from the request.
 	req.MaxCompletionTokens = param.Opt[int64]{}
 }
 

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/v3"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/errors"
@@ -373,7 +373,7 @@ func capabilities() providers.Capabilities {
 		CompletionImage:     true,
 		CompletionPDF:       true,
 		CompletionReasoning: true,
-		CompletionStreaming:  true,
+		CompletionStreaming: true,
 		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
@@ -703,7 +703,9 @@ func (p *Provider) handleRerankErrorResponse(resp *http.Response) error {
 	case http.StatusTooManyRequests:
 		return errors.NewRateLimitError(providerName, fmt.Errorf("%s", msg))
 	case http.StatusBadGateway:
-		return &UpstreamProviderError{BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider)}
+		return &UpstreamProviderError{
+			BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider),
+		}
 	case http.StatusGatewayTimeout:
 		return &TimeoutError{BaseError: errors.New(errCodeTimeout, providerName, fmt.Errorf("%s", msg), ErrTimeout)}
 	default:

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"slices"
 
-	oaisdk "github.com/openai/openai-go"
-	"github.com/openai/openai-go/packages/param"
+	oaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
@@ -141,17 +141,13 @@ func patchMessageParams(params providers.CompletionParams) providers.CompletionP
 	return params
 }
 
-// transformRequest adjusts the OpenAI SDK request for Mistral's API.
-// Mistral uses max_tokens (not max_completion_tokens) and does not accept user or reasoning_effort fields.
-// If both are set, MaxCompletionTokens takes precedence over MaxTokens.
-// See: https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post
+// transformRequest maps the shared token limit to Mistral's max_tokens field
+// and removes fields outside its Chat request schema.
+// https://docs.mistral.ai/api?property=operation-chat_completion_v1_chat_completions_post_request_max_tokens
 func transformRequest(req *oaisdk.ChatCompletionNewParams) {
 	if req.MaxCompletionTokens.Valid() {
-		// Set max_tokens using max_completion_tokens value.
 		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
 	}
-
-	// Clear unsupported fields from the request.
 	req.MaxCompletionTokens = param.Opt[int64]{}
 	req.User = param.Opt[string]{}
 	req.ReasoningEffort = ""

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -7,9 +7,9 @@ import (
 	stderrors "errors"
 	"fmt"
 
-	"github.com/openai/openai-go"
-	"github.com/openai/openai-go/option"
-	"github.com/openai/openai-go/shared"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/shared"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/errors"
@@ -328,13 +328,15 @@ func convertAPIError(name string, apiErr *openai.Error, originalErr error) error
 // convertAssistantMessage converts an assistant message to OpenAI format.
 func convertAssistantMessage(msg providers.Message) openai.ChatCompletionMessageParamUnion {
 	if len(msg.ToolCalls) > 0 {
-		toolCalls := make([]openai.ChatCompletionMessageToolCallParam, 0, len(msg.ToolCalls))
+		toolCalls := make([]openai.ChatCompletionMessageToolCallUnionParam, 0, len(msg.ToolCalls))
 		for _, tc := range msg.ToolCalls {
-			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallParam{
-				ID: tc.ID,
-				Function: openai.ChatCompletionMessageToolCallFunctionParam{
-					Name:      tc.Function.Name,
-					Arguments: tc.Function.Arguments,
+			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnionParam{
+				OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
+					ID: tc.ID,
+					Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
+						Name:      tc.Function.Name,
+						Arguments: tc.Function.Arguments,
+					},
 				},
 			})
 		}
@@ -380,13 +382,16 @@ func convertChunk(chunk *openai.ChatCompletionChunk) providers.ChatCompletionChu
 		choices = append(choices, chunkChoice)
 	}
 
+	// Preserve the existing normalized field even though the v3 SDK marks the
+	// documented response field as deprecated.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	result := providers.ChatCompletionChunk{
 		ID:                chunk.ID,
 		Object:            objectChatCompletionChunk,
 		Created:           chunk.Created,
 		Model:             chunk.Model,
 		Choices:           choices,
-		SystemFingerprint: chunk.SystemFingerprint,
+		SystemFingerprint: chunk.SystemFingerprint, //nolint:staticcheck
 	}
 
 	if chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0 {
@@ -570,13 +575,16 @@ func convertResponse(resp *openai.ChatCompletion) *providers.ChatCompletion {
 		})
 	}
 
+	// Preserve the existing normalized field even though the v3 SDK marks the
+	// documented response field as deprecated.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	result := &providers.ChatCompletion{
 		ID:                resp.ID,
 		Object:            objectChatCompletion,
 		Created:           resp.Created,
 		Model:             resp.Model,
 		Choices:           choices,
-		SystemFingerprint: resp.SystemFingerprint,
+		SystemFingerprint: resp.SystemFingerprint, //nolint:staticcheck
 	}
 
 	if resp.Usage.PromptTokens > 0 || resp.Usage.CompletionTokens > 0 {
@@ -658,7 +666,7 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 		}
 	case providers.ToolChoice:
 		if v.Function != nil {
-			return openai.ChatCompletionToolChoiceOptionParamOfChatCompletionNamedToolChoice(
+			return openai.ToolChoiceOptionFunctionToolChoice(
 				openai.ChatCompletionNamedToolChoiceFunctionParam{
 					Name: v.Function.Name,
 				},
@@ -671,14 +679,16 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 }
 
 // convertTools converts provider tools to OpenAI format.
-func convertTools(tools []providers.Tool) []openai.ChatCompletionToolParam {
-	result := make([]openai.ChatCompletionToolParam, 0, len(tools))
+func convertTools(tools []providers.Tool) []openai.ChatCompletionToolUnionParam {
+	result := make([]openai.ChatCompletionToolUnionParam, 0, len(tools))
 	for _, tool := range tools {
-		result = append(result, openai.ChatCompletionToolParam{
-			Function: openai.FunctionDefinitionParam{
-				Name:        tool.Function.Name,
-				Description: openai.String(tool.Function.Description),
-				Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+		result = append(result, openai.ChatCompletionToolUnionParam{
+			OfFunction: &openai.ChatCompletionFunctionToolParam{
+				Function: openai.FunctionDefinitionParam{
+					Name:        tool.Function.Name,
+					Description: openai.String(tool.Function.Description),
+					Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+				},
 			},
 		})
 	}

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -250,21 +250,6 @@ func (p *CompatibleProvider) ConvertError(err error) error {
 	return errors.NewProviderError(name, err)
 }
 
-// Embedding generates embeddings for the given input.
-func (p *CompatibleProvider) Embedding(
-	ctx context.Context,
-	params providers.EmbeddingParams,
-) (*providers.EmbeddingResponse, error) {
-	req := convertEmbeddingParams(params)
-
-	resp, err := p.client.Embeddings.New(ctx, req)
-	if err != nil {
-		return nil, p.ConvertError(err)
-	}
-
-	return convertEmbeddingResponse(resp), nil
-}
-
 // ListModels returns a list of available models.
 func (p *CompatibleProvider) ListModels(ctx context.Context) (*providers.ModelsResponse, error) {
 	resp, err := p.client.Models.List(ctx)
@@ -399,72 +384,6 @@ func convertChunk(chunk *openai.ChatCompletionChunk) providers.ChatCompletionChu
 			PromptTokens:     int(chunk.Usage.PromptTokens),
 			CompletionTokens: int(chunk.Usage.CompletionTokens),
 			TotalTokens:      int(chunk.Usage.TotalTokens),
-		}
-	}
-
-	return result
-}
-
-// convertEmbeddingParams converts provider embedding params to OpenAI format.
-func convertEmbeddingParams(params providers.EmbeddingParams) openai.EmbeddingNewParams {
-	req := openai.EmbeddingNewParams{
-		Model: openai.EmbeddingModel(params.Model),
-	}
-
-	switch v := params.Input.(type) {
-	case string:
-		req.Input = openai.EmbeddingNewParamsInputUnion{
-			OfString: openai.String(v),
-		}
-	case []string:
-		req.Input = openai.EmbeddingNewParamsInputUnion{
-			OfArrayOfStrings: v,
-		}
-	default:
-		// For unsupported types, convert to string representation.
-		req.Input = openai.EmbeddingNewParamsInputUnion{
-			OfString: openai.String(fmt.Sprintf("%v", params.Input)),
-		}
-	}
-
-	if params.EncodingFormat != "" {
-		req.EncodingFormat = openai.EmbeddingNewParamsEncodingFormat(params.EncodingFormat)
-	}
-
-	if params.Dimensions != nil {
-		req.Dimensions = openai.Int(int64(*params.Dimensions))
-	}
-
-	if params.User != "" {
-		req.User = openai.String(params.User)
-	}
-
-	return req
-}
-
-// convertEmbeddingResponse converts an OpenAI embedding response to provider format.
-func convertEmbeddingResponse(resp *openai.CreateEmbeddingResponse) *providers.EmbeddingResponse {
-	data := make([]providers.EmbeddingData, 0, len(resp.Data))
-	for _, d := range resp.Data {
-		embedding := make([]float64, len(d.Embedding))
-		copy(embedding, d.Embedding)
-		data = append(data, providers.EmbeddingData{
-			Object:    objectEmbedding,
-			Embedding: embedding,
-			Index:     int(d.Index),
-		})
-	}
-
-	result := &providers.EmbeddingResponse{
-		Object: objectList,
-		Data:   data,
-		Model:  resp.Model,
-	}
-
-	if resp.Usage.PromptTokens > 0 || resp.Usage.TotalTokens > 0 {
-		result.Usage = &providers.EmbeddingUsage{
-			PromptTokens: int(resp.Usage.PromptTokens),
-			TotalTokens:  int(resp.Usage.TotalTokens),
 		}
 	}
 

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -517,6 +517,10 @@ func convertParams(params providers.CompletionParams) openai.ChatCompletionNewPa
 		req.TopP = openai.Float(*params.TopP)
 	}
 
+	// OpenAI documents max_completion_tokens as the replacement for the
+	// deprecated max_tokens field. Keep the binding's existing MaxTokens
+	// abstraction on the current wire field.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	if params.MaxTokens != nil {
 		req.MaxCompletionTokens = openai.Int(int64(*params.MaxTokens))
 	}
@@ -551,7 +555,10 @@ func convertParams(params providers.CompletionParams) openai.ChatCompletionNewPa
 		req.User = openai.String(params.User)
 	}
 
-	if params.ReasoningEffort != "" && params.ReasoningEffort != providers.ReasoningEffortNone {
+	// auto is the binding's omission sentinel. OpenAI documents none as an
+	// explicit value, so it must reach the wire unchanged.
+	// https://developers.openai.com/api/docs/guides/latest-model
+	if params.ReasoningEffort != "" && params.ReasoningEffort != providers.ReasoningEffortAuto {
 		req.ReasoningEffort = shared.ReasoningEffort(params.ReasoningEffort)
 	}
 

--- a/providers/openai/compatible_test.go
+++ b/providers/openai/compatible_test.go
@@ -315,64 +315,6 @@ func TestConvertResponseFormat(t *testing.T) {
 	})
 }
 
-func TestConvertEmbeddingParams(t *testing.T) {
-	t.Parallel()
-
-	t.Run("converts string input", func(t *testing.T) {
-		t.Parallel()
-
-		params := providers.EmbeddingParams{
-			Model: "text-embedding-3-small",
-			Input: "Hello, world!",
-		}
-
-		result := convertEmbeddingParams(params)
-		require.NotNil(t, result.Input.OfString)
-	})
-
-	t.Run("converts string array input", func(t *testing.T) {
-		t.Parallel()
-
-		params := providers.EmbeddingParams{
-			Model: "text-embedding-3-small",
-			Input: []string{"Hello", "World"},
-		}
-
-		result := convertEmbeddingParams(params)
-		require.NotNil(t, result.Input.OfArrayOfStrings)
-	})
-
-	t.Run("handles unknown input type", func(t *testing.T) {
-		t.Parallel()
-
-		params := providers.EmbeddingParams{
-			Model: "text-embedding-3-small",
-			Input: 12345, // Unsupported type.
-		}
-
-		result := convertEmbeddingParams(params)
-		// Should convert to string representation.
-		require.NotNil(t, result.Input.OfString)
-	})
-
-	t.Run("includes optional parameters", func(t *testing.T) {
-		t.Parallel()
-
-		dims := 256
-		params := providers.EmbeddingParams{
-			Model:          "text-embedding-3-small",
-			Input:          "Hello",
-			EncodingFormat: "float",
-			Dimensions:     &dims,
-			User:           "test-user",
-		}
-
-		result := convertEmbeddingParams(params)
-		require.Equal(t, int64(256), result.Dimensions.Value)
-		require.Equal(t, "test-user", result.User.Value)
-	})
-}
-
 func TestStreamingContextCancellation(t *testing.T) {
 	t.Parallel()
 

--- a/providers/openai/embeddings.go
+++ b/providers/openai/embeddings.go
@@ -16,6 +16,10 @@ func (p *CompatibleProvider) Embedding(
 	ctx context.Context,
 	params providers.EmbeddingParams,
 ) (*providers.EmbeddingResponse, error) {
+	if !p.Capabilities().Embedding {
+		return nil, errors.NewUnsupportedOperationError(p.Name(), "embedding", nil)
+	}
+
 	req, err := convertEmbeddingParams(params)
 	if err != nil {
 		return nil, errors.NewInvalidRequestError(p.Name(), err)

--- a/providers/openai/embeddings.go
+++ b/providers/openai/embeddings.go
@@ -3,9 +3,11 @@ package openai
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/openai/openai-go/v3"
 
+	"github.com/mozilla-ai/any-llm-go/errors"
 	"github.com/mozilla-ai/any-llm-go/providers"
 )
 
@@ -14,7 +16,10 @@ func (p *CompatibleProvider) Embedding(
 	ctx context.Context,
 	params providers.EmbeddingParams,
 ) (*providers.EmbeddingResponse, error) {
-	req := convertEmbeddingParams(params)
+	req, err := convertEmbeddingParams(params)
+	if err != nil {
+		return nil, errors.NewInvalidRequestError(p.Name(), err)
+	}
 
 	resp, err := p.client.Embeddings.New(ctx, req)
 	if err != nil {
@@ -24,26 +29,48 @@ func (p *CompatibleProvider) Embedding(
 	return convertEmbeddingResponse(resp), nil
 }
 
-// convertEmbeddingParams converts provider embedding params to OpenAI format.
-func convertEmbeddingParams(params providers.EmbeddingParams) openai.EmbeddingNewParams {
+// convertEmbeddingParams converts the four input shapes documented by the
+// OpenAI Embeddings API. The public binding also accepts Go's native int shape
+// and converts it without changing the wire representation.
+// https://developers.openai.com/api/reference/resources/embeddings/methods/create
+func convertEmbeddingParams(params providers.EmbeddingParams) (openai.EmbeddingNewParams, error) {
 	req := openai.EmbeddingNewParams{
-		Model: openai.EmbeddingModel(params.Model),
+		Model: params.Model,
 	}
 
-	switch v := params.Input.(type) {
+	switch input := params.Input.(type) {
 	case string:
 		req.Input = openai.EmbeddingNewParamsInputUnion{
-			OfString: openai.String(v),
+			OfString: openai.String(input),
 		}
 	case []string:
 		req.Input = openai.EmbeddingNewParamsInputUnion{
-			OfArrayOfStrings: v,
+			OfArrayOfStrings: input,
 		}
+	case []int:
+		tokens := make([]int64, len(input))
+		for index, token := range input {
+			tokens[index] = int64(token)
+		}
+		req.Input = openai.EmbeddingNewParamsInputUnion{OfArrayOfTokens: tokens}
+	case []int64:
+		req.Input = openai.EmbeddingNewParamsInputUnion{OfArrayOfTokens: input}
+	case [][]int:
+		tokenArrays := make([][]int64, len(input))
+		for arrayIndex, tokenArray := range input {
+			tokenArrays[arrayIndex] = make([]int64, len(tokenArray))
+			for tokenIndex, token := range tokenArray {
+				tokenArrays[arrayIndex][tokenIndex] = int64(token)
+			}
+		}
+		req.Input = openai.EmbeddingNewParamsInputUnion{OfArrayOfTokenArrays: tokenArrays}
+	case [][]int64:
+		req.Input = openai.EmbeddingNewParamsInputUnion{OfArrayOfTokenArrays: input}
 	default:
-		// For unsupported types, convert to string representation.
-		req.Input = openai.EmbeddingNewParamsInputUnion{
-			OfString: openai.String(fmt.Sprintf("%v", params.Input)),
-		}
+		return openai.EmbeddingNewParams{}, fmt.Errorf(
+			"embedding input must be string, []string, []int, []int64, [][]int, or [][]int64, got %T",
+			params.Input,
+		)
 	}
 
 	if params.EncodingFormat != "" {
@@ -58,18 +85,16 @@ func convertEmbeddingParams(params providers.EmbeddingParams) openai.EmbeddingNe
 		req.User = openai.String(params.User)
 	}
 
-	return req
+	return req, nil
 }
 
 // convertEmbeddingResponse converts an OpenAI embedding response to provider format.
 func convertEmbeddingResponse(resp *openai.CreateEmbeddingResponse) *providers.EmbeddingResponse {
 	data := make([]providers.EmbeddingData, 0, len(resp.Data))
 	for _, d := range resp.Data {
-		embedding := make([]float64, len(d.Embedding))
-		copy(embedding, d.Embedding)
 		data = append(data, providers.EmbeddingData{
 			Object:    objectEmbedding,
-			Embedding: embedding,
+			Embedding: slices.Clone(d.Embedding),
 			Index:     int(d.Index),
 		})
 	}

--- a/providers/openai/embeddings.go
+++ b/providers/openai/embeddings.go
@@ -1,0 +1,91 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openai/openai-go/v3"
+
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+// Embedding generates embeddings for the given input.
+func (p *CompatibleProvider) Embedding(
+	ctx context.Context,
+	params providers.EmbeddingParams,
+) (*providers.EmbeddingResponse, error) {
+	req := convertEmbeddingParams(params)
+
+	resp, err := p.client.Embeddings.New(ctx, req)
+	if err != nil {
+		return nil, p.ConvertError(err)
+	}
+
+	return convertEmbeddingResponse(resp), nil
+}
+
+// convertEmbeddingParams converts provider embedding params to OpenAI format.
+func convertEmbeddingParams(params providers.EmbeddingParams) openai.EmbeddingNewParams {
+	req := openai.EmbeddingNewParams{
+		Model: openai.EmbeddingModel(params.Model),
+	}
+
+	switch v := params.Input.(type) {
+	case string:
+		req.Input = openai.EmbeddingNewParamsInputUnion{
+			OfString: openai.String(v),
+		}
+	case []string:
+		req.Input = openai.EmbeddingNewParamsInputUnion{
+			OfArrayOfStrings: v,
+		}
+	default:
+		// For unsupported types, convert to string representation.
+		req.Input = openai.EmbeddingNewParamsInputUnion{
+			OfString: openai.String(fmt.Sprintf("%v", params.Input)),
+		}
+	}
+
+	if params.EncodingFormat != "" {
+		req.EncodingFormat = openai.EmbeddingNewParamsEncodingFormat(params.EncodingFormat)
+	}
+
+	if params.Dimensions != nil {
+		req.Dimensions = openai.Int(int64(*params.Dimensions))
+	}
+
+	if params.User != "" {
+		req.User = openai.String(params.User)
+	}
+
+	return req
+}
+
+// convertEmbeddingResponse converts an OpenAI embedding response to provider format.
+func convertEmbeddingResponse(resp *openai.CreateEmbeddingResponse) *providers.EmbeddingResponse {
+	data := make([]providers.EmbeddingData, 0, len(resp.Data))
+	for _, d := range resp.Data {
+		embedding := make([]float64, len(d.Embedding))
+		copy(embedding, d.Embedding)
+		data = append(data, providers.EmbeddingData{
+			Object:    objectEmbedding,
+			Embedding: embedding,
+			Index:     int(d.Index),
+		})
+	}
+
+	result := &providers.EmbeddingResponse{
+		Object: objectList,
+		Data:   data,
+		Model:  resp.Model,
+	}
+
+	if resp.Usage.PromptTokens > 0 || resp.Usage.TotalTokens > 0 {
+		result.Usage = &providers.EmbeddingUsage{
+			PromptTokens: int(resp.Usage.PromptTokens),
+			TotalTokens:  int(resp.Usage.TotalTokens),
+		}
+	}
+
+	return result
+}

--- a/providers/openai/embeddings_test.go
+++ b/providers/openai/embeddings_test.go
@@ -68,11 +68,7 @@ func TestEmbeddingWireInputs(t *testing.T) {
 			}))
 			t.Cleanup(server.Close)
 
-			provider, err := anyopenai.NewCompatible(anyopenai.CompatibleConfig{
-				Name:           embeddingTestProvider,
-				DefaultAPIKey:  embeddingTestAPIKey,
-				DefaultBaseURL: server.URL,
-			})
+			provider, err := anyopenai.NewCompatible(embeddingTestConfig(server.URL))
 			require.NoError(t, err)
 
 			_, err = provider.Embedding(t.Context(), testCase.params)
@@ -98,11 +94,7 @@ func TestEmbeddingResponse(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	provider, err := anyopenai.NewCompatible(anyopenai.CompatibleConfig{
-		Name:           embeddingTestProvider,
-		DefaultAPIKey:  embeddingTestAPIKey,
-		DefaultBaseURL: server.URL,
-	})
+	provider, err := anyopenai.NewCompatible(embeddingTestConfig(server.URL))
 	require.NoError(t, err)
 
 	response, err := provider.Embedding(t.Context(), providers.EmbeddingParams{
@@ -130,6 +122,27 @@ func TestEmbeddingRejectsUnsupportedInputBeforeRequest(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
+	provider, err := anyopenai.NewCompatible(embeddingTestConfig(server.URL))
+	require.NoError(t, err)
+
+	_, err = provider.Embedding(t.Context(), providers.EmbeddingParams{
+		Model: embeddingTestModel,
+		Input: map[string]string{"unsupported": "object"},
+	})
+	require.ErrorIs(t, err, errors.ErrInvalidRequest)
+	require.False(t, requested.Load())
+}
+
+func TestEmbeddingRejectsUnsupportedProviderBeforeRequest(t *testing.T) {
+	t.Parallel()
+
+	var requested atomic.Bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requested.Store(true)
+	}))
+	t.Cleanup(server.Close)
+
 	provider, err := anyopenai.NewCompatible(anyopenai.CompatibleConfig{
 		Name:           embeddingTestProvider,
 		DefaultAPIKey:  embeddingTestAPIKey,
@@ -139,9 +152,9 @@ func TestEmbeddingRejectsUnsupportedInputBeforeRequest(t *testing.T) {
 
 	_, err = provider.Embedding(t.Context(), providers.EmbeddingParams{
 		Model: embeddingTestModel,
-		Input: map[string]string{"unsupported": "object"},
+		Input: embeddingTestInput,
 	})
-	require.ErrorIs(t, err, errors.ErrInvalidRequest)
+	require.ErrorIs(t, err, errors.ErrUnsupported)
 	require.False(t, requested.Load())
 }
 
@@ -155,11 +168,7 @@ func TestEmbeddingMapsAPIError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	provider, err := anyopenai.NewCompatible(anyopenai.CompatibleConfig{
-		Name:           embeddingTestProvider,
-		DefaultAPIKey:  embeddingTestAPIKey,
-		DefaultBaseURL: server.URL,
-	})
+	provider, err := anyopenai.NewCompatible(embeddingTestConfig(server.URL))
 	require.NoError(t, err)
 
 	_, err = provider.Embedding(t.Context(), providers.EmbeddingParams{
@@ -179,11 +188,7 @@ func TestEmbeddingHonorsCancellation(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	provider, err := anyopenai.NewCompatible(anyopenai.CompatibleConfig{
-		Name:           embeddingTestProvider,
-		DefaultAPIKey:  embeddingTestAPIKey,
-		DefaultBaseURL: server.URL,
-	})
+	provider, err := anyopenai.NewCompatible(embeddingTestConfig(server.URL))
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -207,11 +212,7 @@ func TestEmbeddingHonorsTimeout(t *testing.T) {
 	t.Cleanup(server.Close)
 	t.Cleanup(func() { close(release) })
 
-	provider, err := anyopenai.NewCompatible(anyopenai.CompatibleConfig{
-		Name:           embeddingTestProvider,
-		DefaultAPIKey:  embeddingTestAPIKey,
-		DefaultBaseURL: server.URL,
-	})
+	provider, err := anyopenai.NewCompatible(embeddingTestConfig(server.URL))
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
@@ -222,4 +223,13 @@ func TestEmbeddingHonorsTimeout(t *testing.T) {
 		Input: embeddingTestInput,
 	})
 	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func embeddingTestConfig(baseURL string) anyopenai.CompatibleConfig {
+	return anyopenai.CompatibleConfig{
+		Capabilities:   providers.Capabilities{Embedding: true},
+		DefaultAPIKey:  embeddingTestAPIKey,
+		DefaultBaseURL: baseURL,
+		Name:           embeddingTestProvider,
+	}
 }

--- a/providers/openai/embeddings_test.go
+++ b/providers/openai/embeddings_test.go
@@ -1,4 +1,4 @@
-package openai
+package openai_test
 
 import (
 	"context"
@@ -13,6 +13,14 @@ import (
 
 	"github.com/mozilla-ai/any-llm-go/errors"
 	"github.com/mozilla-ai/any-llm-go/providers"
+	anyopenai "github.com/mozilla-ai/any-llm-go/providers/openai"
+)
+
+const (
+	embeddingTestAPIKey   = "test-key"
+	embeddingTestInput    = "Hello"
+	embeddingTestModel    = "text-embedding-3-small"
+	embeddingTestProvider = "openai-test"
 )
 
 func TestEmbeddingWireInputs(t *testing.T) {
@@ -24,84 +32,113 @@ func TestEmbeddingWireInputs(t *testing.T) {
 		params providers.EmbeddingParams
 		want   string
 	}{
-		{name: "string", params: providers.EmbeddingParams{Model: "text-embedding-3-small", Input: "Hello"}, want: `{"input":"Hello","model":"text-embedding-3-small"}`},
-		{name: "string array", params: providers.EmbeddingParams{Model: "text-embedding-3-small", Input: []string{"Hello", "World"}}, want: `{"input":["Hello","World"],"model":"text-embedding-3-small"}`},
-		{name: "native token array", params: providers.EmbeddingParams{Model: "text-embedding-3-small", Input: []int{1, 2}}, want: `{"input":[1,2],"model":"text-embedding-3-small"}`},
-		{name: "SDK token array", params: providers.EmbeddingParams{Model: "text-embedding-3-small", Input: []int64{1, 2}}, want: `{"input":[1,2],"model":"text-embedding-3-small"}`},
-		{name: "native token arrays", params: providers.EmbeddingParams{Model: "text-embedding-3-small", Input: [][]int{{1, 2}, {3}}}, want: `{"input":[[1,2],[3]],"model":"text-embedding-3-small"}`},
-		{name: "SDK token arrays", params: providers.EmbeddingParams{Model: "text-embedding-3-small", Input: [][]int64{{1, 2}, {3}}}, want: `{"input":[[1,2],[3]],"model":"text-embedding-3-small"}`},
+		{name: "string", params: providers.EmbeddingParams{Model: embeddingTestModel, Input: embeddingTestInput}, want: `{"input":"Hello","model":"text-embedding-3-small"}`},
+		{name: "string array", params: providers.EmbeddingParams{Model: embeddingTestModel, Input: []string{embeddingTestInput, "World"}}, want: `{"input":["Hello","World"],"model":"text-embedding-3-small"}`},
+		{name: "native token array", params: providers.EmbeddingParams{Model: embeddingTestModel, Input: []int{1, 2}}, want: `{"input":[1,2],"model":"text-embedding-3-small"}`},
+		{name: "SDK token array", params: providers.EmbeddingParams{Model: embeddingTestModel, Input: []int64{1, 2}}, want: `{"input":[1,2],"model":"text-embedding-3-small"}`},
+		{name: "native token arrays", params: providers.EmbeddingParams{Model: embeddingTestModel, Input: [][]int{{1, 2}, {3}}}, want: `{"input":[[1,2],[3]],"model":"text-embedding-3-small"}`},
+		{name: "SDK token arrays", params: providers.EmbeddingParams{Model: embeddingTestModel, Input: [][]int64{{1, 2}, {3}}}, want: `{"input":[[1,2],[3]],"model":"text-embedding-3-small"}`},
 		{
 			name: "optional parameters",
 			params: providers.EmbeddingParams{
-				Model:          "text-embedding-3-small",
-				Input:          "Hello",
+				Model:          embeddingTestModel,
+				Input:          embeddingTestInput,
 				EncodingFormat: "float",
 				Dimensions:     &dimensions,
 				User:           "test-user",
 			},
-			want: `{"dimensions":256,"encoding_format":"float","input":"Hello","model":"text-embedding-3-small","user":"test-user"}`,
+			want: `{"dimensions":256,"encoding_format":"float","input":"Hello",` +
+				`"model":"text-embedding-3-small","user":"test-user"}`,
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			var requestBody []byte
-			var requestPath string
+			var (
+				requestBody []byte
+				requestPath string
+			)
+
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 				requestPath = request.URL.Path
 				requestBody, _ = io.ReadAll(request.Body)
+
 				w.Header().Set("Content-Type", "application/json")
-				_, _ = io.WriteString(w, `{
-					"object":"list",
-					"data":[{"object":"embedding","embedding":[0.25,-0.5],"index":7,"future":"ignored"}],
-					"model":"text-embedding-3-small",
-					"usage":{"prompt_tokens":2,"total_tokens":2},
-					"future":"ignored"
-				}`)
+				_, _ = io.WriteString(w, `{"object":"list","data":[],"model":"text-embedding-3-small"}`)
 			}))
 			t.Cleanup(server.Close)
 
-			provider, err := NewCompatible(CompatibleConfig{
-				Name:           providerName,
-				DefaultAPIKey:  "test-key",
+			provider, err := anyopenai.NewCompatible(anyopenai.CompatibleConfig{
+				Name:           embeddingTestProvider,
+				DefaultAPIKey:  embeddingTestAPIKey,
 				DefaultBaseURL: server.URL,
 			})
 			require.NoError(t, err)
 
-			response, err := provider.Embedding(t.Context(), testCase.params)
+			_, err = provider.Embedding(t.Context(), testCase.params)
 			require.NoError(t, err)
 			require.Equal(t, "/embeddings", requestPath)
 			require.JSONEq(t, testCase.want, string(requestBody))
-			require.Equal(t, "list", response.Object)
-			require.Equal(t, "text-embedding-3-small", response.Model)
-			require.Equal(t, []providers.EmbeddingData{{
-				Object:    "embedding",
-				Embedding: []float64{0.25, -0.5},
-				Index:     7,
-			}}, response.Data)
-			require.Equal(t, &providers.EmbeddingUsage{PromptTokens: 2, TotalTokens: 2}, response.Usage)
 		})
 	}
+}
+
+func TestEmbeddingResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"object":"list",
+			"data":[{"object":"embedding","embedding":[0.25,-0.5],"index":7,"future":"ignored"}],
+			"model":"text-embedding-3-small",
+			"usage":{"prompt_tokens":2,"total_tokens":2},
+			"future":"ignored"
+		}`)
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := anyopenai.NewCompatible(anyopenai.CompatibleConfig{
+		Name:           embeddingTestProvider,
+		DefaultAPIKey:  embeddingTestAPIKey,
+		DefaultBaseURL: server.URL,
+	})
+	require.NoError(t, err)
+
+	response, err := provider.Embedding(t.Context(), providers.EmbeddingParams{
+		Model: embeddingTestModel,
+		Input: embeddingTestInput,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "list", response.Object)
+	require.Equal(t, embeddingTestModel, response.Model)
+	require.Equal(t, []providers.EmbeddingData{{
+		Object:    "embedding",
+		Embedding: []float64{0.25, -0.5},
+		Index:     7,
+	}}, response.Data)
+	require.Equal(t, &providers.EmbeddingUsage{PromptTokens: 2, TotalTokens: 2}, response.Usage)
 }
 
 func TestEmbeddingRejectsUnsupportedInputBeforeRequest(t *testing.T) {
 	t.Parallel()
 
 	var requested atomic.Bool
+
 	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		requested.Store(true)
 	}))
 	t.Cleanup(server.Close)
 
-	provider, err := NewCompatible(CompatibleConfig{
-		Name:           providerName,
-		DefaultAPIKey:  "test-key",
+	provider, err := anyopenai.NewCompatible(anyopenai.CompatibleConfig{
+		Name:           embeddingTestProvider,
+		DefaultAPIKey:  embeddingTestAPIKey,
 		DefaultBaseURL: server.URL,
 	})
 	require.NoError(t, err)
 
 	_, err = provider.Embedding(t.Context(), providers.EmbeddingParams{
-		Model: "text-embedding-3-small",
+		Model: embeddingTestModel,
 		Input: map[string]string{"unsupported": "object"},
 	})
 	require.ErrorIs(t, err, errors.ErrInvalidRequest)
@@ -118,16 +155,16 @@ func TestEmbeddingMapsAPIError(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	provider, err := NewCompatible(CompatibleConfig{
-		Name:           providerName,
-		DefaultAPIKey:  "test-key",
+	provider, err := anyopenai.NewCompatible(anyopenai.CompatibleConfig{
+		Name:           embeddingTestProvider,
+		DefaultAPIKey:  embeddingTestAPIKey,
 		DefaultBaseURL: server.URL,
 	})
 	require.NoError(t, err)
 
 	_, err = provider.Embedding(t.Context(), providers.EmbeddingParams{
-		Model: "text-embedding-3-small",
-		Input: "Hello",
+		Model: embeddingTestModel,
+		Input: embeddingTestInput,
 	})
 	require.ErrorIs(t, err, errors.ErrAuthentication)
 }
@@ -136,23 +173,25 @@ func TestEmbeddingHonorsCancellation(t *testing.T) {
 	t.Parallel()
 
 	var requested atomic.Bool
+
 	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		requested.Store(true)
 	}))
 	t.Cleanup(server.Close)
 
-	provider, err := NewCompatible(CompatibleConfig{
-		Name:           providerName,
-		DefaultAPIKey:  "test-key",
+	provider, err := anyopenai.NewCompatible(anyopenai.CompatibleConfig{
+		Name:           embeddingTestProvider,
+		DefaultAPIKey:  embeddingTestAPIKey,
 		DefaultBaseURL: server.URL,
 	})
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
+
 	_, err = provider.Embedding(ctx, providers.EmbeddingParams{
-		Model: "text-embedding-3-small",
-		Input: "Hello",
+		Model: embeddingTestModel,
+		Input: embeddingTestInput,
 	})
 	require.ErrorIs(t, err, context.Canceled)
 	require.False(t, requested.Load())
@@ -168,18 +207,19 @@ func TestEmbeddingHonorsTimeout(t *testing.T) {
 	t.Cleanup(server.Close)
 	t.Cleanup(func() { close(release) })
 
-	provider, err := NewCompatible(CompatibleConfig{
-		Name:           providerName,
-		DefaultAPIKey:  "test-key",
+	provider, err := anyopenai.NewCompatible(anyopenai.CompatibleConfig{
+		Name:           embeddingTestProvider,
+		DefaultAPIKey:  embeddingTestAPIKey,
 		DefaultBaseURL: server.URL,
 	})
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	t.Cleanup(cancel)
+
 	_, err = provider.Embedding(ctx, providers.EmbeddingParams{
-		Model: "text-embedding-3-small",
-		Input: "Hello",
+		Model: embeddingTestModel,
+		Input: embeddingTestInput,
 	})
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }

--- a/providers/openai/embeddings_test.go
+++ b/providers/openai/embeddings_test.go
@@ -1,0 +1,185 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+func TestEmbeddingWireInputs(t *testing.T) {
+	t.Parallel()
+
+	dimensions := 256
+	for _, testCase := range []struct {
+		name   string
+		params providers.EmbeddingParams
+		want   string
+	}{
+		{name: "string", params: providers.EmbeddingParams{Model: "text-embedding-3-small", Input: "Hello"}, want: `{"input":"Hello","model":"text-embedding-3-small"}`},
+		{name: "string array", params: providers.EmbeddingParams{Model: "text-embedding-3-small", Input: []string{"Hello", "World"}}, want: `{"input":["Hello","World"],"model":"text-embedding-3-small"}`},
+		{name: "native token array", params: providers.EmbeddingParams{Model: "text-embedding-3-small", Input: []int{1, 2}}, want: `{"input":[1,2],"model":"text-embedding-3-small"}`},
+		{name: "SDK token array", params: providers.EmbeddingParams{Model: "text-embedding-3-small", Input: []int64{1, 2}}, want: `{"input":[1,2],"model":"text-embedding-3-small"}`},
+		{name: "native token arrays", params: providers.EmbeddingParams{Model: "text-embedding-3-small", Input: [][]int{{1, 2}, {3}}}, want: `{"input":[[1,2],[3]],"model":"text-embedding-3-small"}`},
+		{name: "SDK token arrays", params: providers.EmbeddingParams{Model: "text-embedding-3-small", Input: [][]int64{{1, 2}, {3}}}, want: `{"input":[[1,2],[3]],"model":"text-embedding-3-small"}`},
+		{
+			name: "optional parameters",
+			params: providers.EmbeddingParams{
+				Model:          "text-embedding-3-small",
+				Input:          "Hello",
+				EncodingFormat: "float",
+				Dimensions:     &dimensions,
+				User:           "test-user",
+			},
+			want: `{"dimensions":256,"encoding_format":"float","input":"Hello","model":"text-embedding-3-small","user":"test-user"}`,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			var requestBody []byte
+			var requestPath string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				requestPath = request.URL.Path
+				requestBody, _ = io.ReadAll(request.Body)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{
+					"object":"list",
+					"data":[{"object":"embedding","embedding":[0.25,-0.5],"index":7,"future":"ignored"}],
+					"model":"text-embedding-3-small",
+					"usage":{"prompt_tokens":2,"total_tokens":2},
+					"future":"ignored"
+				}`)
+			}))
+			t.Cleanup(server.Close)
+
+			provider, err := NewCompatible(CompatibleConfig{
+				Name:           providerName,
+				DefaultAPIKey:  "test-key",
+				DefaultBaseURL: server.URL,
+			})
+			require.NoError(t, err)
+
+			response, err := provider.Embedding(t.Context(), testCase.params)
+			require.NoError(t, err)
+			require.Equal(t, "/embeddings", requestPath)
+			require.JSONEq(t, testCase.want, string(requestBody))
+			require.Equal(t, "list", response.Object)
+			require.Equal(t, "text-embedding-3-small", response.Model)
+			require.Equal(t, []providers.EmbeddingData{{
+				Object:    "embedding",
+				Embedding: []float64{0.25, -0.5},
+				Index:     7,
+			}}, response.Data)
+			require.Equal(t, &providers.EmbeddingUsage{PromptTokens: 2, TotalTokens: 2}, response.Usage)
+		})
+	}
+}
+
+func TestEmbeddingRejectsUnsupportedInputBeforeRequest(t *testing.T) {
+	t.Parallel()
+
+	var requested atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requested.Store(true)
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewCompatible(CompatibleConfig{
+		Name:           providerName,
+		DefaultAPIKey:  "test-key",
+		DefaultBaseURL: server.URL,
+	})
+	require.NoError(t, err)
+
+	_, err = provider.Embedding(t.Context(), providers.EmbeddingParams{
+		Model: "text-embedding-3-small",
+		Input: map[string]string{"unsupported": "object"},
+	})
+	require.ErrorIs(t, err, errors.ErrInvalidRequest)
+	require.False(t, requested.Load())
+}
+
+func TestEmbeddingMapsAPIError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":{"message":"invalid key","type":"invalid_request_error"}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewCompatible(CompatibleConfig{
+		Name:           providerName,
+		DefaultAPIKey:  "test-key",
+		DefaultBaseURL: server.URL,
+	})
+	require.NoError(t, err)
+
+	_, err = provider.Embedding(t.Context(), providers.EmbeddingParams{
+		Model: "text-embedding-3-small",
+		Input: "Hello",
+	})
+	require.ErrorIs(t, err, errors.ErrAuthentication)
+}
+
+func TestEmbeddingHonorsCancellation(t *testing.T) {
+	t.Parallel()
+
+	var requested atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requested.Store(true)
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewCompatible(CompatibleConfig{
+		Name:           providerName,
+		DefaultAPIKey:  "test-key",
+		DefaultBaseURL: server.URL,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = provider.Embedding(ctx, providers.EmbeddingParams{
+		Model: "text-embedding-3-small",
+		Input: "Hello",
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, requested.Load())
+}
+
+func TestEmbeddingHonorsTimeout(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-release
+	}))
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(release) })
+
+	provider, err := NewCompatible(CompatibleConfig{
+		Name:           providerName,
+		DefaultAPIKey:  "test-key",
+		DefaultBaseURL: server.URL,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	t.Cleanup(cancel)
+	_, err = provider.Embedding(ctx, providers.EmbeddingParams{
+		Model: "text-embedding-3-small",
+		Input: "Hello",
+	})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -9,6 +9,7 @@ import (
 const (
 	defaultBaseURL = "https://api.openai.com/v1"
 	envAPIKey      = "OPENAI_API_KEY"
+	envBaseURL     = "OPENAI_BASE_URL"
 	providerName   = "openai"
 )
 
@@ -31,6 +32,7 @@ type Provider struct {
 func New(opts ...config.Option) (*Provider, error) {
 	base, err := NewCompatible(CompatibleConfig{
 		APIKeyEnvVar:   envAPIKey,
+		BaseURLEnvVar:  envBaseURL,
 		Capabilities:   capabilities(),
 		DefaultBaseURL: defaultBaseURL,
 		Name:           providerName,

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -34,6 +34,21 @@ func TestNew(t *testing.T) {
 		require.NotNil(t, provider)
 	})
 
+	t.Run("reads OPENAI_BASE_URL", func(t *testing.T) {
+		serverURL, _ := testutil.FakeCompletionServer(t)
+		t.Setenv("OPENAI_API_KEY", "env-api-key")
+		t.Setenv("OPENAI_BASE_URL", serverURL)
+
+		provider, err := New()
+		require.NoError(t, err)
+
+		_, err = provider.Completion(t.Context(), providers.CompletionParams{
+			Model:    "test-model",
+			Messages: testutil.SimpleMessages(),
+		})
+		require.NoError(t, err)
+	})
+
 	t.Run("returns error when API key is missing", func(t *testing.T) {
 		t.Setenv("OPENAI_API_KEY", "")
 

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -116,7 +116,7 @@ func TestConvertParams(t *testing.T) {
 		require.Equal(t, 0.9, req.TopP.Value)
 	})
 
-	t.Run("converts max_tokens", func(t *testing.T) {
+	t.Run("maps token limit to max_completion_tokens", func(t *testing.T) {
 		t.Parallel()
 
 		maxTokens := 100
@@ -128,6 +128,7 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
+		require.False(t, req.MaxTokens.Valid())
 		require.Equal(t, int64(100), req.MaxCompletionTokens.Value)
 	})
 
@@ -223,18 +224,43 @@ func TestConvertParams(t *testing.T) {
 		require.NotNil(t, req.ResponseFormat)
 	})
 
-	t.Run("converts reasoning_effort", func(t *testing.T) {
+	t.Run("preserves current reasoning_effort values", func(t *testing.T) {
+		t.Parallel()
+
+		efforts := []providers.ReasoningEffort{
+			providers.ReasoningEffortNone,
+			providers.ReasoningEffortMinimal,
+			providers.ReasoningEffortLow,
+			providers.ReasoningEffortMedium,
+			providers.ReasoningEffortHigh,
+			providers.ReasoningEffortXHigh,
+			providers.ReasoningEffortMax,
+		}
+		for _, effort := range efforts {
+			params := providers.CompletionParams{
+				Model:           "test-model",
+				Messages:        testutil.SimpleMessages(),
+				ReasoningEffort: effort,
+			}
+
+			req := convertParams(params)
+
+			require.Equal(t, string(effort), string(req.ReasoningEffort))
+		}
+	})
+
+	t.Run("omits automatic reasoning_effort sentinel", func(t *testing.T) {
 		t.Parallel()
 
 		params := providers.CompletionParams{
-			Model:           "o1-mini",
+			Model:           "test-model",
 			Messages:        testutil.SimpleMessages(),
-			ReasoningEffort: providers.ReasoningEffortHigh,
+			ReasoningEffort: providers.ReasoningEffortAuto,
 		}
 
 		req := convertParams(params)
 
-		require.NotNil(t, req.ReasoningEffort)
+		require.Empty(t, req.ReasoningEffort)
 	})
 
 	t.Run("converts seed", func(t *testing.T) {
@@ -487,10 +513,33 @@ func TestCompletionSendsMaxCompletionTokensOnWire(t *testing.T) {
 
 	body := capturedBody()
 
-	// OpenAI requires max_completion_tokens (not max_tokens) for current models.
 	require.Contains(t, body, "max_completion_tokens")
 	require.NotContains(t, body, "max_tokens")
 	require.Equal(t, float64(1024), body["max_completion_tokens"])
+}
+
+func TestCompletionPreservesReasoningEffortOnWire(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeCompletionServer(t)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	params := providers.CompletionParams{
+		Model:           "test-model",
+		Messages:        testutil.SimpleMessages(),
+		ReasoningEffort: providers.ReasoningEffortNone,
+	}
+
+	_, err = provider.Completion(context.Background(), params)
+	require.NoError(t, err)
+
+	body := capturedBody()
+	require.Equal(t, "none", body["reasoning_effort"])
 }
 
 func TestCompletionStreamSendsMaxCompletionTokensOnWire(t *testing.T) {
@@ -520,7 +569,6 @@ func TestCompletionStreamSendsMaxCompletionTokensOnWire(t *testing.T) {
 
 	body := capturedBody()
 
-	// OpenAI requires max_completion_tokens (not max_tokens) for current models.
 	require.Contains(t, body, "max_completion_tokens")
 	require.NotContains(t, body, "max_tokens")
 	require.Equal(t, float64(1024), body["max_completion_tokens"])

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/any-llm-go/config"
@@ -362,11 +362,16 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 1)
-		require.Equal(t, "get_weather", result[0].Function.Name)
-		require.Equal(t, "Get the current weather for a location.", result[0].Function.Description.Value)
+		require.NotNil(t, result[0].OfFunction)
+		require.Equal(t, "get_weather", result[0].OfFunction.Function.Name)
+		require.Equal(
+			t,
+			"Get the current weather for a location.",
+			result[0].OfFunction.Function.Description.Value,
+		)
 
 		// FunctionParameters is map[string]any - access directly.
-		params := result[0].Function.Parameters
+		params := result[0].OfFunction.Function.Parameters
 		require.Equal(t, "object", params["type"])
 
 		props, ok := params["properties"].(map[string]any)
@@ -391,10 +396,11 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 1)
-		require.Equal(t, "calculate", result[0].Function.Name)
+		require.NotNil(t, result[0].OfFunction)
+		require.Equal(t, "calculate", result[0].OfFunction.Function.Name)
 
 		// FunctionParameters is map[string]any - access directly.
-		params := result[0].Function.Parameters
+		params := result[0].OfFunction.Function.Parameters
 
 		props, ok := params["properties"].(map[string]any)
 		require.True(t, ok)
@@ -436,8 +442,10 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 2)
-		require.Equal(t, "get_weather", result[0].Function.Name)
-		require.Equal(t, "get_current_date", result[1].Function.Name)
+		require.NotNil(t, result[0].OfFunction)
+		require.NotNil(t, result[1].OfFunction)
+		require.Equal(t, "get_weather", result[0].OfFunction.Function.Name)
+		require.Equal(t, "get_current_date", result[1].OfFunction.Function.Name)
 	})
 }
 

--- a/providers/types.go
+++ b/providers/types.go
@@ -16,11 +16,14 @@ const (
 
 // Reasoning effort levels for extended thinking.
 const (
-	ReasoningEffortAuto   ReasoningEffort = "auto"
-	ReasoningEffortHigh   ReasoningEffort = "high"
-	ReasoningEffortLow    ReasoningEffort = "low"
-	ReasoningEffortMedium ReasoningEffort = "medium"
-	ReasoningEffortNone   ReasoningEffort = "none"
+	ReasoningEffortAuto    ReasoningEffort = "auto"
+	ReasoningEffortHigh    ReasoningEffort = "high"
+	ReasoningEffortLow     ReasoningEffort = "low"
+	ReasoningEffortMax     ReasoningEffort = "max"
+	ReasoningEffortMedium  ReasoningEffort = "medium"
+	ReasoningEffortMinimal ReasoningEffort = "minimal"
+	ReasoningEffortNone    ReasoningEffort = "none"
+	ReasoningEffortXHigh   ReasoningEffort = "xhigh"
 )
 
 // Message roles.
@@ -95,7 +98,7 @@ type Capabilities struct {
 	CompletionImage     bool
 	CompletionPDF       bool
 	CompletionReasoning bool
-	CompletionStreaming  bool
+	CompletionStreaming bool
 	CompletionTools     bool
 	Embedding           bool
 	ListModels          bool


### PR DESCRIPTION
## Summary

- Preserve the four documented embedding wire shapes: string, string array, token array, and token-array batch.
- Accept native Go `int` slices and official SDK `int64` slices with identical JSON.
- Reject every other dynamic input with a typed invalid-request error before transport.
- Enforce `Capabilities().Embedding` before validation or transport, preventing direct calls on providers such as DeepSeek and Groq from reaching undocumented `/embeddings` endpoints.
- Move embedding mapping out of the shared Chat transport file.

This PR does not duplicate OpenAI's model-specific token and batch-size limits in a compatible transport shared by providers with different limits.

## Review boundary

GitHub cannot base this upstream PR on a contributor-fork branch, so the branch includes the four commits from #141 at `d6327122b119c1854a48f399956c68fa84354512`. Review these five commits after that dependency:

- `9d092b7c70782824ac34ca59d145f3f23e2a73cb` moves the existing embedding path without changing behavior.
- `501d33c8713a3a6090609a94791af420489a46ec` implements the documented input union.
- `91b2d85d19492c160ae5be56ff565949d207b2b4` adds literal HTTP wire and error contracts.
- `51bbed7b4c3a1683177220531950cc5b2b9b6c79` separates public API request, response, error, cancellation, and timeout tests.
- `5d7afe35c85ba8f7a0203ee96e276cfddfdcdc28` enforces the advertised embedding capability before transport.

The owning range changes four files with 355 additions and 139 deletions. Production code grows by 39 net lines; 235 test lines cover request, response, and failure contracts.

## Sources and dependency decision

- Current OpenAI create contract: <https://developers.openai.com/api/reference/resources/embeddings/methods/create>
- Latest official Go SDK release, v3.55.0: <https://github.com/openai/openai-go/blob/20816bd16e21a0b8c57fdd43256187028c979362/embedding.go#L170-L186>
- Current DeepSeek public API catalog: <https://api-docs.deepseek.com/sitemap.xml>
- Current Groq API catalog: <https://console.groq.com/docs/api-reference>

The four OpenAI input variants and the optional fields used here have existed since openai-go v3.0.0. #141 already uses v3.42.0, so this PR does not upgrade the SDK. Tests also pass with a temporary module graph using v3.55.0.

DeepSeek's current sitemap and Groq's current API reference do not list embeddings. The capability guard expresses the documented support surface rather than assuming that an undocumented endpoint cannot exist.

`EmbeddingParams.Input` remains `any` because it is an existing cross-provider public union: OpenAI, Gemini, Ollama, Gateway, and local providers accept different concrete sets, while Ollama's SDK accepts a dynamic input. Closing the public type here would break callers. This PR instead closes the OpenAI boundary to six explicit Go types.

The official openai-go test only checks that one optional-parameter request returns no error. Its code and fixtures were not copied. This PR uses independently written literal HTTP contracts, so no third-party notice is required.

## Exact-head evidence

Dependency head: #141 `d6327122b119c1854a48f399956c68fa84354512`, based on upstream `ef366a4218ed67ad82156742c985829fc389df3d`

Exact head: `5d7afe35c85ba8f7a0203ee96e276cfddfdcdc28`

```text
go test ./... -count=1                                                               PASS
CGO_ENABLED=1 go test -race ./providers/openai ./providers/deepseek ./providers/groq \
  ./providers/gateway ./providers/mistral -count=1                                  PASS
go mod tidy -diff                                                                    no diff
go mod verify                                                                        all modules verified
golangci-lint run --fix=false ./...                                                  0 issues
golangci-lint fmt --diff ./...                                                       no diff
temporary module graph with openai-go/v3 v3.55.0, five compatible consumers         PASS
git diff --check                                                                     PASS
```

All five owning commits have valid local SSH signatures. All 112 nondeprecated GolangCI-Lint rules were also run against the owning range. The 32 reported items are policy conflicts: 23 generated/optional struct `exhaustruct_v5`, seven `depguard` findings without an allow policy, one dynamic-detail `err113`, and one direct six-variant input switch `cyclop`. No suppression was added.

No `OPENAI_API_KEY` is available, so live acceptance of the four inputs and service-side limits remains unverified. The PR remains Draft pending exact-head CodeRabbit review and later aggregate verification.
