### PR TITLE
fix(ollama): preserve reasoning request levels

### DIFF
--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -2,8 +2,10 @@
 package ollama
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	stderrors "errors"
@@ -80,7 +82,7 @@ const (
 // Content part constants.
 const (
 	contentTypeImageURL = "image_url"
-	dataImagePrefix     = "data:image/"
+	contentTypeText     = "text"
 )
 
 // Ensure Provider implements the required interfaces.
@@ -154,14 +156,17 @@ func (p *Provider) Completion(
 	ctx context.Context,
 	params providers.CompletionParams,
 ) (*providers.ChatCompletion, error) {
-	req := p.convertParams(params)
+	req, err := p.convertParams(params)
+	if err != nil {
+		return nil, err
+	}
 
 	// Disable streaming for non-stream requests.
 	stream := false
 	req.Stream = &stream
 
 	var response api.ChatResponse
-	err := p.client.Chat(ctx, req, func(resp api.ChatResponse) error {
+	err = p.client.Chat(ctx, req, func(resp api.ChatResponse) error {
 		response = resp
 		return nil
 	})
@@ -184,10 +189,14 @@ func (p *Provider) CompletionStream(
 		defer close(chunks)
 		defer close(errs)
 
-		req := p.convertParams(params)
+		req, err := p.convertParams(params)
+		if err != nil {
+			errs <- err
+			return
+		}
 		state := newStreamState()
 
-		err := p.client.Chat(ctx, req, func(resp api.ChatResponse) error {
+		err = p.client.Chat(ctx, req, func(resp api.ChatResponse) error {
 			chunk := state.handleChunk(&resp)
 			chunks <- chunk
 			return nil
@@ -273,36 +282,16 @@ func (p *Provider) Name() string {
 }
 
 // convertParams converts providers.CompletionParams to Ollama ChatRequest.
-func (p *Provider) convertParams(params providers.CompletionParams) *api.ChatRequest {
-	messages := convertMessages(params.Messages)
+func (p *Provider) convertParams(params providers.CompletionParams) (*api.ChatRequest, error) {
+	messages, err := convertMessages(params.Messages)
+	if err != nil {
+		return nil, err
+	}
 
 	req := &api.ChatRequest{
 		Model:    params.Model,
 		Messages: messages,
-		Options:  make(map[string]any),
-	}
-
-	// Set default context size.
-	req.Options[optionNumCtx] = defaultNumCtx
-
-	if params.Temperature != nil {
-		req.Options[optionTemperature] = *params.Temperature
-	}
-
-	if params.TopP != nil {
-		req.Options[optionTopP] = *params.TopP
-	}
-
-	if len(params.Stop) > 0 {
-		req.Options[optionStop] = params.Stop
-	}
-
-	if params.MaxTokens != nil {
-		req.Options[optionNumPredict] = *params.MaxTokens
-	}
-
-	if params.Seed != nil {
-		req.Options[optionSeed] = *params.Seed
+		Options:  convertOptions(params),
 	}
 
 	if len(params.Tools) > 0 {
@@ -323,7 +312,27 @@ func (p *Provider) convertParams(params providers.CompletionParams) *api.ChatReq
 		req.Think = &think
 	}
 
-	return req
+	return req, nil
+}
+
+func convertOptions(params providers.CompletionParams) map[string]any {
+	options := map[string]any{optionNumCtx: defaultNumCtx}
+	if params.Temperature != nil {
+		options[optionTemperature] = *params.Temperature
+	}
+	if params.TopP != nil {
+		options[optionTopP] = *params.TopP
+	}
+	if len(params.Stop) > 0 {
+		options[optionStop] = params.Stop
+	}
+	if params.MaxTokens != nil {
+		options[optionNumPredict] = *params.MaxTokens
+	}
+	if params.Seed != nil {
+		options[optionSeed] = *params.Seed
+	}
+	return options
 }
 
 // newStreamState creates a new stream state.
@@ -408,37 +417,6 @@ func (s *streamState) handleDone(resp *api.ChatResponse, chunk *providers.ChatCo
 	}
 }
 
-// convertAssistantMessage converts an assistant message to Ollama format.
-func convertAssistantMessage(msg providers.Message) *api.Message {
-	ollamaMsg := &api.Message{
-		Role:    msg.Role,
-		Content: msg.ContentString(),
-	}
-
-	if len(msg.ToolCalls) > 0 {
-		toolCalls := make([]api.ToolCall, 0, len(msg.ToolCalls))
-		for _, tc := range msg.ToolCalls {
-			var argsMap map[string]any
-			_ = json.Unmarshal([]byte(tc.Function.Arguments), &argsMap)
-
-			args := api.NewToolCallFunctionArguments()
-			for k, v := range argsMap {
-				args.Set(k, v)
-			}
-
-			toolCalls = append(toolCalls, api.ToolCall{
-				Function: api.ToolCallFunction{
-					Name:      tc.Function.Name,
-					Arguments: args,
-				},
-			})
-		}
-		ollamaMsg.ToolCalls = toolCalls
-	}
-
-	return ollamaMsg
-}
-
 // convertDoneReason converts Ollama done reason to OpenAI finish reason.
 func convertDoneReason(reason string) string {
 	switch reason {
@@ -478,36 +456,234 @@ func convertEmbeddingResponse(resp *api.EmbedResponse, model string) *providers.
 	}
 }
 
-// convertMessage converts a single message to Ollama format.
-func convertMessage(msg providers.Message) *api.Message {
-	switch msg.Role {
-	case providers.RoleTool:
-		return convertToolMessage(msg)
-	case providers.RoleAssistant:
-		return convertAssistantMessage(msg)
-	case providers.RoleUser:
-		return convertUserMessage(msg)
-	default:
-		// System and other roles.
-		return &api.Message{
-			Role:    msg.Role,
-			Content: msg.ContentString(),
-		}
+// convertMessage converts a single message to Ollama's documented wire model.
+func convertMessage(msg providers.Message) (*api.Message, error) {
+	if err := validateMessageMetadata(msg); err != nil {
+		return nil, err
 	}
+
+	content, images, err := convertMessageContent(msg)
+	if err != nil {
+		return nil, err
+	}
+	toolCalls, err := convertRequestToolCalls(msg.ToolCalls)
+	if err != nil {
+		return nil, err
+	}
+
+	converted := &api.Message{
+		Role:      msg.Role,
+		Content:   content,
+		Images:    images,
+		ToolCalls: toolCalls,
+	}
+	if msg.Role == providers.RoleTool {
+		converted.ToolName = msg.Name
+	}
+	if msg.Reasoning != nil {
+		converted.Thinking = msg.Reasoning.Content
+	}
+
+	return converted, nil
+}
+
+func validateMessageMetadata(msg providers.Message) error {
+	switch msg.Role {
+	case providers.RoleSystem, providers.RoleUser, providers.RoleAssistant, providers.RoleTool:
+	default:
+		return errors.NewInvalidRequestError(providerName, fmt.Errorf("unsupported message role %q", msg.Role))
+	}
+	if msg.Role != providers.RoleTool && (msg.Name != "" || msg.ToolCallID != "") {
+		return errors.NewUnsupportedParamError(providerName, "messages.name/tool_call_id")
+	}
+	if msg.Role != providers.RoleAssistant && len(msg.ToolCalls) > 0 {
+		return errors.NewUnsupportedParamError(providerName, "messages.tool_calls")
+	}
+	if msg.Role != providers.RoleAssistant && msg.Reasoning != nil {
+		return errors.NewUnsupportedParamError(providerName, "messages.reasoning")
+	}
+	return nil
+}
+
+func convertRequestToolCalls(toolCalls []providers.ToolCall) ([]api.ToolCall, error) {
+	if len(toolCalls) == 0 {
+		return nil, nil
+	}
+
+	converted := make([]api.ToolCall, 0, len(toolCalls))
+	for _, toolCall := range toolCalls {
+		if toolCall.Type != toolTypeFunction {
+			return nil, errors.NewUnsupportedParamError(providerName, "messages.tool_calls.type")
+		}
+		if toolCall.Function.Name == "" {
+			return nil, errors.NewInvalidRequestError(
+				providerName,
+				stderrors.New("tool call requires a function name"),
+			)
+		}
+		argumentsJSON := strings.TrimSpace(toolCall.Function.Arguments)
+		if !strings.HasPrefix(argumentsJSON, "{") {
+			return nil, errors.NewInvalidRequestError(
+				providerName,
+				stderrors.New("tool arguments must be a JSON object"),
+			)
+		}
+		var arguments api.ToolCallFunctionArguments
+		if err := json.Unmarshal([]byte(argumentsJSON), &arguments); err != nil {
+			return nil, errors.NewInvalidRequestError(
+				providerName,
+				fmt.Errorf("tool arguments must be a JSON object: %w", err),
+			)
+		}
+		// https://docs.ollama.com/capabilities/tool-calling includes
+		// type:"function", but Chat OpenAPI and the Go SDK type used here omit it.
+		converted = append(converted, api.ToolCall{
+			Function: api.ToolCallFunction{
+				Name:      toolCall.Function.Name,
+				Arguments: arguments,
+			},
+		})
+	}
+
+	return converted, nil
 }
 
 // convertMessages converts provider messages to Ollama format.
-func convertMessages(messages []providers.Message) []api.Message {
+func convertMessages(messages []providers.Message) ([]api.Message, error) {
 	result := make([]api.Message, 0, len(messages))
+	toolNames := make(map[string]string)
 
 	for _, msg := range messages {
-		ollamaMsg := convertMessage(msg)
-		if ollamaMsg != nil {
-			result = append(result, *ollamaMsg)
+		converted, err := convertMessage(msg)
+		if err != nil {
+			return nil, err
+		}
+		for _, toolCall := range msg.ToolCalls {
+			if toolCall.ID != "" {
+				toolNames[toolCall.ID] = toolCall.Function.Name
+			}
+		}
+		// https://docs.ollama.com/capabilities/tool-calling identifies tool
+		// results by tool_name. Resolve the normalized call ID before encoding.
+		if msg.Role == providers.RoleTool && converted.ToolName == "" {
+			converted.ToolName = toolNames[msg.ToolCallID]
+			if converted.ToolName == "" {
+				return nil, errors.NewInvalidRequestError(
+					providerName,
+					stderrors.New("tool result requires a name or a matching tool call ID"),
+				)
+			}
+		}
+		result = append(result, *converted)
+	}
+
+	return result, nil
+}
+
+func convertMessageContent(msg providers.Message) (string, []api.ImageData, error) {
+	if content, ok := msg.Content.(string); ok {
+		return content, nil, nil
+	}
+	if msg.Content == nil {
+		return "", nil, nil
+	}
+	var parts []providers.ContentPart
+	switch content := msg.Content.(type) {
+	case []providers.ContentPart:
+		parts = content
+	case []any:
+		var err error
+		parts, err = decodeContentParts(content)
+		if err != nil {
+			return "", nil, err
+		}
+	default:
+		return "", nil, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("unsupported message content type %T", msg.Content),
+		)
+	}
+
+	var content strings.Builder
+	var images []api.ImageData
+	for _, part := range parts {
+		text, image, err := convertContentPart(part)
+		if err != nil {
+			return "", nil, err
+		}
+		content.WriteString(text)
+		if image != nil {
+			images = append(images, image)
 		}
 	}
 
-	return result
+	return content.String(), images, nil
+}
+
+func decodeContentParts(rawParts []any) ([]providers.ContentPart, error) {
+	parts := make([]providers.ContentPart, 0, len(rawParts))
+	for _, rawPart := range rawParts {
+		encoded, err := json.Marshal(rawPart)
+		if err != nil {
+			return nil, errors.NewInvalidRequestError(providerName, fmt.Errorf("invalid content part: %w", err))
+		}
+		decoder := json.NewDecoder(bytes.NewReader(encoded))
+		decoder.DisallowUnknownFields()
+
+		var part providers.ContentPart
+		if err := decoder.Decode(&part); err != nil {
+			return nil, errors.NewInvalidRequestError(providerName, fmt.Errorf("invalid content part: %w", err))
+		}
+		parts = append(parts, part)
+	}
+	return parts, nil
+}
+
+func convertContentPart(part providers.ContentPart) (string, api.ImageData, error) {
+	switch part.Type {
+	case contentTypeText:
+		if part.ImageURL != nil {
+			return "", nil, errors.NewInvalidRequestError(
+				providerName,
+				stderrors.New("text content cannot include image_url"),
+			)
+		}
+		return part.Text, nil, nil
+	case contentTypeImageURL:
+		if part.Text != "" || part.ImageURL == nil {
+			return "", nil, errors.NewInvalidRequestError(
+				providerName,
+				stderrors.New("image content requires image_url only"),
+			)
+		}
+		if part.ImageURL.Detail != "" {
+			return "", nil, errors.NewUnsupportedParamError(providerName, "messages.content.image_url.detail")
+		}
+		decoded, err := decodeImageDataURL(part.ImageURL.URL)
+		if err != nil {
+			return "", nil, err
+		}
+		return "", api.ImageData(decoded), nil
+	default:
+		return "", nil, errors.NewUnsupportedParamError(providerName, "messages.content.type")
+	}
+}
+
+func decodeImageDataURL(dataURL string) ([]byte, error) {
+	metadata, encoded, ok := strings.Cut(dataURL, ",")
+	if !ok || !strings.HasPrefix(metadata, "data:image/") || !strings.HasSuffix(metadata, ";base64") {
+		return nil, errors.NewUnsupportedParamError(providerName, "messages.content.image_url")
+	}
+	// Ollama's Go SDK models images as raw []byte and base64-encodes them when
+	// marshaling. Decode the normalized data URL here so it is encoded once.
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("image content must contain valid base64: %w", err),
+		)
+	}
+	return decoded, nil
 }
 
 // convertModelsResponse converts an Ollama list response to provider format.
@@ -612,15 +788,6 @@ func convertToolCalls(toolCalls []api.ToolCall) []providers.ToolCall {
 	return result
 }
 
-// convertToolMessage converts a tool message to Ollama format.
-func convertToolMessage(msg providers.Message) *api.Message {
-	// Ollama uses user role for tool results.
-	return &api.Message{
-		Role:    providers.RoleUser,
-		Content: msg.ContentString(),
-	}
-}
-
 // convertTools converts provider tools to Ollama format.
 func convertTools(tools []providers.Tool) api.Tools {
 	result := make(api.Tools, 0, len(tools))
@@ -670,50 +837,6 @@ func convertTools(tools []providers.Tool) api.Tools {
 	}
 
 	return result
-}
-
-// convertUserMessage converts a user message to Ollama format.
-func convertUserMessage(msg providers.Message) *api.Message {
-	ollamaMsg := &api.Message{
-		Role:    msg.Role,
-		Content: msg.ContentString(),
-	}
-
-	// Handle multi-modal messages with images.
-	if msg.IsMultiModal() {
-		images := extractImages(msg)
-		if len(images) > 0 {
-			ollamaMsg.Images = images
-		}
-	}
-
-	return ollamaMsg
-}
-
-// extractImages extracts base64 image data from a multi-modal message.
-func extractImages(msg providers.Message) []api.ImageData {
-	var images []api.ImageData
-
-	for _, part := range msg.ContentParts() {
-		if part.Type != contentTypeImageURL || part.ImageURL == nil {
-			continue
-		}
-
-		imgURL := part.ImageURL.URL
-		if !strings.HasPrefix(imgURL, dataImagePrefix) {
-			continue
-		}
-
-		// Extract base64 data from data URL.
-		parts := strings.SplitN(imgURL, ",", 2)
-		if len(parts) != 2 {
-			continue
-		}
-
-		images = append(images, api.ImageData(parts[1]))
-	}
-
-	return images
 }
 
 // extractThinking extracts thinking content from response.

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -24,7 +24,6 @@ import (
 // Provider configuration constants.
 const (
 	defaultBaseURL = "http://localhost:11434"
-	defaultNumCtx  = 32000
 	envBaseURL     = "OLLAMA_HOST"
 	providerName   = "ollama"
 )
@@ -37,7 +36,6 @@ const (
 
 // Ollama option keys.
 const (
-	optionNumCtx      = "num_ctx"
 	optionNumPredict  = "num_predict"
 	optionSeed        = "seed"
 	optionStop        = "stop"
@@ -304,19 +302,26 @@ func (p *Provider) convertParams(params providers.CompletionParams) (*api.ChatRe
 		}
 	}
 
-	// Handle reasoning/thinking.
-	if params.ReasoningEffort != "" &&
-		params.ReasoningEffort != providers.ReasoningEffortNone &&
-		params.ReasoningEffort != providers.ReasoningEffortAuto {
-		think := api.ThinkValue{Value: true}
-		req.Think = &think
+	// https://docs.ollama.com/api/chat defines think as a boolean or one of
+	// low, medium, high, and max. Preserve "none" as false on that wire type.
+	switch params.ReasoningEffort {
+	case "", providers.ReasoningEffortAuto:
+	case providers.ReasoningEffortNone:
+		req.Think = new(api.ThinkValue{Value: false})
+	case providers.ReasoningEffortLow,
+		providers.ReasoningEffortMedium,
+		providers.ReasoningEffortHigh,
+		providers.ReasoningEffort("max"):
+		req.Think = new(api.ThinkValue{Value: string(params.ReasoningEffort)})
+	default:
+		return nil, errors.NewUnsupportedParamError(providerName, "reasoning_effort")
 	}
 
 	return req, nil
 }
 
 func convertOptions(params providers.CompletionParams) map[string]any {
-	options := map[string]any{optionNumCtx: defaultNumCtx}
+	options := make(map[string]any)
 	if params.Temperature != nil {
 		options[optionTemperature] = *params.Temperature
 	}

--- a/providers/ollama/ollama_test.go
+++ b/providers/ollama/ollama_test.go
@@ -2,6 +2,7 @@ package ollama
 
 import (
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"fmt"
 	"strings"
@@ -18,6 +19,27 @@ import (
 )
 
 const testOllamaAvailabilityTimeout = 5 * time.Second
+
+type invalidMessageCase struct {
+	name    string
+	msg     providers.Message
+	wantErr error
+}
+
+func runInvalidMessageCases(t *testing.T, tests []invalidMessageCase) {
+	t.Helper()
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			converted, err := convertMessage(testCase.msg)
+
+			require.Nil(t, converted)
+			require.ErrorIs(t, err, testCase.wantErr)
+		})
+	}
+}
 
 func TestNew(t *testing.T) {
 	// Note: Not using t.Parallel() here because child test uses t.Setenv.
@@ -66,91 +88,41 @@ func TestCapabilities(t *testing.T) {
 	require.True(t, caps.ListModels)
 }
 
-func TestConvertMessages(t *testing.T) {
+func TestConvertMessagesPreservesToolResultNameAndReasoning(t *testing.T) {
 	t.Parallel()
 
-	t.Run("converts system message", func(t *testing.T) {
-		t.Parallel()
-
-		messages := []providers.Message{
-			{Role: providers.RoleSystem, Content: "You are a helpful assistant."},
-		}
-
-		result := convertMessages(messages)
-
-		require.Len(t, result, 1)
-		require.Equal(t, providers.RoleSystem, result[0].Role)
-		require.Equal(t, "You are a helpful assistant.", result[0].Content)
-	})
-
-	t.Run("converts user message", func(t *testing.T) {
-		t.Parallel()
-
-		messages := []providers.Message{
-			{Role: providers.RoleUser, Content: "Hello"},
-		}
-
-		result := convertMessages(messages)
-
-		require.Len(t, result, 1)
-		require.Equal(t, providers.RoleUser, result[0].Role)
-		require.Equal(t, "Hello", result[0].Content)
-	})
-
-	t.Run("converts assistant message", func(t *testing.T) {
-		t.Parallel()
-
-		messages := []providers.Message{
-			{Role: providers.RoleAssistant, Content: "Hi there!"},
-		}
-
-		result := convertMessages(messages)
-
-		require.Len(t, result, 1)
-		require.Equal(t, providers.RoleAssistant, result[0].Role)
-		require.Equal(t, "Hi there!", result[0].Content)
-	})
-
-	t.Run("converts tool message to user message", func(t *testing.T) {
-		t.Parallel()
-
-		messages := []providers.Message{
-			{Role: providers.RoleTool, Content: "sunny, 22°C", ToolCallID: "call_123"},
-		}
-
-		result := convertMessages(messages)
-
-		require.Len(t, result, 1)
-		require.Equal(t, providers.RoleUser, result[0].Role) // Ollama uses user for tool results.
-	})
-
-	t.Run("converts assistant message with tool calls", func(t *testing.T) {
-		t.Parallel()
-
-		messages := []providers.Message{
-			{
-				Role:    providers.RoleAssistant,
-				Content: "",
-				ToolCalls: []providers.ToolCall{
-					{
-						ID:   "call_123",
-						Type: toolTypeFunction,
-						Function: providers.FunctionCall{
-							Name:      "get_weather",
-							Arguments: `{"location": "Paris"}`,
-						},
-					},
+	messages := []providers.Message{
+		{Role: providers.RoleSystem, Content: "Use tools."},
+		{Role: providers.RoleUser, Content: "Weather?"},
+		{
+			Role:      providers.RoleAssistant,
+			Content:   "",
+			Reasoning: &providers.Reasoning{Content: "checking"},
+			ToolCalls: []providers.ToolCall{{
+				ID:   "call_weather",
+				Type: toolTypeFunction,
+				Function: providers.FunctionCall{
+					Name:      "get_weather",
+					Arguments: `{"city":"Paris"}`,
 				},
-			},
-		}
+			}},
+		},
+		{Role: providers.RoleTool, Content: "sunny", ToolCallID: "call_weather"},
+	}
 
-		result := convertMessages(messages)
+	converted, err := convertMessages(messages)
+	require.NoError(t, err)
 
-		require.Len(t, result, 1)
-		require.Equal(t, providers.RoleAssistant, result[0].Role)
-		require.Len(t, result[0].ToolCalls, 1)
-		require.Equal(t, "get_weather", result[0].ToolCalls[0].Function.Name)
-	})
+	wire, err := json.Marshal(converted)
+	require.NoError(t, err)
+	require.JSONEq(t, `[
+		{"role":"system","content":"Use tools."},
+		{"role":"user","content":"Weather?"},
+		{"role":"assistant","content":"","thinking":"checking","tool_calls":[
+			{"function":{"index":0,"name":"get_weather","arguments":{"city":"Paris"}}}
+		]},
+		{"role":"tool","content":"sunny","tool_name":"get_weather"}
+	]`, string(wire))
 }
 
 func TestConvertDoneReason(t *testing.T) {
@@ -193,32 +165,42 @@ func TestConvertDoneReason(t *testing.T) {
 	}
 }
 
-func TestExtractImages(t *testing.T) {
+func TestConvertMessageImages(t *testing.T) {
 	t.Parallel()
 
-	t.Run("extracts base64 image", func(t *testing.T) {
+	t.Run("decodes a base64 data URL once", func(t *testing.T) {
 		t.Parallel()
 
 		msg := providers.Message{
 			Role: providers.RoleUser,
-			Content: []providers.ContentPart{
-				{Type: "text", Text: "What's in this image?"},
-				{
-					Type: "image_url",
-					ImageURL: &providers.ImageURL{
-						URL: "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+			Content: []any{
+				map[string]any{"type": "text", "text": "What's in this image?"},
+				map[string]any{
+					"type": "image_url",
+					"image_url": map[string]any{
+						"url": "data:image/jpeg;base64,aGVsbG8=",
 					},
 				},
 			},
 		}
 
-		images := extractImages(msg)
+		converted, err := convertMessage(msg)
 
-		require.Len(t, images, 1)
-		require.Equal(t, "/9j/4AAQSkZJRg==", string(images[0]))
+		require.NoError(t, err)
+		require.Equal(t, "What's in this image?", converted.Content)
+		require.Len(t, converted.Images, 1)
+		require.Equal(t, "hello", string(converted.Images[0]))
+
+		wire, err := json.Marshal(converted)
+		require.NoError(t, err)
+		require.JSONEq(t, `{
+			"role":"user",
+			"content":"What's in this image?",
+			"images":["aGVsbG8="]
+		}`, string(wire))
 	})
 
-	t.Run("ignores non-data URLs", func(t *testing.T) {
+	t.Run("rejects image URLs the SDK cannot encode", func(t *testing.T) {
 		t.Parallel()
 
 		msg := providers.Message{
@@ -233,9 +215,10 @@ func TestExtractImages(t *testing.T) {
 			},
 		}
 
-		images := extractImages(msg)
+		converted, err := convertMessage(msg)
 
-		require.Empty(t, images)
+		require.Nil(t, converted)
+		require.ErrorIs(t, err, errors.ErrUnsupportedParam)
 	})
 }
 
@@ -337,45 +320,202 @@ func TestConvertResponseFormat(t *testing.T) {
 	})
 }
 
-func TestConvertMessage(t *testing.T) {
+func TestConvertMessageRejectsInvalidMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name         string
-		msg          providers.Message
-		expectedRole string
-	}{
+	tests := []invalidMessageCase{
 		{
-			name:         "user message",
-			msg:          providers.Message{Role: providers.RoleUser, Content: "Hello"},
-			expectedRole: providers.RoleUser,
+			name:    "unknown role",
+			msg:     providers.Message{Role: "developer", Content: "Hello"},
+			wantErr: errors.ErrInvalidRequest,
 		},
 		{
-			name:         "assistant message",
-			msg:          providers.Message{Role: providers.RoleAssistant, Content: "Hi"},
-			expectedRole: providers.RoleAssistant,
+			name:    "name on user message",
+			msg:     providers.Message{Role: providers.RoleUser, Content: "Hello", Name: "alice"},
+			wantErr: errors.ErrUnsupportedParam,
 		},
 		{
-			name:         "system message",
-			msg:          providers.Message{Role: providers.RoleSystem, Content: "You are helpful"},
-			expectedRole: providers.RoleSystem,
+			name: "tool call on user message",
+			msg: providers.Message{
+				Role: providers.RoleUser, Content: "Hello", ToolCalls: []providers.ToolCall{{}},
+			},
+			wantErr: errors.ErrUnsupportedParam,
 		},
 		{
-			name:         "tool message becomes user",
-			msg:          providers.Message{Role: providers.RoleTool, Content: "result", ToolCallID: "123"},
-			expectedRole: providers.RoleUser,
+			name: "reasoning on user message",
+			msg: providers.Message{
+				Role: providers.RoleUser, Content: "Hello", Reasoning: &providers.Reasoning{Content: "why"},
+			},
+			wantErr: errors.ErrUnsupportedParam,
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+	runInvalidMessageCases(t, tests)
+}
 
-			result := convertMessage(tc.msg)
-			require.NotNil(t, result)
-			require.Equal(t, tc.expectedRole, result.Role)
-		})
+func TestConvertMessageRejectsInvalidContent(t *testing.T) {
+	t.Parallel()
+
+	tests := []invalidMessageCase{
+		{
+			name:    "unsupported content representation",
+			msg:     providers.Message{Role: providers.RoleUser, Content: 42},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name:    "invalid dynamic content part",
+			msg:     providers.Message{Role: providers.RoleUser, Content: []any{"text"}},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name: "unknown dynamic content field",
+			msg: providers.Message{
+				Role: providers.RoleUser,
+				Content: []any{map[string]any{
+					"type": "text", "text": "Hello", "future": true,
+				}},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name: "unknown content part",
+			msg: providers.Message{
+				Role: providers.RoleUser, Content: []providers.ContentPart{{Type: "audio"}},
+			},
+			wantErr: errors.ErrUnsupportedParam,
+		},
 	}
+
+	runInvalidMessageCases(t, tests)
+}
+
+func TestConvertMessageRejectsInvalidImageContent(t *testing.T) {
+	t.Parallel()
+
+	tests := []invalidMessageCase{
+		{
+			name: "text part with image field",
+			msg: providers.Message{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{{
+					Type: contentTypeText, ImageURL: &providers.ImageURL{URL: "data:image/png;base64,aA=="},
+				}},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name: "image part without URL",
+			msg: providers.Message{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{{
+					Type: contentTypeImageURL,
+				}},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name: "invalid image base64",
+			msg: providers.Message{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{{
+					Type: contentTypeImageURL, ImageURL: &providers.ImageURL{URL: "data:image/png;base64,!"},
+				}},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name: "unsupported image detail",
+			msg: providers.Message{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{{
+					Type: contentTypeImageURL,
+					ImageURL: &providers.ImageURL{
+						URL: "data:image/png;base64,aA==", Detail: "high",
+					},
+				}},
+			},
+			wantErr: errors.ErrUnsupportedParam,
+		},
+	}
+
+	runInvalidMessageCases(t, tests)
+}
+
+func TestConvertMessageRejectsInvalidToolCall(t *testing.T) {
+	t.Parallel()
+
+	tests := []invalidMessageCase{
+		{
+			name: "unknown tool call type",
+			msg: providers.Message{
+				Role: providers.RoleAssistant,
+				ToolCalls: []providers.ToolCall{{
+					Type: "custom", Function: providers.FunctionCall{Arguments: `{}`},
+				}},
+			},
+			wantErr: errors.ErrUnsupportedParam,
+		},
+		{
+			name: "missing tool function name",
+			msg: providers.Message{
+				Role: providers.RoleAssistant,
+				ToolCalls: []providers.ToolCall{{
+					Type: toolTypeFunction, Function: providers.FunctionCall{Arguments: `{}`},
+				}},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name: "non-object tool arguments",
+			msg: providers.Message{
+				Role: providers.RoleAssistant,
+				ToolCalls: []providers.ToolCall{{
+					Type:     toolTypeFunction,
+					Function: providers.FunctionCall{Name: "get_weather", Arguments: `[]`},
+				}},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name: "null tool arguments",
+			msg: providers.Message{
+				Role: providers.RoleAssistant,
+				ToolCalls: []providers.ToolCall{{
+					Type:     toolTypeFunction,
+					Function: providers.FunctionCall{Name: "get_weather", Arguments: `null`},
+				}},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+	}
+
+	runInvalidMessageCases(t, tests)
+}
+
+func TestConvertMessagesRejectsUnresolvedToolResult(t *testing.T) {
+	t.Parallel()
+
+	converted, err := convertMessages([]providers.Message{{
+		Role: providers.RoleTool, Content: "sunny", ToolCallID: "missing",
+	}})
+
+	require.Nil(t, converted)
+	require.ErrorIs(t, err, errors.ErrInvalidRequest)
+}
+
+func TestCompletionEntryPointsRejectInvalidMessages(t *testing.T) {
+	t.Parallel()
+
+	provider := &Provider{}
+	params := providers.CompletionParams{Messages: []providers.Message{{Role: "developer"}}}
+
+	completion, err := provider.Completion(t.Context(), params)
+	require.Nil(t, completion)
+	require.ErrorIs(t, err, errors.ErrInvalidRequest)
+
+	chunks, streamErrors := provider.CompletionStream(t.Context(), params)
+	require.Empty(t, chunks)
+	require.ErrorIs(t, <-streamErrors, errors.ErrInvalidRequest)
 }
 
 func TestNewStreamState(t *testing.T) {

--- a/providers/ollama/ollama_test.go
+++ b/providers/ollama/ollama_test.go
@@ -88,6 +88,47 @@ func TestCapabilities(t *testing.T) {
 	require.True(t, caps.ListModels)
 }
 
+func TestConvertParamsPreservesReasoningAndModelDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		effort   providers.ReasoningEffort
+		wantJSON string
+		wantErr  error
+	}{
+		{name: "unset", wantJSON: "null"},
+		{name: "auto", effort: providers.ReasoningEffortAuto, wantJSON: "null"},
+		{name: "none", effort: providers.ReasoningEffortNone, wantJSON: "false"},
+		{name: "low", effort: providers.ReasoningEffortLow, wantJSON: `"low"`},
+		{name: "medium", effort: providers.ReasoningEffortMedium, wantJSON: `"medium"`},
+		{name: "high", effort: providers.ReasoningEffortHigh, wantJSON: `"high"`},
+		{name: "max", effort: providers.ReasoningEffort("max"), wantJSON: `"max"`},
+		{name: "unsupported", effort: providers.ReasoningEffort("xhigh"), wantErr: errors.ErrUnsupportedParam},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			request, err := (&Provider{}).convertParams(providers.CompletionParams{
+				ReasoningEffort: testCase.effort,
+			})
+			if testCase.wantErr != nil {
+				require.Nil(t, request)
+				require.ErrorIs(t, err, testCase.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Empty(t, request.Options)
+			encoded, err := json.Marshal(request.Think)
+			require.NoError(t, err)
+			require.Equal(t, testCase.wantJSON, string(encoded))
+		})
+	}
+}
+
 func TestConvertMessagesPreservesToolResultNameAndReasoning(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Preserve Ollama's documented reasoning controls and stop overriding each model's context-window default.

## Changes

- Serialize normalized `none` as `think:false`.
- Preserve `low`, `medium`, `high`, and `max` as their documented string wire values.
- Leave `auto` and an unset effort absent so Ollama and the selected model choose the default.
- Reject unsupported reasoning levels instead of silently coercing them to `true`.
- Remove the adapter-owned `num_ctx:32000` fallback. Ollama documents `num_ctx` as a model option but does not define 32000 as a universal default.

## Dependency and review range

This branch includes Draft #143 because GitHub cannot use a contributor-fork branch as the upstream PR base. Review this PR's owning commit after #143:

- `70024c3 fix(ollama): preserve reasoning request levels`
- two files, `+55/-9`

No other request parameters, schemas, responses, streams, or errors change here.

## Contract basis

- Current Chat OpenAPI: <https://docs.ollama.com/api/chat>
- Latest formal SDK release checked: `v0.33.2`, commit [`f96e7aa`](https://github.com/ollama/ollama/commit/f96e7aa0513b9973a0ccc71be414c2ecb9d65b1a)

No SDK upgrade is needed. The repository's current `v0.32.5` `ThinkValue` already supports the documented boolean and string values, and the same tests pass with a temporary `v0.33.2` modfile.

Ablation inlined the one-use reasoning converter after the focused tests and cyclomatic-complexity gate remained green. No new helper or public type remains.

## Testing

- `go test ./providers/ollama -run '^TestConvertParamsPreservesReasoningAndModelDefaults$' -count=1`
- `go test ./providers/ollama -count=1`
- `CGO_ENABLED=1 go test -race ./providers/ollama -count=1`
- `go test ./... -count=1`
- `go mod tidy -diff`
- `go mod verify`
- `golangci-lint run --fix=false ./providers/ollama/...`
- all 112 non-deprecated GolangCI-Lint 2.13.2 linters on the owning diff: no correctness or complexity findings; ten remaining reports are external/anonymous partial literals, independent golden constants, and a repository-conflicting blank-line rule
- temporary `v0.33.2` modfile: provider tests pass
- `git diff --check`

No local Ollama daemon/model is available, so live reasoning-level behavior remains incomplete.

## Checklist

- [x] Linting passes
- [x] Tests pass locally
- [x] Contract source and behavior change are documented
- [x] No dependency or public API change