### PR TITLE
fix(anthropic): preserve tool result errors

### DIFF
--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -671,8 +671,10 @@ func convertToolChoice(choice any, parallelToolCalls *bool) anthropic.ToolChoice
 
 // convertToolMessage converts a tool result message to Anthropic format.
 func convertToolMessage(msg providers.Message) *anthropic.MessageParam {
+	// Anthropic uses is_error to let Claude recover from client tool failures.
+	// https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls#handling-errors-with-is_error
 	m := anthropic.NewUserMessage(
-		anthropic.NewToolResultBlock(msg.ToolCallID, msg.ContentString(), false),
+		anthropic.NewToolResultBlock(msg.ToolCallID, msg.ContentString(), msg.ToolResultIsError),
 	)
 	return &m
 }

--- a/providers/anthropic/anthropic_test.go
+++ b/providers/anthropic/anthropic_test.go
@@ -174,6 +174,29 @@ func TestConvertMessages(t *testing.T) {
 
 		require.Len(t, result, 3)
 	})
+
+	t.Run("preserves tool result errors", func(t *testing.T) {
+		t.Parallel()
+
+		message := convertToolMessage(providers.Message{
+			Role:              providers.RoleTool,
+			Content:           "weather service unavailable",
+			ToolCallID:        "call_123",
+			ToolResultIsError: true,
+		})
+		body, err := json.Marshal(message)
+
+		require.NoError(t, err)
+		require.JSONEq(t, `{
+			"role": "user",
+			"content": [{
+				"type": "tool_result",
+				"tool_use_id": "call_123",
+				"content": [{"type": "text", "text": "weather service unavailable"}],
+				"is_error": true
+			}]
+		}`, string(body))
+	})
 }
 
 func TestConvertImagePart(t *testing.T) {

--- a/providers/types.go
+++ b/providers/types.go
@@ -95,7 +95,7 @@ type Capabilities struct {
 	CompletionImage     bool
 	CompletionPDF       bool
 	CompletionReasoning bool
-	CompletionStreaming  bool
+	CompletionStreaming bool
 	CompletionTools     bool
 	Embedding           bool
 	ListModels          bool
@@ -300,7 +300,9 @@ type Message struct {
 	Name       string     `json:"name,omitempty"`
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string     `json:"tool_call_id,omitempty"`
-	Reasoning  *Reasoning `json:"reasoning,omitempty"`
+	// ToolResultIsError tells providers that a tool message reports a failed execution.
+	ToolResultIsError bool       `json:"is_error,omitzero"`
+	Reasoning         *Reasoning `json:"reasoning,omitempty"`
 }
 
 // Model represents a model from the list models API.


### PR DESCRIPTION
## Summary

- let callers mark normalized tool messages as failed executions
- forward that typed flag to Anthropic `tool_result.is_error` instead of always sending `false`
- add a request-wire regression for the documented error result

## Contract and dependency evidence

Anthropic documents `is_error: true` as the client-tool failure signal that lets Claude recover or adjust:

- https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls#handling-errors-with-is_error
- https://platform.claude.com/docs/en/api/messages/create.md

The latest official Go SDK release checked for this change is `github.com/anthropics/anthropic-sdk-go` v1.69.0 at `6298207eac7ff589e7fcc8a78f6c034ab09de47f`. Its `ToolResultBlockParam.IsError` is optional, and `NewToolResultBlock` forwards the bool supplied by the caller. The repository's existing v1.61.0 dependency already has the same field and helper, so no dependency upgrade is needed.

The SDK is MIT licensed. This PR does not copy or adapt SDK, documentation, or Fantasy source or fixtures.

## Failure reproduced before the fix

The RED test could not construct a normalized failed tool result because `providers.Message` had no typed field. The existing provider then hard-coded `false` when calling the SDK helper.

## Size and scope

- production and required formatting: `+7/-3`
- required wire regression: `+23/-0`
- total: `+30/-3`

The one unrelated-looking whitespace deletion in `Capabilities` is the Go 1.27 formatter correcting an existing field alignment in the modified `providers/types.go` file.

This PR only owns client tool execution error signaling. Tool input, multimodal results, result ordering, response/replay, streaming, and live API evidence are separate and remain incomplete. It does not claim that the Anthropic provider is fully aligned.

## Verification

- `go test ./... -count=1`
- `CGO_ENABLED=1 go test -race ./providers ./providers/anthropic -count=1`
- `go mod tidy -diff`
- `go mod verify`
- configured GolangCI-Lint 2.13.2 on `./providers ./providers/anthropic`
- temporary Anthropic Go SDK v1.69.0 modfile overlay: provider tests and `go mod verify`
- Go 1.27 formatting and Modern Go guidance check

All commands passed locally. A scan using all 112 nondeprecated GolangCI-Lint 2.13.2 linters left one `exhaustruct_v5` result that asks the focused test to initialize unrelated optional message fields. No suppression was added. No Claude API credential was available, so live failure recovery is not verified.

## Checklist

- [x] Necessary regression added
- [x] Local tests and lint pass
- [x] No dependency upgrade
- [x] AI-assisted development disclosed
