### PR TITLE
fix(anthropic): preserve tool input JSON

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -167,6 +167,20 @@ func (p *Provider) Completion(
 
 // convertParams converts providers.CompletionParams to Anthropic request parameters.
 func (p *Provider) convertParams(params providers.CompletionParams) (anthropic.MessageNewParams, error) {
+	for _, message := range params.Messages {
+		if message.Role != providers.RoleAssistant {
+			continue
+		}
+
+		for _, toolCall := range message.ToolCalls {
+			if !validToolInput(toolCall.Function.Arguments) {
+				return anthropic.MessageNewParams{}, errors.NewInvalidRequestError(
+					providerName,
+					stderrors.New("tool input must be a JSON object"),
+				)
+			}
+		}
+	}
 	messages, system := convertMessages(params.Messages)
 
 	maxTokens := int64(defaultMaxTokens)
@@ -219,6 +233,12 @@ func (p *Provider) convertParams(params providers.CompletionParams) (anthropic.M
 	applyThinking(&req, params.ReasoningEffort, maxTokens)
 
 	return req, nil
+}
+
+func validToolInput(arguments string) bool {
+	var input map[string]json.RawMessage
+
+	return json.Unmarshal([]byte(arguments), &input) == nil && input != nil
 }
 
 // CompletionStream performs a streaming chat completion request.
@@ -613,16 +633,16 @@ func buildToolParam(tool providers.Tool, schema anthropic.ToolInputSchemaParam) 
 }
 
 // convertToolCall converts a tool call to Anthropic content block format.
-func convertToolCall(tc providers.ToolCall) anthropic.ContentBlockParamUnion {
-	var input map[string]any
-	_ = json.Unmarshal([]byte(tc.Function.Arguments), &input) // Ignore error: use nil on failure.
-
+func convertToolCall(toolCall providers.ToolCall) anthropic.ContentBlockParamUnion {
 	return anthropic.ContentBlockParamUnion{
 		OfToolUse: &anthropic.ToolUseBlockParam{
-			Type:  "tool_use",
-			ID:    tc.ID,
-			Name:  tc.Function.Name,
-			Input: input,
+			Type: "tool_use",
+			ID:   toolCall.ID,
+			Name: toolCall.Function.Name,
+			// RawMessage preserves JSON integers that map[string]any would round
+			// through float64. convertParams validates the required object shape.
+			// https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls
+			Input: json.RawMessage(toolCall.Function.Arguments),
 		},
 	}
 }

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -463,65 +463,21 @@ func TestConvertMessage(t *testing.T) {
 func TestConvertToolCall(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name        string
-		toolCall    providers.ToolCall
-		expectInput bool
-	}{
-		{
-			name: "valid JSON arguments",
-			toolCall: providers.ToolCall{
-				ID:   "call_123",
-				Type: "function",
-				Function: providers.FunctionCall{
-					Name:      "get_weather",
-					Arguments: `{"location": "Paris"}`,
-				},
-			},
-			expectInput: true,
-		},
-		{
-			name: "invalid JSON arguments results in nil input",
-			toolCall: providers.ToolCall{
-				ID:   "call_456",
-				Type: "function",
-				Function: providers.FunctionCall{
-					Name:      "get_weather",
-					Arguments: `{invalid json`,
-				},
-			},
-			expectInput: false,
-		},
-		{
-			name: "empty arguments results in nil input",
-			toolCall: providers.ToolCall{
-				ID:   "call_789",
-				Type: "function",
-				Function: providers.FunctionCall{
-					Name:      "get_weather",
-					Arguments: "",
-				},
-			},
-			expectInput: false,
+	toolCall := providers.ToolCall{
+		ID:   "call_123",
+		Type: "function",
+		Function: providers.FunctionCall{
+			Name:      "get_weather",
+			Arguments: `{"location": "Paris"}`,
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			result := convertToolCall(tc.toolCall)
-			require.NotNil(t, result.OfToolUse)
-			require.Equal(t, tc.toolCall.ID, result.OfToolUse.ID)
-			require.Equal(t, tc.toolCall.Function.Name, result.OfToolUse.Name)
-			require.Equal(t, "tool_use", string(result.OfToolUse.Type))
-			if tc.expectInput {
-				require.NotNil(t, result.OfToolUse.Input)
-			} else {
-				require.Nil(t, result.OfToolUse.Input)
-			}
-		})
-	}
+	result := convertToolCall(toolCall)
+	require.NotNil(t, result.OfToolUse)
+	require.Equal(t, toolCall.ID, result.OfToolUse.ID)
+	require.Equal(t, toolCall.Function.Name, result.OfToolUse.Name)
+	require.Equal(t, "tool_use", string(result.OfToolUse.Type))
+	require.NotNil(t, result.OfToolUse.Input)
 }
 
 func TestConvertTool(t *testing.T) {

--- a/providers/anthropic/tool_input_contract_test.go
+++ b/providers/anthropic/tool_input_contract_test.go
@@ -1,0 +1,73 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+func TestConvertParamsPreservesToolInputJSON(t *testing.T) {
+	t.Parallel()
+
+	req, err := (&Provider{}).convertParams(providers.CompletionParams{
+		Model: "claude-opus-5",
+		Messages: []providers.Message{{
+			Role: providers.RoleAssistant,
+			ToolCalls: []providers.ToolCall{{
+				ID: "toolu_1",
+				Function: providers.FunctionCall{
+					Name:      "weather",
+					Arguments: `{"city":"Paris","population":9007199254740993}`,
+				},
+			}},
+		}},
+	})
+	require.NoError(t, err)
+
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var wire struct {
+		Messages []struct {
+			Content []struct {
+				Input json.RawMessage `json:"input"`
+				Type  string          `json:"type"`
+			} `json:"content"`
+		} `json:"messages"`
+	}
+	require.NoError(t, json.Unmarshal(body, &wire))
+	require.Len(t, wire.Messages, 1)
+	require.Len(t, wire.Messages[0].Content, 1)
+	require.Equal(t, "tool_use", wire.Messages[0].Content[0].Type)
+	require.JSONEq(
+		t,
+		`{"city":"Paris","population":9007199254740993}`,
+		string(wire.Messages[0].Content[0].Input),
+	)
+	require.Contains(t, string(wire.Messages[0].Content[0].Input), "9007199254740993")
+}
+
+func TestConvertParamsRejectsInvalidToolInput(t *testing.T) {
+	t.Parallel()
+
+	for _, input := range []string{"", `{"city":`, `[]`, `null`} {
+		_, err := (&Provider{}).convertParams(providers.CompletionParams{
+			Model: "claude-opus-5",
+			Messages: []providers.Message{{
+				Role: providers.RoleAssistant,
+				ToolCalls: []providers.ToolCall{{
+					ID: "toolu_1",
+					Function: providers.FunctionCall{
+						Name:      "weather",
+						Arguments: input,
+					},
+				}},
+			}},
+		})
+		require.ErrorIs(t, err, errors.ErrInvalidRequest, input)
+	}
+}


### PR DESCRIPTION
## Summary

- reject assistant tool-call arguments that are malformed JSON or are not JSON objects
- preserve valid tool input as raw JSON so integers larger than 2^53 are not rounded through `float64`
- replace the old unit test that treated malformed arguments as successful nil input with request-boundary wire and error regressions

## Contract and dependency evidence

Anthropic documents `tool_use.input` as an object matching the tool's `input_schema`:

- https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls
- https://platform.claude.com/docs/en/api/messages/create.md

The latest official Go SDK release checked for this change is `github.com/anthropics/anthropic-sdk-go` v1.69.0 at `6298207eac7ff589e7fcc8a78f6c034ab09de47f`. Its `ToolUseBlockParam.Input` remains dynamic, so this provider boundary validates the documented object shape. The repository's existing v1.61.0 dependency already exposes that field and supports the implementation. No dependency upgrade is necessary.

The official SDK is MIT licensed. This PR does not copy or adapt SDK, documentation, or Fantasy source or fixtures.

## Failure reproduced before the fix

The request-boundary tests failed on upstream `main` because invalid input returned no error and `9007199254740993` was serialized as `9007199254740992`.

## Size and scope

- production: `+28/-8`
- existing tests: `+12/-56`
- required contract tests: `+73/-0`
- total: `+113/-64`

This PR only owns assistant `tool_use.input` request serialization. Tool results, response/replay, streaming, files, Batch, and live API evidence remain incomplete. It does not claim that the Anthropic provider is fully aligned.

## Verification

- `go test ./... -count=1`
- `CGO_ENABLED=1 go test -race ./providers/anthropic -count=1`
- `go mod tidy -diff`
- `go mod verify`
- configured GolangCI-Lint 2.13.2 on `./providers/anthropic`
- temporary Anthropic Go SDK v1.69.0 overlay: provider tests and `go mod verify`

All commands passed locally. A scan using all 112 nondeprecated GolangCI-Lint 2.13.2 linters left only documented configuration or semantic false positives and added no suppressions. No Claude API credential was available, so live tool-use replay is not verified.

## Checklist

- [x] Tests added for the failure and boundary cases
- [x] Local tests and lint pass
- [x] No dependency upgrade
- [x] AI-assisted development disclosed
