### PR TITLE
feat(types): retain provider reasoning wire data

### DIFF
--- a/providers/types.go
+++ b/providers/types.go
@@ -320,6 +320,10 @@ type ModelsResponse struct {
 // Reasoning represents extended thinking/reasoning content.
 type Reasoning struct {
 	Content string `json:"content,omitempty"`
+	// ProviderRaw retains provider-native blocks that Content cannot represent.
+	// Mistral requires complete assistant content for multi-turn reasoning replay:
+	// https://docs.mistral.ai/studio-api/conversations/reasoning
+	ProviderRaw json.RawMessage `json:"provider_raw,omitempty"`
 }
 
 // ResponseFormat specifies the format of the response.

--- a/providers/types_test.go
+++ b/providers/types_test.go
@@ -88,3 +88,27 @@ func TestToolCallExtraExcludedFromJSON(t *testing.T) {
 	require.Equal(t, "call_123", decoded["id"])
 	require.Equal(t, "function", decoded["type"])
 }
+
+func TestReasoningProviderRawRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	reasoning := Reasoning{
+		Content: "step one",
+		ProviderRaw: json.RawMessage(
+			`[{"type":"thinking","thinking":[{"type":"text","text":"step one"}],"signature":"sig-abc"}]`,
+		),
+	}
+
+	data, err := json.Marshal(reasoning)
+	require.NoError(t, err)
+
+	var decoded Reasoning
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, reasoning, decoded)
+
+	var empty Reasoning
+
+	emptyData, err := json.Marshal(empty)
+	require.NoError(t, err)
+	require.JSONEq(t, `{}`, string(emptyData))
+}


### PR DESCRIPTION
## Summary

- Add `Reasoning.ProviderRaw` as a typed `json.RawMessage` boundary.
- Preserve provider-native reasoning blocks that `Reasoning.Content` cannot represent.
- Cover present and omitted JSON behavior without adding a metadata map.

This PR changes two files and adds 28 lines in one signed responsibility commit. It does not parse provider responses, change transport, or upgrade dependencies.

## Why the field is needed

Mistral requires callers to replay complete assistant content, including the full `ThinkChunk` list. Signatures, closure state, references, tool references, explicit nulls, and unknown top-level content chunks cannot be represented by the portable text projection alone.

A Mistral-private type cannot cross the public `Message.Reasoning` boundary that callers submit on the next turn. An open `map[string]any` would expose a broader untyped API. `json.RawMessage` is the smaller boundary and follows the existing `ProviderRaw` pattern used by normalized results elsewhere in this repository.

## Current official sources

The current latest releases were queried again on 2026-09-03:

- Mistral reasoning and multi-turn replay: <https://docs.mistral.ai/studio-api/conversations/reasoning>
- Official Python SDK [v2.9.4](https://github.com/mistralai/client-python/tree/df37126528859588193a9e954e820b12861ad106)
- Official TypeScript SDK [v2.6.4](https://github.com/mistralai/client-ts/tree/7ed5ba7825ed295f1962822f8eb586eb44a3c051)

The two SDK repositories and any-llm-go use Apache-2.0. No SDK or Fantasy code, fixture, control flow, or assertion sequence was copied.

## Ablation result

The rejected alternatives were a provider-private replay type and a public metadata map. The private type cannot support caller-visible multi-turn replay. The map adds an untyped surface that this use case does not need. The remaining field is required by the dependent Mistral response/replay PR.

The previous head also formatted an unrelated pre-existing whitespace issue in `Capabilities`. The rebuilt commit removes that unrelated diff.

## Exact-head evidence

Base: upstream `ef366a4218ed67ad82156742c985829fc389df3d`

Exact head: `2debe5f8007ba3ef51be3398b4632008f2607623`

```text
go test ./providers -count=1                         PASS
CGO_ENABLED=1 go test -race ./providers -count=1    PASS
go test ./... -count=1                               PASS
go mod tidy -diff                                     no diff
go mod verify                                         all modules verified
golangci-lint run --new-from-rev=upstream/main ./...  0 issues
git diff --check                                      PASS
```

All 112 stable GolangCI-Lint rules were also run against the owning diff. The only report was `tagliatelle` requesting `providerRaw`; this repository's public JSON contract consistently uses snake_case and already exposes other `provider_raw` fields, so no code change or suppression was added.

Provider-specific replay and live Mistral validation remain outside this PR. The broader provider alignment task is incomplete, and this PR remains Draft pending exact-head CodeRabbit review.
