### PR TITLE
fix(anthropic): preserve mid-conversation system scope

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -481,13 +481,29 @@ func convertMessages(messages []providers.Message) ([]anthropic.MessageParam, st
 	result := make([]anthropic.MessageParam, 0, len(messages))
 	var systemParts []string
 
+	seenConversation := false
+
 	for _, msg := range messages {
 		if msg.Role == providers.RoleSystem {
-			systemParts = append(systemParts, msg.ContentString())
+			if !seenConversation {
+				systemParts = append(systemParts, msg.ContentString())
+
+				continue
+			}
+			// Stable mid-conversation system messages are positional. Moving one to
+			// the top-level system field changes which later messages it governs.
+			// https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages
+			result = append(result, anthropic.MessageParam{
+				Role: anthropic.MessageParamRoleSystem,
+				Content: []anthropic.ContentBlockParamUnion{
+					anthropic.NewTextBlock(msg.ContentString()),
+				},
+			})
 			continue
 		}
 
 		if converted := convertMessage(msg); converted != nil {
+			seenConversation = true
 			result = append(result, *converted)
 		}
 	}

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -66,6 +66,32 @@ func TestCapabilities(t *testing.T) {
 	require.False(t, caps.ListModels)
 }
 
+func TestConvertParamsPreservesSystemMessageScope(t *testing.T) {
+	t.Parallel()
+
+	request, err := new(Provider).convertParams(providers.CompletionParams{
+		Model: "claude-opus-5",
+		Messages: []providers.Message{
+			{Role: providers.RoleSystem, Content: "global instruction"},
+			{Role: providers.RoleUser, Content: "start"},
+			{Role: providers.RoleSystem, Content: "instruction from this point"},
+		},
+	})
+	require.NoError(t, err)
+
+	body, err := json.Marshal(request)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"model": "claude-opus-5",
+		"max_tokens": 4096,
+		"system": [{"type": "text", "text": "global instruction"}],
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "start"}]},
+			{"role": "system", "content": [{"type": "text", "text": "instruction from this point"}]}
+		]
+	}`, string(body))
+}
+
 func TestConvertMessages(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Anthropic's stable Messages API preserves mid-conversation system messages in the message sequence. The adapter previously concatenated every system message into the top-level `system` field, which widened the scope of later instructions.

Official contract: https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages

The existing minimum Anthropic Go SDK already exposes `MessageParamRoleSystem`; the same wire golden also passes with the latest formal SDK release, v1.69.0. No dependency upgrade is required.

## Changes

- Keep leading system messages in the top-level `system` field.
- Serialize system messages after conversation content at their original positions.
- Add a request JSON golden that distinguishes top-level and positional system instructions.

Owning diff: 2 files, +43/-1. This PR contains one signed commit and no dependency or public API changes.

## Testing

- RED proof: the new focused test fails on upstream `ef366a4218ed67ad82156742c985829fc389df3d` because the later instruction is concatenated into the top-level field.
- `go test ./... -count=1`
- `CGO_ENABLED=1 go test -race ./providers/anthropic -count=1`
- `go mod tidy -diff`
- `go mod verify`
- `golangci-lint run --fix=false ./providers/anthropic/...`
- Anthropic Go SDK v1.69.0 overlay: `go test -modfile=/tmp/any-llm-go-anthropic-system-v169.mod ./providers/anthropic -count=1`
- 112 stable GolangCI linters: no production finding; four `exhaustruct_v5` reports are optional-field test fixtures where explicit zero values would obscure the presence semantics under test.

## Checklist

- [x] Linting passes for the affected package
- [x] Tests pass locally
- [x] Documentation source is linked from the behavior-sensitive code
- [x] No breaking changes

## AI usage

Implemented and verified with Amp using GPT-5.6 Sol X-HIGH.