### PR TITLE
fix(anthropic): reject lossy image requests

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -167,6 +167,20 @@ func (p *Provider) Completion(
 
 // convertParams converts providers.CompletionParams to Anthropic request parameters.
 func (p *Provider) convertParams(params providers.CompletionParams) (anthropic.MessageNewParams, error) {
+	for _, message := range params.Messages {
+		if message.Role != providers.RoleUser || !message.IsMultiModal() {
+			continue
+		}
+
+		for _, part := range message.ContentParts() {
+			if part.Type == "image_url" {
+				err := validateImagePart(part.ImageURL)
+				if err != nil {
+					return anthropic.MessageNewParams{}, err
+				}
+			}
+		}
+	}
 	messages, system := convertMessages(params.Messages)
 
 	maxTokens := int64(defaultMaxTokens)
@@ -219,6 +233,40 @@ func (p *Provider) convertParams(params providers.CompletionParams) (anthropic.M
 	applyThinking(&req, params.ReasoningEffort, maxTokens)
 
 	return req, nil
+}
+
+func validateImagePart(image *providers.ImageURL) error {
+	if image == nil {
+		return errors.NewInvalidRequestError(providerName, fmt.Errorf("image content is missing image_url"))
+	}
+
+	if image.Detail != "" {
+		// Anthropic image blocks have no OpenAI-style detail control.
+		// https://platform.claude.com/docs/en/api/messages/create#body-messages-content-source
+		return errors.NewUnsupportedParamError(providerName, "image_url.detail")
+	}
+
+	if !strings.HasPrefix(image.URL, "data:") {
+		return nil
+	}
+
+	header, data, ok := strings.Cut(image.URL, ",")
+	if !ok || data == "" || !strings.HasSuffix(header, ";base64") {
+		return errors.NewInvalidRequestError(providerName, fmt.Errorf("invalid base64 image data URL"))
+	}
+
+	mediaType := strings.TrimSuffix(strings.TrimPrefix(header, "data:"), ";base64")
+	// Anthropic accepts only these four media types for base64 image blocks.
+	// https://platform.claude.com/docs/en/build-with-claude/vision#supported-formats
+	switch mediaType {
+	case "image/jpeg", "image/png", "image/gif", "image/webp":
+		return nil
+	default:
+		return errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("unsupported Anthropic image media type %q", mediaType),
+		)
+	}
 }
 
 // CompletionStream performs a streaming chat completion request.

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	stderrors "errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -16,6 +18,11 @@ import (
 	"github.com/mozilla-ai/any-llm-go/errors"
 	"github.com/mozilla-ai/any-llm-go/internal/testutil"
 	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+const (
+	imagePartType = "image_url"
+	testImageURL  = "https://example.com/image.png"
 )
 
 func TestNew(t *testing.T) {
@@ -64,6 +71,134 @@ func TestCapabilities(t *testing.T) {
 	require.True(t, caps.CompletionTools)
 	require.False(t, caps.Embedding) // Anthropic doesn't support embeddings.
 	require.False(t, caps.ListModels)
+}
+
+func TestCompletionSerializesSupportedImageSources(t *testing.T) {
+	t.Parallel()
+
+	body, err := captureAnthropicRequest(t, []providers.Message{{
+		Role: providers.RoleUser,
+		Content: []providers.ContentPart{
+			{Type: imagePartType, ImageURL: new(providers.ImageURL{URL: testImageURL})},
+			{Type: imagePartType, ImageURL: new(providers.ImageURL{URL: "data:image/png;base64,aGVsbG8="})},
+			{Type: "text", Text: "Compare the images."},
+		},
+	}})
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"model": "claude-opus-5",
+		"max_tokens": 4096,
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "image", "source": {"type": "url", "url": "https://example.com/image.png"}},
+				{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "aGVsbG8="}},
+				{"type": "text", "text": "Compare the images."}
+			]
+		}]
+	}`, string(body))
+}
+
+func TestCompletionRejectsInvalidImageContent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		image    *providers.ImageURL
+		sentinel error
+	}{
+		{
+			name:     "image without source",
+			image:    nil,
+			sentinel: errors.ErrInvalidRequest,
+		},
+		{
+			name:     "image detail",
+			image:    new(providers.ImageURL{URL: testImageURL, Detail: "high"}),
+			sentinel: errors.ErrUnsupportedParam,
+		},
+		{
+			name:     "data URL without base64 marker",
+			image:    new(providers.ImageURL{URL: "data:image/png,aGVsbG8="}),
+			sentinel: errors.ErrInvalidRequest,
+		},
+		{
+			name:     "empty base64 data",
+			image:    new(providers.ImageURL{URL: "data:image/png;base64,"}),
+			sentinel: errors.ErrInvalidRequest,
+		},
+		{
+			name:     "unsupported image media type",
+			image:    new(providers.ImageURL{URL: "data:image/svg+xml;base64,PHN2Zy8+"}),
+			sentinel: errors.ErrInvalidRequest,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := captureAnthropicRequest(t, []providers.Message{{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{{
+					Type:     imagePartType,
+					ImageURL: testCase.image,
+				}},
+			}})
+			require.ErrorIs(t, err, testCase.sentinel)
+		})
+	}
+}
+
+func captureAnthropicRequest(t *testing.T, messages []providers.Message) ([]byte, error) {
+	t.Helper()
+
+	requestBody := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			http.Error(writer, "bad request", http.StatusBadRequest)
+
+			return
+		}
+
+		requestBody <- body
+
+		writer.Header().Set("Content-Type", "application/json")
+
+		_, err = io.WriteString(writer, `{
+			"id":"msg_test",
+			"type":"message",
+			"role":"assistant",
+			"model":"claude-opus-5",
+			"content":[{"type":"text","text":"ok"}],
+			"stop_reason":"end_turn",
+			"stop_sequence":null,
+			"usage":{"input_tokens":1,"output_tokens":1}
+		}`)
+		if err != nil {
+			t.Errorf("write response body: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(server.URL),
+	)
+	if err != nil {
+		return nil, err
+	}
+	_, err = provider.Completion(t.Context(), providers.CompletionParams{
+		Model:    "claude-opus-5",
+		Messages: messages,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return <-requestBody, nil
 }
 
 func TestConvertMessages(t *testing.T) {


### PR DESCRIPTION
## Summary

Reject Anthropic image inputs that the provider cannot serialize without changing or dropping caller intent. URL and base64 image requests keep their existing public shape.

Official contract:
- Anthropic Vision documents URL, base64, and Files API image sources and limits base64 media types to JPEG, PNG, GIF, and WebP: https://platform.claude.com/docs/en/build-with-claude/vision
- The Message API has no OpenAI-style `image_url.detail` field: https://platform.claude.com/docs/en/api/messages/create
- The current formal Go SDK is v1.69.0 at `6298207eac7ff589e7fcc8a78f6c034ab09de47f`; its generated image union confirms URL, base64, and file sources: https://github.com/anthropics/anthropic-sdk-go/blob/6298207eac7ff589e7fcc8a78f6c034ab09de47f/message.go#L4907-L4954

## Changes

- Validate user image parts before request conversion.
- Return typed errors for missing image sources, malformed or empty data URLs, unsupported base64 media types, and unsupported `detail`.
- Add an HTTP-wire golden that exercises the real Anthropic SDK request serializer.

This PR does not add Files API image IDs because the normalized `Message` type cannot express them yet. It does not change tool results, assistant content, thinking replay, response parsing, streaming, Files operations, or Batch.

## Dependency

No SDK upgrade is required. The current minimum dependency, `anthropic-sdk-go` v1.61.0, already exposes the stable URL and base64 request types. The same tests pass with current v1.69.0 overlaid.

## Testing

The regression test was first applied without the implementation. All five invalid-input cases failed because the old provider returned success.

- `go test ./... -count=1`
- `CGO_ENABLED=1 go test -race ./providers/anthropic -count=1`
- `go mod tidy -diff`
- `go mod verify`
- `golangci-lint run --fix=false ./providers/anthropic`
- current SDK overlay: `go get github.com/anthropics/anthropic-sdk-go@v1.69.0 && go test ./providers/anthropic -count=1`
- all 112 nondeprecated GolangCI linters on this owning range

Configured lint reports 0 issues. The raw all-stable scan leaves 3 `err113` reports inside the repository's typed `InvalidRequestError` boundary and 10 `exhaustruct_v5` reports for deliberately sparse optional request fixtures. Adding package sentinels or filling unrelated optional fields would enlarge and weaken the tests, so no suppression was added.

No Anthropic or Fantasy code, tests, fixtures, control flow, or assertion sequences were copied. The wire expectations were independently written from Anthropic's public REST documentation. Anthropic's SDK is MIT licensed; Fantasy is Apache-2.0 with NOTICE and was used only to compare package boundaries.

## Checklist

- [x] Linting passes (`make lint` equivalent command above)
- [x] Tests pass locally (`make test` equivalent command above)
- [x] Documentation updated in the PR body and source comments
- [x] No breaking changes, unsupported inputs now fail instead of being silently changed

AI assistance: GPT-5.6 Sol X-HIGH was used for implementation and review.