### PR TITLE
fix(ollama): preserve response wire semantics

### DIFF
--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -91,13 +91,12 @@ type Provider struct {
 	config *config.Config
 }
 
-// streamState tracks accumulated state during streaming.
+// streamState tracks response metadata and whether Ollama sent its terminal event.
 type streamState struct {
-	id        string
-	model     string
-	created   int64
-	content   strings.Builder
-	reasoning strings.Builder
+	id      string
+	model   string
+	created int64
+	done    bool
 }
 
 // New creates a new Ollama provider.
@@ -157,12 +156,20 @@ func (p *Provider) Completion(
 	req.Stream = &stream
 
 	var response api.ChatResponse
+	done := false
 	err = p.client.Chat(ctx, req, func(resp api.ChatResponse) error {
 		response = resp
+		done = resp.Done
 		return nil
 	})
 	if err != nil {
 		return nil, p.ConvertError(err)
+	}
+	if !done {
+		return nil, errors.NewProviderError(
+			providerName,
+			stderrors.New("response ended before the terminal event"),
+		)
 	}
 
 	return convertResponse(&response), nil
@@ -189,11 +196,22 @@ func (p *Provider) CompletionStream(
 
 		err = p.client.Chat(ctx, req, func(resp api.ChatResponse) error {
 			chunk := state.handleChunk(&resp)
-			chunks <- chunk
-			return nil
+			select {
+			case chunks <- chunk:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		})
 		if err != nil {
 			errs <- p.ConvertError(err)
+			return
+		}
+		if !state.done {
+			errs <- errors.NewProviderError(
+				providerName,
+				stderrors.New("stream ended before the terminal event"),
+			)
 		}
 	}()
 
@@ -355,6 +373,9 @@ func (s *streamState) chunk() providers.ChatCompletionChunk {
 // handleChunk processes a streaming response and returns a chunk.
 func (s *streamState) handleChunk(resp *api.ChatResponse) providers.ChatCompletionChunk {
 	s.updateMetadata(resp)
+	if resp.Done {
+		s.done = true
+	}
 
 	chunk := s.chunk()
 	chunk.Choices[0].Delta = s.buildDelta(resp)
@@ -382,13 +403,11 @@ func (s *streamState) buildDelta(resp *api.ChatResponse) providers.ChunkDelta {
 
 	// Handle content.
 	if resp.Message.Content != "" {
-		s.content.WriteString(resp.Message.Content)
 		delta.Content = resp.Message.Content
 	}
 
 	// Handle thinking/reasoning.
 	if resp.Message.Thinking != "" {
-		s.reasoning.WriteString(resp.Message.Thinking)
 		delta.Reasoning = &providers.Reasoning{Content: resp.Message.Thinking}
 	}
 

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -11,6 +11,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"net/url"
+	"reflect"
 	"strings"
 	"time"
 
@@ -292,8 +293,9 @@ func (p *Provider) convertParams(params providers.CompletionParams) (*api.ChatRe
 		Options:  convertOptions(params),
 	}
 
-	if len(params.Tools) > 0 {
-		req.Tools = convertTools(params.Tools)
+	req.Tools, err = convertTools(params.Tools)
+	if err != nil {
+		return nil, err
 	}
 
 	if params.ResponseFormat != nil {
@@ -794,54 +796,91 @@ func convertToolCalls(toolCalls []api.ToolCall) []providers.ToolCall {
 }
 
 // convertTools converts provider tools to Ollama format.
-func convertTools(tools []providers.Tool) api.Tools {
+func convertTools(tools []providers.Tool) (api.Tools, error) {
+	if len(tools) == 0 {
+		return nil, nil
+	}
+
 	result := make(api.Tools, 0, len(tools))
 
 	for _, tool := range tools {
-		params := api.ToolFunctionParameters{
-			Type: schemaTypeObject,
+		if tool.Type != toolTypeFunction {
+			return nil, errors.NewUnsupportedParamError(providerName, "tools.type")
 		}
-
-		// Convert properties.
-		if props, ok := tool.Function.Parameters[schemaKeyProperties].(map[string]any); ok {
-			propsMap := api.NewToolPropertiesMap()
-			for name, prop := range props {
-				if propMap, ok := prop.(map[string]any); ok {
-					tp := api.ToolProperty{}
-					if t, ok := propMap[schemaKeyType].(string); ok {
-						tp.Type = api.PropertyType{t}
-					}
-					if d, ok := propMap[schemaKeyDescription].(string); ok {
-						tp.Description = d
-					}
-					propsMap.Set(name, tp)
-				}
-			}
-			params.Properties = propsMap
+		if tool.Function.Name == "" {
+			return nil, errors.NewInvalidRequestError(providerName, stderrors.New("tool requires a function name"))
 		}
-
-		// Convert required fields.
-		if req, ok := tool.Function.Parameters[schemaKeyRequired].([]any); ok {
-			for _, r := range req {
-				if s, ok := r.(string); ok {
-					params.Required = append(params.Required, s)
-				}
-			}
+		parameters, err := convertToolParameters(tool.Function.Parameters)
+		if err != nil {
+			return nil, err
 		}
-
-		ollamaTool := api.Tool{
+		result = append(result, api.Tool{
 			Type: toolTypeFunction,
 			Function: api.ToolFunction{
 				Name:        tool.Function.Name,
 				Description: tool.Function.Description,
-				Parameters:  params,
+				Parameters:  parameters,
 			},
-		}
-
-		result = append(result, ollamaTool)
+		})
 	}
 
-	return result
+	return result, nil
+}
+
+func convertToolParameters(parameters map[string]any) (api.ToolFunctionParameters, error) {
+	if parameters == nil {
+		return api.ToolFunctionParameters{}, errors.NewInvalidRequestError(
+			providerName,
+			stderrors.New("tool requires a parameters schema"),
+		)
+	}
+	encoded, err := json.Marshal(parameters)
+	if err != nil {
+		return api.ToolFunctionParameters{}, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("tool schema must be valid JSON: %w", err),
+		)
+	}
+
+	var converted api.ToolFunctionParameters
+	if unmarshalErr := json.Unmarshal(encoded, &converted); unmarshalErr != nil {
+		return api.ToolFunctionParameters{}, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("tool schema is invalid: %w", unmarshalErr),
+		)
+	}
+	var normalized map[string]any
+	if unmarshalErr := json.Unmarshal(encoded, &normalized); unmarshalErr != nil {
+		return api.ToolFunctionParameters{}, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("tool schema cannot be compared: %w", unmarshalErr),
+		)
+	}
+
+	// https://docs.ollama.com/api/chat accepts JSON Schema, while the Go SDK
+	// exposes a typed subset. Reject schemas the SDK would silently weaken.
+	roundTripJSON, err := json.Marshal(converted)
+	if err != nil {
+		return api.ToolFunctionParameters{}, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("tool schema cannot be encoded: %w", err),
+		)
+	}
+	var roundTrip map[string]any
+	if err := json.Unmarshal(roundTripJSON, &roundTrip); err != nil {
+		return api.ToolFunctionParameters{}, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("tool schema cannot be compared: %w", err),
+		)
+	}
+	if !reflect.DeepEqual(normalized, roundTrip) {
+		return api.ToolFunctionParameters{}, errors.NewUnsupportedParamError(
+			providerName,
+			"tools.function.parameters",
+		)
+	}
+
+	return converted, nil
 }
 
 // extractThinking extracts thinking content from response.

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -44,21 +44,13 @@ const (
 	optionTopP        = "top_p"
 )
 
-// JSON schema keys and types.
-const (
-	schemaKeyDescription = "description"
-	schemaKeyProperties  = "properties"
-	schemaKeyRequired    = "required"
-	schemaKeyType        = "type"
-	schemaTypeObject     = "object"
-)
-
 // Tool and response format constants.
 const (
 	emptyJSONObject      = "{}"
 	ollamaFormatJSON     = "json"
 	responseFormatJSON   = "json_object"
 	responseFormatSchema = "json_schema"
+	responseFormatText   = "text"
 	toolCallIDFormat     = "call_%d"
 	toolTypeFunction     = "function"
 )
@@ -298,10 +290,9 @@ func (p *Provider) convertParams(params providers.CompletionParams) (*api.ChatRe
 		return nil, err
 	}
 
-	if params.ResponseFormat != nil {
-		if schema := convertResponseFormat(params.ResponseFormat); schema != nil {
-			req.Format = schema
-		}
+	req.Format, err = convertResponseFormat(params.ResponseFormat)
+	if err != nil {
+		return nil, err
 	}
 
 	// https://docs.ollama.com/api/chat defines think as a boolean or one of
@@ -751,22 +742,42 @@ func convertResponse(resp *api.ChatResponse) *providers.ChatCompletion {
 }
 
 // convertResponseFormat converts a response format to Ollama JSON schema.
-func convertResponseFormat(format *providers.ResponseFormat) json.RawMessage {
+func convertResponseFormat(format *providers.ResponseFormat) (json.RawMessage, error) {
 	if format == nil {
-		return nil
+		return nil, nil
 	}
 
 	if format.Type == responseFormatJSON {
-		return json.RawMessage(`"` + ollamaFormatJSON + `"`)
+		return json.RawMessage(`"` + ollamaFormatJSON + `"`), nil
+	}
+	if format.Type == responseFormatText {
+		return nil, nil
 	}
 
-	if format.Type == responseFormatSchema && format.JSONSchema != nil {
-		if schemaBytes, err := json.Marshal(format.JSONSchema.Schema); err == nil {
-			return schemaBytes
+	if format.Type == responseFormatSchema {
+		if format.JSONSchema == nil || format.JSONSchema.Schema == nil {
+			return nil, errors.NewInvalidRequestError(
+				providerName,
+				stderrors.New("json_schema response format requires a schema"),
+			)
 		}
+		if format.JSONSchema.Strict != nil && !*format.JSONSchema.Strict {
+			return nil, errors.NewUnsupportedParamError(providerName, "response_format.json_schema.strict")
+		}
+		// Ollama accepts the raw schema without OpenAI's name, description, or
+		// strict wrapper and enforces it by default. The schema itself is kept intact.
+		// https://docs.ollama.com/capabilities/structured-outputs
+		schemaBytes, err := json.Marshal(format.JSONSchema.Schema)
+		if err != nil {
+			return nil, errors.NewInvalidRequestError(
+				providerName,
+				fmt.Errorf("response schema must be valid JSON: %w", err),
+			)
+		}
+		return schemaBytes, nil
 	}
 
-	return nil
+	return nil, errors.NewUnsupportedParamError(providerName, "response_format.type")
 }
 
 // convertToolCalls converts Ollama tool calls to provider format.

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -2,8 +2,10 @@
 package ollama
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	stderrors "errors"
@@ -80,7 +82,7 @@ const (
 // Content part constants.
 const (
 	contentTypeImageURL = "image_url"
-	dataImagePrefix     = "data:image/"
+	contentTypeText     = "text"
 )
 
 // Ensure Provider implements the required interfaces.
@@ -154,14 +156,17 @@ func (p *Provider) Completion(
 	ctx context.Context,
 	params providers.CompletionParams,
 ) (*providers.ChatCompletion, error) {
-	req := p.convertParams(params)
+	req, err := p.convertParams(params)
+	if err != nil {
+		return nil, err
+	}
 
 	// Disable streaming for non-stream requests.
 	stream := false
 	req.Stream = &stream
 
 	var response api.ChatResponse
-	err := p.client.Chat(ctx, req, func(resp api.ChatResponse) error {
+	err = p.client.Chat(ctx, req, func(resp api.ChatResponse) error {
 		response = resp
 		return nil
 	})
@@ -184,10 +189,14 @@ func (p *Provider) CompletionStream(
 		defer close(chunks)
 		defer close(errs)
 
-		req := p.convertParams(params)
+		req, err := p.convertParams(params)
+		if err != nil {
+			errs <- err
+			return
+		}
 		state := newStreamState()
 
-		err := p.client.Chat(ctx, req, func(resp api.ChatResponse) error {
+		err = p.client.Chat(ctx, req, func(resp api.ChatResponse) error {
 			chunk := state.handleChunk(&resp)
 			chunks <- chunk
 			return nil
@@ -273,36 +282,16 @@ func (p *Provider) Name() string {
 }
 
 // convertParams converts providers.CompletionParams to Ollama ChatRequest.
-func (p *Provider) convertParams(params providers.CompletionParams) *api.ChatRequest {
-	messages := convertMessages(params.Messages)
+func (p *Provider) convertParams(params providers.CompletionParams) (*api.ChatRequest, error) {
+	messages, err := convertMessages(params.Messages)
+	if err != nil {
+		return nil, err
+	}
 
 	req := &api.ChatRequest{
 		Model:    params.Model,
 		Messages: messages,
-		Options:  make(map[string]any),
-	}
-
-	// Set default context size.
-	req.Options[optionNumCtx] = defaultNumCtx
-
-	if params.Temperature != nil {
-		req.Options[optionTemperature] = *params.Temperature
-	}
-
-	if params.TopP != nil {
-		req.Options[optionTopP] = *params.TopP
-	}
-
-	if len(params.Stop) > 0 {
-		req.Options[optionStop] = params.Stop
-	}
-
-	if params.MaxTokens != nil {
-		req.Options[optionNumPredict] = *params.MaxTokens
-	}
-
-	if params.Seed != nil {
-		req.Options[optionSeed] = *params.Seed
+		Options:  convertOptions(params),
 	}
 
 	if len(params.Tools) > 0 {
@@ -323,7 +312,27 @@ func (p *Provider) convertParams(params providers.CompletionParams) *api.ChatReq
 		req.Think = &think
 	}
 
-	return req
+	return req, nil
+}
+
+func convertOptions(params providers.CompletionParams) map[string]any {
+	options := map[string]any{optionNumCtx: defaultNumCtx}
+	if params.Temperature != nil {
+		options[optionTemperature] = *params.Temperature
+	}
+	if params.TopP != nil {
+		options[optionTopP] = *params.TopP
+	}
+	if len(params.Stop) > 0 {
+		options[optionStop] = params.Stop
+	}
+	if params.MaxTokens != nil {
+		options[optionNumPredict] = *params.MaxTokens
+	}
+	if params.Seed != nil {
+		options[optionSeed] = *params.Seed
+	}
+	return options
 }
 
 // newStreamState creates a new stream state.
@@ -408,37 +417,6 @@ func (s *streamState) handleDone(resp *api.ChatResponse, chunk *providers.ChatCo
 	}
 }
 
-// convertAssistantMessage converts an assistant message to Ollama format.
-func convertAssistantMessage(msg providers.Message) *api.Message {
-	ollamaMsg := &api.Message{
-		Role:    msg.Role,
-		Content: msg.ContentString(),
-	}
-
-	if len(msg.ToolCalls) > 0 {
-		toolCalls := make([]api.ToolCall, 0, len(msg.ToolCalls))
-		for _, tc := range msg.ToolCalls {
-			var argsMap map[string]any
-			_ = json.Unmarshal([]byte(tc.Function.Arguments), &argsMap)
-
-			args := api.NewToolCallFunctionArguments()
-			for k, v := range argsMap {
-				args.Set(k, v)
-			}
-
-			toolCalls = append(toolCalls, api.ToolCall{
-				Function: api.ToolCallFunction{
-					Name:      tc.Function.Name,
-					Arguments: args,
-				},
-			})
-		}
-		ollamaMsg.ToolCalls = toolCalls
-	}
-
-	return ollamaMsg
-}
-
 // convertDoneReason converts Ollama done reason to OpenAI finish reason.
 func convertDoneReason(reason string) string {
 	switch reason {
@@ -478,36 +456,234 @@ func convertEmbeddingResponse(resp *api.EmbedResponse, model string) *providers.
 	}
 }
 
-// convertMessage converts a single message to Ollama format.
-func convertMessage(msg providers.Message) *api.Message {
-	switch msg.Role {
-	case providers.RoleTool:
-		return convertToolMessage(msg)
-	case providers.RoleAssistant:
-		return convertAssistantMessage(msg)
-	case providers.RoleUser:
-		return convertUserMessage(msg)
-	default:
-		// System and other roles.
-		return &api.Message{
-			Role:    msg.Role,
-			Content: msg.ContentString(),
-		}
+// convertMessage converts a single message to Ollama's documented wire model.
+func convertMessage(msg providers.Message) (*api.Message, error) {
+	if err := validateMessageMetadata(msg); err != nil {
+		return nil, err
 	}
+
+	content, images, err := convertMessageContent(msg)
+	if err != nil {
+		return nil, err
+	}
+	toolCalls, err := convertRequestToolCalls(msg.ToolCalls)
+	if err != nil {
+		return nil, err
+	}
+
+	converted := &api.Message{
+		Role:      msg.Role,
+		Content:   content,
+		Images:    images,
+		ToolCalls: toolCalls,
+	}
+	if msg.Role == providers.RoleTool {
+		converted.ToolName = msg.Name
+	}
+	if msg.Reasoning != nil {
+		converted.Thinking = msg.Reasoning.Content
+	}
+
+	return converted, nil
+}
+
+func validateMessageMetadata(msg providers.Message) error {
+	switch msg.Role {
+	case providers.RoleSystem, providers.RoleUser, providers.RoleAssistant, providers.RoleTool:
+	default:
+		return errors.NewInvalidRequestError(providerName, fmt.Errorf("unsupported message role %q", msg.Role))
+	}
+	if msg.Role != providers.RoleTool && (msg.Name != "" || msg.ToolCallID != "") {
+		return errors.NewUnsupportedParamError(providerName, "messages.name/tool_call_id")
+	}
+	if msg.Role != providers.RoleAssistant && len(msg.ToolCalls) > 0 {
+		return errors.NewUnsupportedParamError(providerName, "messages.tool_calls")
+	}
+	if msg.Role != providers.RoleAssistant && msg.Reasoning != nil {
+		return errors.NewUnsupportedParamError(providerName, "messages.reasoning")
+	}
+	return nil
+}
+
+func convertRequestToolCalls(toolCalls []providers.ToolCall) ([]api.ToolCall, error) {
+	if len(toolCalls) == 0 {
+		return nil, nil
+	}
+
+	converted := make([]api.ToolCall, 0, len(toolCalls))
+	for _, toolCall := range toolCalls {
+		if toolCall.Type != toolTypeFunction {
+			return nil, errors.NewUnsupportedParamError(providerName, "messages.tool_calls.type")
+		}
+		if toolCall.Function.Name == "" {
+			return nil, errors.NewInvalidRequestError(
+				providerName,
+				stderrors.New("tool call requires a function name"),
+			)
+		}
+		argumentsJSON := strings.TrimSpace(toolCall.Function.Arguments)
+		if !strings.HasPrefix(argumentsJSON, "{") {
+			return nil, errors.NewInvalidRequestError(
+				providerName,
+				stderrors.New("tool arguments must be a JSON object"),
+			)
+		}
+		var arguments api.ToolCallFunctionArguments
+		if err := json.Unmarshal([]byte(argumentsJSON), &arguments); err != nil {
+			return nil, errors.NewInvalidRequestError(
+				providerName,
+				fmt.Errorf("tool arguments must be a JSON object: %w", err),
+			)
+		}
+		// https://docs.ollama.com/capabilities/tool-calling includes
+		// type:"function", but Chat OpenAPI and the Go SDK type used here omit it.
+		converted = append(converted, api.ToolCall{
+			Function: api.ToolCallFunction{
+				Name:      toolCall.Function.Name,
+				Arguments: arguments,
+			},
+		})
+	}
+
+	return converted, nil
 }
 
 // convertMessages converts provider messages to Ollama format.
-func convertMessages(messages []providers.Message) []api.Message {
+func convertMessages(messages []providers.Message) ([]api.Message, error) {
 	result := make([]api.Message, 0, len(messages))
+	toolNames := make(map[string]string)
 
 	for _, msg := range messages {
-		ollamaMsg := convertMessage(msg)
-		if ollamaMsg != nil {
-			result = append(result, *ollamaMsg)
+		converted, err := convertMessage(msg)
+		if err != nil {
+			return nil, err
+		}
+		for _, toolCall := range msg.ToolCalls {
+			if toolCall.ID != "" {
+				toolNames[toolCall.ID] = toolCall.Function.Name
+			}
+		}
+		// https://docs.ollama.com/capabilities/tool-calling identifies tool
+		// results by tool_name. Resolve the normalized call ID before encoding.
+		if msg.Role == providers.RoleTool && converted.ToolName == "" {
+			converted.ToolName = toolNames[msg.ToolCallID]
+			if converted.ToolName == "" {
+				return nil, errors.NewInvalidRequestError(
+					providerName,
+					stderrors.New("tool result requires a name or a matching tool call ID"),
+				)
+			}
+		}
+		result = append(result, *converted)
+	}
+
+	return result, nil
+}
+
+func convertMessageContent(msg providers.Message) (string, []api.ImageData, error) {
+	if content, ok := msg.Content.(string); ok {
+		return content, nil, nil
+	}
+	if msg.Content == nil {
+		return "", nil, nil
+	}
+	var parts []providers.ContentPart
+	switch content := msg.Content.(type) {
+	case []providers.ContentPart:
+		parts = content
+	case []any:
+		var err error
+		parts, err = decodeContentParts(content)
+		if err != nil {
+			return "", nil, err
+		}
+	default:
+		return "", nil, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("unsupported message content type %T", msg.Content),
+		)
+	}
+
+	var content strings.Builder
+	var images []api.ImageData
+	for _, part := range parts {
+		text, image, err := convertContentPart(part)
+		if err != nil {
+			return "", nil, err
+		}
+		content.WriteString(text)
+		if image != nil {
+			images = append(images, image)
 		}
 	}
 
-	return result
+	return content.String(), images, nil
+}
+
+func decodeContentParts(rawParts []any) ([]providers.ContentPart, error) {
+	parts := make([]providers.ContentPart, 0, len(rawParts))
+	for _, rawPart := range rawParts {
+		encoded, err := json.Marshal(rawPart)
+		if err != nil {
+			return nil, errors.NewInvalidRequestError(providerName, fmt.Errorf("invalid content part: %w", err))
+		}
+		decoder := json.NewDecoder(bytes.NewReader(encoded))
+		decoder.DisallowUnknownFields()
+
+		var part providers.ContentPart
+		if err := decoder.Decode(&part); err != nil {
+			return nil, errors.NewInvalidRequestError(providerName, fmt.Errorf("invalid content part: %w", err))
+		}
+		parts = append(parts, part)
+	}
+	return parts, nil
+}
+
+func convertContentPart(part providers.ContentPart) (string, api.ImageData, error) {
+	switch part.Type {
+	case contentTypeText:
+		if part.ImageURL != nil {
+			return "", nil, errors.NewInvalidRequestError(
+				providerName,
+				stderrors.New("text content cannot include image_url"),
+			)
+		}
+		return part.Text, nil, nil
+	case contentTypeImageURL:
+		if part.Text != "" || part.ImageURL == nil {
+			return "", nil, errors.NewInvalidRequestError(
+				providerName,
+				stderrors.New("image content requires image_url only"),
+			)
+		}
+		if part.ImageURL.Detail != "" {
+			return "", nil, errors.NewUnsupportedParamError(providerName, "messages.content.image_url.detail")
+		}
+		decoded, err := decodeImageDataURL(part.ImageURL.URL)
+		if err != nil {
+			return "", nil, err
+		}
+		return "", api.ImageData(decoded), nil
+	default:
+		return "", nil, errors.NewUnsupportedParamError(providerName, "messages.content.type")
+	}
+}
+
+func decodeImageDataURL(dataURL string) ([]byte, error) {
+	metadata, encoded, ok := strings.Cut(dataURL, ",")
+	if !ok || !strings.HasPrefix(metadata, "data:image/") || !strings.HasSuffix(metadata, ";base64") {
+		return nil, errors.NewUnsupportedParamError(providerName, "messages.content.image_url")
+	}
+	// Ollama's Go SDK models images as raw []byte and base64-encodes them when
+	// marshaling. Decode the normalized data URL here so it is encoded once.
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("image content must contain valid base64: %w", err),
+		)
+	}
+	return decoded, nil
 }
 
 // convertModelsResponse converts an Ollama list response to provider format.
@@ -612,15 +788,6 @@ func convertToolCalls(toolCalls []api.ToolCall) []providers.ToolCall {
 	return result
 }
 
-// convertToolMessage converts a tool message to Ollama format.
-func convertToolMessage(msg providers.Message) *api.Message {
-	// Ollama uses user role for tool results.
-	return &api.Message{
-		Role:    providers.RoleUser,
-		Content: msg.ContentString(),
-	}
-}
-
 // convertTools converts provider tools to Ollama format.
 func convertTools(tools []providers.Tool) api.Tools {
 	result := make(api.Tools, 0, len(tools))
@@ -670,50 +837,6 @@ func convertTools(tools []providers.Tool) api.Tools {
 	}
 
 	return result
-}
-
-// convertUserMessage converts a user message to Ollama format.
-func convertUserMessage(msg providers.Message) *api.Message {
-	ollamaMsg := &api.Message{
-		Role:    msg.Role,
-		Content: msg.ContentString(),
-	}
-
-	// Handle multi-modal messages with images.
-	if msg.IsMultiModal() {
-		images := extractImages(msg)
-		if len(images) > 0 {
-			ollamaMsg.Images = images
-		}
-	}
-
-	return ollamaMsg
-}
-
-// extractImages extracts base64 image data from a multi-modal message.
-func extractImages(msg providers.Message) []api.ImageData {
-	var images []api.ImageData
-
-	for _, part := range msg.ContentParts() {
-		if part.Type != contentTypeImageURL || part.ImageURL == nil {
-			continue
-		}
-
-		imgURL := part.ImageURL.URL
-		if !strings.HasPrefix(imgURL, dataImagePrefix) {
-			continue
-		}
-
-		// Extract base64 data from data URL.
-		parts := strings.SplitN(imgURL, ",", 2)
-		if len(parts) != 2 {
-			continue
-		}
-
-		images = append(images, api.ImageData(parts[1]))
-	}
-
-	return images
 }
 
 // extractThinking extracts thinking content from response.

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -24,7 +24,6 @@ import (
 // Provider configuration constants.
 const (
 	defaultBaseURL = "http://localhost:11434"
-	defaultNumCtx  = 32000
 	envBaseURL     = "OLLAMA_HOST"
 	providerName   = "ollama"
 )
@@ -37,7 +36,6 @@ const (
 
 // Ollama option keys.
 const (
-	optionNumCtx      = "num_ctx"
 	optionNumPredict  = "num_predict"
 	optionSeed        = "seed"
 	optionStop        = "stop"
@@ -304,19 +302,26 @@ func (p *Provider) convertParams(params providers.CompletionParams) (*api.ChatRe
 		}
 	}
 
-	// Handle reasoning/thinking.
-	if params.ReasoningEffort != "" &&
-		params.ReasoningEffort != providers.ReasoningEffortNone &&
-		params.ReasoningEffort != providers.ReasoningEffortAuto {
-		think := api.ThinkValue{Value: true}
-		req.Think = &think
+	// https://docs.ollama.com/api/chat defines think as a boolean or one of
+	// low, medium, high, and max. Preserve "none" as false on that wire type.
+	switch params.ReasoningEffort {
+	case "", providers.ReasoningEffortAuto:
+	case providers.ReasoningEffortNone:
+		req.Think = new(api.ThinkValue{Value: false})
+	case providers.ReasoningEffortLow,
+		providers.ReasoningEffortMedium,
+		providers.ReasoningEffortHigh,
+		providers.ReasoningEffort("max"):
+		req.Think = new(api.ThinkValue{Value: string(params.ReasoningEffort)})
+	default:
+		return nil, errors.NewUnsupportedParamError(providerName, "reasoning_effort")
 	}
 
 	return req, nil
 }
 
 func convertOptions(params providers.CompletionParams) map[string]any {
-	options := map[string]any{optionNumCtx: defaultNumCtx}
+	options := make(map[string]any)
 	if params.Temperature != nil {
 		options[optionTemperature] = *params.Temperature
 	}

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -235,9 +235,8 @@ func (p *Provider) ConvertError(err error) error {
 		case 429:
 			return errors.NewRateLimitError(providerName, err)
 		case 400:
-			if strings.Contains(statusErr.ErrorMessage, "context") {
-				return errors.NewContextLengthError(providerName, err)
-			}
+			// Ollama exposes only status and message, without a machine-readable
+			// context-length code. https://docs.ollama.com/api/errors
 			return errors.NewInvalidRequestError(providerName, err)
 		}
 	}

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -46,7 +46,6 @@ const (
 
 // Tool and response format constants.
 const (
-	emptyJSONObject      = "{}"
 	ollamaFormatJSON     = "json"
 	responseFormatJSON   = "json_object"
 	responseFormatSchema = "json_schema"
@@ -62,12 +61,6 @@ const (
 	objectEmbedding           = "embedding"
 	objectList                = "list"
 	objectModel               = "model"
-)
-
-// Thinking tag constants.
-const (
-	thinkingTagClose = "</think>"
-	thinkingTagOpen  = "<think>"
 )
 
 // Content part constants.
@@ -439,8 +432,10 @@ func convertDoneReason(reason string) string {
 	switch reason {
 	case doneReasonLength:
 		return providers.FinishReasonLength
-	default:
+	case "", doneReasonStop:
 		return providers.FinishReasonStop
+	default:
+		return reason
 	}
 }
 
@@ -724,12 +719,14 @@ func convertModelsResponse(resp *api.ListResponse) *providers.ModelsResponse {
 
 // convertResponse converts an Ollama response to provider format.
 func convertResponse(resp *api.ChatResponse) *providers.ChatCompletion {
-	content, reasoning := extractThinking(resp.Message.Content, resp.Message.Thinking)
-
 	message := providers.Message{
-		Role:      providers.RoleAssistant,
-		Content:   content,
-		Reasoning: reasoning,
+		Role:    providers.RoleAssistant,
+		Content: resp.Message.Content,
+	}
+	// The Chat schema exposes thinking separately, so content remains opaque.
+	// https://docs.ollama.com/api/chat
+	if resp.Message.Thinking != "" {
+		message.Reasoning = &providers.Reasoning{Content: resp.Message.Thinking}
 	}
 
 	// Handle tool calls.
@@ -804,20 +801,17 @@ func convertToolCalls(toolCalls []api.ToolCall) []providers.ToolCall {
 	result := make([]providers.ToolCall, 0, len(toolCalls))
 
 	for i, tc := range toolCalls {
-		args := emptyJSONObject
-		argsMap := tc.Function.Arguments.ToMap()
-		if len(argsMap) > 0 {
-			if argsBytes, err := json.Marshal(argsMap); err == nil {
-				args = string(argsBytes)
-			}
+		toolCallID := tc.ID
+		if toolCallID == "" {
+			toolCallID = fmt.Sprintf(toolCallIDFormat, i)
 		}
 
 		result = append(result, providers.ToolCall{
-			ID:   fmt.Sprintf(toolCallIDFormat, i),
+			ID:   toolCallID,
 			Type: toolTypeFunction,
 			Function: providers.FunctionCall{
 				Name:      tc.Function.Name,
-				Arguments: args,
+				Arguments: tc.Function.Arguments.String(),
 			},
 		})
 	}
@@ -911,35 +905,6 @@ func convertToolParameters(parameters map[string]any) (api.ToolFunctionParameter
 	}
 
 	return converted, nil
-}
-
-// extractThinking extracts thinking content from response.
-// It checks the dedicated Thinking field first, then falls back to parsing <think> tags.
-func extractThinking(content, thinking string) (string, *providers.Reasoning) {
-	// Check for dedicated thinking content first.
-	if thinking != "" {
-		return content, &providers.Reasoning{Content: thinking}
-	}
-
-	// Fall back to parsing <think> tags in content.
-	if !strings.Contains(content, thinkingTagOpen) || !strings.Contains(content, thinkingTagClose) {
-		return content, nil
-	}
-
-	parts := strings.SplitN(content, thinkingTagOpen, 2)
-	if len(parts) != 2 {
-		return content, nil
-	}
-
-	thinkParts := strings.SplitN(parts[1], thinkingTagClose, 2)
-	if len(thinkParts) != 2 {
-		return content, nil
-	}
-
-	reasoning := &providers.Reasoning{Content: thinkParts[0]}
-	cleanContent := strings.TrimSpace(parts[0] + thinkParts[1])
-
-	return cleanContent, reasoning
 }
 
 // generateID generates a unique ID for responses using crypto/rand.

--- a/providers/ollama/ollama_test.go
+++ b/providers/ollama/ollama_test.go
@@ -909,9 +909,9 @@ func TestConvertError(t *testing.T) {
 			wantSentinel: errors.ErrRateLimit,
 		},
 		{
-			name:         "StatusError 400 with context becomes ContextLengthError",
+			name:         "StatusError 400 with context remains InvalidRequestError",
 			err:          api.StatusError{StatusCode: 400, ErrorMessage: "context length exceeded"},
-			wantSentinel: errors.ErrContextLength,
+			wantSentinel: errors.ErrInvalidRequest,
 		},
 		{
 			name:         "StatusError 400 without context becomes InvalidRequestError",

--- a/providers/ollama/ollama_test.go
+++ b/providers/ollama/ollama_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -779,7 +781,6 @@ func TestStreamStateHandleChunk(t *testing.T) {
 		require.Equal(t, "llama3.2", chunk.Model)
 		require.Len(t, chunk.Choices, 1)
 		require.Equal(t, "Hello ", chunk.Choices[0].Delta.Content)
-		require.Equal(t, "Hello ", state.content.String())
 	})
 
 	t.Run("handles thinking chunk", func(t *testing.T) {
@@ -797,7 +798,6 @@ func TestStreamStateHandleChunk(t *testing.T) {
 
 		require.NotNil(t, chunk.Choices[0].Delta.Reasoning)
 		require.Equal(t, "Let me think...", chunk.Choices[0].Delta.Reasoning.Content)
-		require.Equal(t, "Let me think...", state.reasoning.String())
 	})
 
 	t.Run("handles done chunk with usage", func(t *testing.T) {
@@ -822,6 +822,7 @@ func TestStreamStateHandleChunk(t *testing.T) {
 		require.Equal(t, 10, chunk.Usage.PromptTokens)
 		require.Equal(t, 20, chunk.Usage.CompletionTokens)
 		require.Equal(t, 30, chunk.Usage.TotalTokens)
+		require.True(t, state.done)
 	})
 
 	t.Run("handles done chunk with tool calls", func(t *testing.T) {
@@ -967,6 +968,135 @@ func TestGenerateID(t *testing.T) {
 	require.NotEmpty(t, id2)
 	require.True(t, strings.HasPrefix(id1, "chatcmpl-"))
 	require.NotEqual(t, id1, id2) // IDs should be unique.
+}
+
+func newTestProvider(t *testing.T, handler http.Handler) *Provider {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	provider, err := New(config.WithBaseURL(server.URL))
+	require.NoError(t, err)
+
+	return provider
+}
+
+func TestCompletionRequiresTerminalResponse(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintln(w, `{"model":"test","message":{"role":"assistant","content":"partial"},"done":false}`)
+	}))
+
+	_, err := provider.Completion(t.Context(), providers.CompletionParams{Model: "test"})
+	require.ErrorIs(t, err, errors.ErrProvider)
+}
+
+func TestCompletionAcceptsTerminalResponse(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintln(w, `{"model":"test","message":{"role":"assistant","content":"done"},"done":true}`)
+	}))
+
+	response, err := provider.Completion(t.Context(), providers.CompletionParams{Model: "test"})
+
+	require.NoError(t, err)
+	require.Equal(t, "done", response.Choices[0].Message.Content)
+}
+
+func TestCompletionStreamRequiresTerminalResponse(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintln(w, `{"model":"test","message":{"role":"assistant","content":"partial"},"done":false}`)
+	}))
+
+	chunks, errs := provider.CompletionStream(t.Context(), providers.CompletionParams{Model: "test"})
+	chunkCount := 0
+	for range chunks {
+		chunkCount++
+	}
+
+	require.Equal(t, 1, chunkCount)
+	require.ErrorIs(t, <-errs, errors.ErrProvider)
+}
+
+func TestCompletionStreamAcceptsTerminalResponse(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintln(w, `{"model":"test","message":{"role":"assistant","content":"done"},"done":true}`)
+	}))
+
+	chunks, errs := provider.CompletionStream(t.Context(), providers.CompletionParams{Model: "test"})
+	chunkCount := 0
+	for range chunks {
+		chunkCount++
+	}
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, 1, chunkCount)
+}
+
+func TestCompletionStreamReturnsMidstreamError(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintln(w, `{"model":"test","message":{"role":"assistant","content":"partial"},"done":false}`)
+		_, _ = fmt.Fprintln(w, `{"error":"generation failed"}`)
+	}))
+
+	chunks, errs := provider.CompletionStream(t.Context(), providers.CompletionParams{Model: "test"})
+	chunkCount := 0
+	for range chunks {
+		chunkCount++
+	}
+
+	require.Equal(t, 1, chunkCount)
+	require.ErrorIs(t, <-errs, errors.ErrProvider)
+}
+
+func TestCompletionStreamCancellationUnblocksUnreadConsumer(t *testing.T) {
+	t.Parallel()
+
+	wroteChunk := make(chan struct{})
+	provider := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintln(w, `{"model":"test","message":{"role":"assistant","content":"partial"},"done":false}`)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+		flusher.Flush()
+		close(wroteChunk)
+		<-request.Context().Done()
+	}))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	chunks, errs := provider.CompletionStream(ctx, providers.CompletionParams{Model: "test"})
+	select {
+	case <-wroteChunk:
+	case <-time.After(time.Second):
+		t.Fatal("server did not write the first stream chunk")
+	}
+	cancel()
+
+	select {
+	case err := <-errs:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("stream did not stop after cancellation")
+	}
+	_, open := <-chunks
+	require.False(t, open)
 }
 
 // Integration tests - only run if Ollama is available.

--- a/providers/ollama/ollama_test.go
+++ b/providers/ollama/ollama_test.go
@@ -194,7 +194,7 @@ func TestConvertDoneReason(t *testing.T) {
 		{
 			name:     "unknown reason",
 			reason:   "unknown",
-			expected: providers.FinishReasonStop,
+			expected: "unknown",
 		},
 	}
 
@@ -402,20 +402,24 @@ func TestConvertToolCalls(t *testing.T) {
 
 	toolCalls := []api.ToolCall{
 		{
+			ID: "server-call-id",
 			Function: api.ToolCallFunction{
 				Name:      "get_weather",
 				Arguments: args,
 			},
 		},
+		{Function: api.ToolCallFunction{Name: "fallback_id"}},
 	}
 
 	result := convertToolCalls(toolCalls)
 
-	require.Len(t, result, 1)
-	require.Equal(t, "call_0", result[0].ID)
+	require.Len(t, result, 2)
+	require.Equal(t, "server-call-id", result[0].ID)
 	require.Equal(t, toolTypeFunction, result[0].Type)
 	require.Equal(t, "get_weather", result[0].Function.Name)
-	require.Contains(t, result[0].Function.Arguments, "Paris")
+	require.JSONEq(t, `{"location":"Paris"}`, result[0].Function.Arguments)
+	require.Equal(t, "call_1", result[1].ID)
+	require.JSONEq(t, `{}`, result[1].Function.Arguments)
 }
 
 func TestConvertResponseFormat(t *testing.T) {
@@ -851,37 +855,23 @@ func TestStreamStateHandleChunk(t *testing.T) {
 	})
 }
 
-func TestExtractThinking(t *testing.T) {
+func TestConvertResponsePreservesOfficialThinkingField(t *testing.T) {
 	t.Parallel()
 
-	t.Run("returns dedicated thinking content", func(t *testing.T) {
-		t.Parallel()
-
-		content, reasoning := extractThinking("Hello", "I'm thinking...")
-
-		require.Equal(t, "Hello", content)
-		require.NotNil(t, reasoning)
-		require.Equal(t, "I'm thinking...", reasoning.Content)
+	response := convertResponse(&api.ChatResponse{
+		Message: api.Message{
+			Content:  "<think>literal content</think>Hello",
+			Thinking: "official thinking field",
+		},
 	})
 
-	t.Run("parses think tags from content", func(t *testing.T) {
-		t.Parallel()
+	message := response.Choices[0].Message
+	require.Equal(t, "<think>literal content</think>Hello", message.Content)
+	require.NotNil(t, message.Reasoning)
+	require.Equal(t, "official thinking field", message.Reasoning.Content)
 
-		content, reasoning := extractThinking("<think>Let me think</think>Hello world", "")
-
-		require.Equal(t, "Hello world", content)
-		require.NotNil(t, reasoning)
-		require.Equal(t, "Let me think", reasoning.Content)
-	})
-
-	t.Run("returns nil reasoning when no thinking", func(t *testing.T) {
-		t.Parallel()
-
-		content, reasoning := extractThinking("Hello world", "")
-
-		require.Equal(t, "Hello world", content)
-		require.Nil(t, reasoning)
-	})
+	withoutThinking := convertResponse(&api.ChatResponse{Message: api.Message{Content: "Hello"}})
+	require.Nil(t, withoutThinking.Choices[0].Message.Reasoning)
 }
 
 func TestConvertError(t *testing.T) {

--- a/providers/ollama/ollama_test.go
+++ b/providers/ollama/ollama_test.go
@@ -266,6 +266,10 @@ func TestConvertMessageImages(t *testing.T) {
 func TestConvertTools(t *testing.T) {
 	t.Parallel()
 
+	empty, err := convertTools(nil)
+	require.NoError(t, err)
+	require.Nil(t, empty)
+
 	tools := []providers.Tool{
 		{
 			Type: toolTypeFunction,
@@ -273,26 +277,119 @@ func TestConvertTools(t *testing.T) {
 				Name:        "get_weather",
 				Description: "Get the current weather",
 				Parameters: map[string]any{
-					schemaKeyType: schemaTypeObject,
-					schemaKeyProperties: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
 						"location": map[string]any{
-							schemaKeyType:        "string",
-							schemaKeyDescription: "The city name",
+							"type":        "string",
+							"description": "The city name",
 						},
 					},
-					schemaKeyRequired: []any{"location"},
+					"required": []any{"location"},
 				},
 			},
 		},
 	}
 
-	result := convertTools(tools)
+	result, err := convertTools(tools)
+	require.NoError(t, err)
 
-	require.Len(t, result, 1)
-	require.Equal(t, toolTypeFunction, result[0].Type)
-	require.Equal(t, "get_weather", result[0].Function.Name)
-	require.Equal(t, "Get the current weather", result[0].Function.Description)
-	require.Contains(t, result[0].Function.Parameters.Required, "location")
+	wire, err := json.Marshal(result)
+	require.NoError(t, err)
+	require.JSONEq(t, `[{"type":"function","function":{
+		"name":"get_weather",
+		"description":"Get the current weather",
+		"parameters":{
+			"type":"object",
+			"required":["location"],
+			"properties":{"location":{"type":"string","description":"The city name"}}
+		}
+	}}]`, string(wire))
+}
+
+func TestConvertToolsRejectsInvalidDefinitions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		tool    providers.Tool
+		wantErr error
+	}{
+		{
+			name:    "unknown tool type",
+			tool:    providers.Tool{Type: "custom"},
+			wantErr: errors.ErrUnsupportedParam,
+		},
+		{
+			name: "missing function name",
+			tool: providers.Tool{
+				Type: toolTypeFunction,
+				Function: providers.Function{
+					Parameters: map[string]any{"type": "object", "properties": map[string]any{}},
+				},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name: "missing parameters schema",
+			tool: providers.Tool{
+				Type: toolTypeFunction, Function: providers.Function{Name: "get_weather"},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			converted, err := convertTools([]providers.Tool{testCase.tool})
+
+			require.Nil(t, converted)
+			require.ErrorIs(t, err, testCase.wantErr)
+		})
+	}
+}
+
+func TestConvertToolsRejectsInvalidOrLossySchemas(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		params  map[string]any
+		wantErr error
+	}{
+		{
+			name:    "unencodable schema",
+			params:  map[string]any{"type": make(chan int)},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name:    "invalid schema shape",
+			params:  map[string]any{"type": "object", "properties": []string{"not", "a", "mapping"}},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name:    "schema outside SDK subset",
+			params:  map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false},
+			wantErr: errors.ErrUnsupportedParam,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			converted, err := convertTools([]providers.Tool{{
+				Type: toolTypeFunction,
+				Function: providers.Function{
+					Name: "get_weather", Parameters: testCase.params,
+				},
+			}})
+
+			require.Nil(t, converted)
+			require.ErrorIs(t, err, testCase.wantErr)
+		})
+	}
 }
 
 func TestConvertToolCalls(t *testing.T) {

--- a/providers/ollama/ollama_test.go
+++ b/providers/ollama/ollama_test.go
@@ -2,6 +2,7 @@ package ollama
 
 import (
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"fmt"
 	"strings"
@@ -18,6 +19,27 @@ import (
 )
 
 const testOllamaAvailabilityTimeout = 5 * time.Second
+
+type invalidMessageCase struct {
+	name    string
+	msg     providers.Message
+	wantErr error
+}
+
+func runInvalidMessageCases(t *testing.T, tests []invalidMessageCase) {
+	t.Helper()
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			converted, err := convertMessage(testCase.msg)
+
+			require.Nil(t, converted)
+			require.ErrorIs(t, err, testCase.wantErr)
+		})
+	}
+}
 
 func TestNew(t *testing.T) {
 	// Note: Not using t.Parallel() here because child test uses t.Setenv.
@@ -66,91 +88,41 @@ func TestCapabilities(t *testing.T) {
 	require.True(t, caps.ListModels)
 }
 
-func TestConvertMessages(t *testing.T) {
+func TestConvertMessagesPreservesToolResultNameAndReasoning(t *testing.T) {
 	t.Parallel()
 
-	t.Run("converts system message", func(t *testing.T) {
-		t.Parallel()
-
-		messages := []providers.Message{
-			{Role: providers.RoleSystem, Content: "You are a helpful assistant."},
-		}
-
-		result := convertMessages(messages)
-
-		require.Len(t, result, 1)
-		require.Equal(t, providers.RoleSystem, result[0].Role)
-		require.Equal(t, "You are a helpful assistant.", result[0].Content)
-	})
-
-	t.Run("converts user message", func(t *testing.T) {
-		t.Parallel()
-
-		messages := []providers.Message{
-			{Role: providers.RoleUser, Content: "Hello"},
-		}
-
-		result := convertMessages(messages)
-
-		require.Len(t, result, 1)
-		require.Equal(t, providers.RoleUser, result[0].Role)
-		require.Equal(t, "Hello", result[0].Content)
-	})
-
-	t.Run("converts assistant message", func(t *testing.T) {
-		t.Parallel()
-
-		messages := []providers.Message{
-			{Role: providers.RoleAssistant, Content: "Hi there!"},
-		}
-
-		result := convertMessages(messages)
-
-		require.Len(t, result, 1)
-		require.Equal(t, providers.RoleAssistant, result[0].Role)
-		require.Equal(t, "Hi there!", result[0].Content)
-	})
-
-	t.Run("converts tool message to user message", func(t *testing.T) {
-		t.Parallel()
-
-		messages := []providers.Message{
-			{Role: providers.RoleTool, Content: "sunny, 22°C", ToolCallID: "call_123"},
-		}
-
-		result := convertMessages(messages)
-
-		require.Len(t, result, 1)
-		require.Equal(t, providers.RoleUser, result[0].Role) // Ollama uses user for tool results.
-	})
-
-	t.Run("converts assistant message with tool calls", func(t *testing.T) {
-		t.Parallel()
-
-		messages := []providers.Message{
-			{
-				Role:    providers.RoleAssistant,
-				Content: "",
-				ToolCalls: []providers.ToolCall{
-					{
-						ID:   "call_123",
-						Type: toolTypeFunction,
-						Function: providers.FunctionCall{
-							Name:      "get_weather",
-							Arguments: `{"location": "Paris"}`,
-						},
-					},
+	messages := []providers.Message{
+		{Role: providers.RoleSystem, Content: "Use tools."},
+		{Role: providers.RoleUser, Content: "Weather?"},
+		{
+			Role:      providers.RoleAssistant,
+			Content:   "",
+			Reasoning: &providers.Reasoning{Content: "checking"},
+			ToolCalls: []providers.ToolCall{{
+				ID:   "call_weather",
+				Type: toolTypeFunction,
+				Function: providers.FunctionCall{
+					Name:      "get_weather",
+					Arguments: `{"city":"Paris"}`,
 				},
-			},
-		}
+			}},
+		},
+		{Role: providers.RoleTool, Content: "sunny", ToolCallID: "call_weather"},
+	}
 
-		result := convertMessages(messages)
+	converted, err := convertMessages(messages)
+	require.NoError(t, err)
 
-		require.Len(t, result, 1)
-		require.Equal(t, providers.RoleAssistant, result[0].Role)
-		require.Len(t, result[0].ToolCalls, 1)
-		require.Equal(t, "get_weather", result[0].ToolCalls[0].Function.Name)
-	})
+	wire, err := json.Marshal(converted)
+	require.NoError(t, err)
+	require.JSONEq(t, `[
+		{"role":"system","content":"Use tools."},
+		{"role":"user","content":"Weather?"},
+		{"role":"assistant","content":"","thinking":"checking","tool_calls":[
+			{"function":{"index":0,"name":"get_weather","arguments":{"city":"Paris"}}}
+		]},
+		{"role":"tool","content":"sunny","tool_name":"get_weather"}
+	]`, string(wire))
 }
 
 func TestConvertDoneReason(t *testing.T) {
@@ -193,32 +165,42 @@ func TestConvertDoneReason(t *testing.T) {
 	}
 }
 
-func TestExtractImages(t *testing.T) {
+func TestConvertMessageImages(t *testing.T) {
 	t.Parallel()
 
-	t.Run("extracts base64 image", func(t *testing.T) {
+	t.Run("decodes a base64 data URL once", func(t *testing.T) {
 		t.Parallel()
 
 		msg := providers.Message{
 			Role: providers.RoleUser,
-			Content: []providers.ContentPart{
-				{Type: "text", Text: "What's in this image?"},
-				{
-					Type: "image_url",
-					ImageURL: &providers.ImageURL{
-						URL: "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+			Content: []any{
+				map[string]any{"type": "text", "text": "What's in this image?"},
+				map[string]any{
+					"type": "image_url",
+					"image_url": map[string]any{
+						"url": "data:image/jpeg;base64,aGVsbG8=",
 					},
 				},
 			},
 		}
 
-		images := extractImages(msg)
+		converted, err := convertMessage(msg)
 
-		require.Len(t, images, 1)
-		require.Equal(t, "/9j/4AAQSkZJRg==", string(images[0]))
+		require.NoError(t, err)
+		require.Equal(t, "What's in this image?", converted.Content)
+		require.Len(t, converted.Images, 1)
+		require.Equal(t, "hello", string(converted.Images[0]))
+
+		wire, err := json.Marshal(converted)
+		require.NoError(t, err)
+		require.JSONEq(t, `{
+			"role":"user",
+			"content":"What's in this image?",
+			"images":["aGVsbG8="]
+		}`, string(wire))
 	})
 
-	t.Run("ignores non-data URLs", func(t *testing.T) {
+	t.Run("rejects image URLs the SDK cannot encode", func(t *testing.T) {
 		t.Parallel()
 
 		msg := providers.Message{
@@ -233,9 +215,10 @@ func TestExtractImages(t *testing.T) {
 			},
 		}
 
-		images := extractImages(msg)
+		converted, err := convertMessage(msg)
 
-		require.Empty(t, images)
+		require.Nil(t, converted)
+		require.ErrorIs(t, err, errors.ErrUnsupportedParam)
 	})
 }
 
@@ -337,45 +320,202 @@ func TestConvertResponseFormat(t *testing.T) {
 	})
 }
 
-func TestConvertMessage(t *testing.T) {
+func TestConvertMessageRejectsInvalidMetadata(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name         string
-		msg          providers.Message
-		expectedRole string
-	}{
+	tests := []invalidMessageCase{
 		{
-			name:         "user message",
-			msg:          providers.Message{Role: providers.RoleUser, Content: "Hello"},
-			expectedRole: providers.RoleUser,
+			name:    "unknown role",
+			msg:     providers.Message{Role: "developer", Content: "Hello"},
+			wantErr: errors.ErrInvalidRequest,
 		},
 		{
-			name:         "assistant message",
-			msg:          providers.Message{Role: providers.RoleAssistant, Content: "Hi"},
-			expectedRole: providers.RoleAssistant,
+			name:    "name on user message",
+			msg:     providers.Message{Role: providers.RoleUser, Content: "Hello", Name: "alice"},
+			wantErr: errors.ErrUnsupportedParam,
 		},
 		{
-			name:         "system message",
-			msg:          providers.Message{Role: providers.RoleSystem, Content: "You are helpful"},
-			expectedRole: providers.RoleSystem,
+			name: "tool call on user message",
+			msg: providers.Message{
+				Role: providers.RoleUser, Content: "Hello", ToolCalls: []providers.ToolCall{{}},
+			},
+			wantErr: errors.ErrUnsupportedParam,
 		},
 		{
-			name:         "tool message becomes user",
-			msg:          providers.Message{Role: providers.RoleTool, Content: "result", ToolCallID: "123"},
-			expectedRole: providers.RoleUser,
+			name: "reasoning on user message",
+			msg: providers.Message{
+				Role: providers.RoleUser, Content: "Hello", Reasoning: &providers.Reasoning{Content: "why"},
+			},
+			wantErr: errors.ErrUnsupportedParam,
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+	runInvalidMessageCases(t, tests)
+}
 
-			result := convertMessage(tc.msg)
-			require.NotNil(t, result)
-			require.Equal(t, tc.expectedRole, result.Role)
-		})
+func TestConvertMessageRejectsInvalidContent(t *testing.T) {
+	t.Parallel()
+
+	tests := []invalidMessageCase{
+		{
+			name:    "unsupported content representation",
+			msg:     providers.Message{Role: providers.RoleUser, Content: 42},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name:    "invalid dynamic content part",
+			msg:     providers.Message{Role: providers.RoleUser, Content: []any{"text"}},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name: "unknown dynamic content field",
+			msg: providers.Message{
+				Role: providers.RoleUser,
+				Content: []any{map[string]any{
+					"type": "text", "text": "Hello", "future": true,
+				}},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name: "unknown content part",
+			msg: providers.Message{
+				Role: providers.RoleUser, Content: []providers.ContentPart{{Type: "audio"}},
+			},
+			wantErr: errors.ErrUnsupportedParam,
+		},
 	}
+
+	runInvalidMessageCases(t, tests)
+}
+
+func TestConvertMessageRejectsInvalidImageContent(t *testing.T) {
+	t.Parallel()
+
+	tests := []invalidMessageCase{
+		{
+			name: "text part with image field",
+			msg: providers.Message{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{{
+					Type: contentTypeText, ImageURL: &providers.ImageURL{URL: "data:image/png;base64,aA=="},
+				}},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name: "image part without URL",
+			msg: providers.Message{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{{
+					Type: contentTypeImageURL,
+				}},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name: "invalid image base64",
+			msg: providers.Message{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{{
+					Type: contentTypeImageURL, ImageURL: &providers.ImageURL{URL: "data:image/png;base64,!"},
+				}},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name: "unsupported image detail",
+			msg: providers.Message{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{{
+					Type: contentTypeImageURL,
+					ImageURL: &providers.ImageURL{
+						URL: "data:image/png;base64,aA==", Detail: "high",
+					},
+				}},
+			},
+			wantErr: errors.ErrUnsupportedParam,
+		},
+	}
+
+	runInvalidMessageCases(t, tests)
+}
+
+func TestConvertMessageRejectsInvalidToolCall(t *testing.T) {
+	t.Parallel()
+
+	tests := []invalidMessageCase{
+		{
+			name: "unknown tool call type",
+			msg: providers.Message{
+				Role: providers.RoleAssistant,
+				ToolCalls: []providers.ToolCall{{
+					Type: "custom", Function: providers.FunctionCall{Arguments: `{}`},
+				}},
+			},
+			wantErr: errors.ErrUnsupportedParam,
+		},
+		{
+			name: "missing tool function name",
+			msg: providers.Message{
+				Role: providers.RoleAssistant,
+				ToolCalls: []providers.ToolCall{{
+					Type: toolTypeFunction, Function: providers.FunctionCall{Arguments: `{}`},
+				}},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name: "non-object tool arguments",
+			msg: providers.Message{
+				Role: providers.RoleAssistant,
+				ToolCalls: []providers.ToolCall{{
+					Type:     toolTypeFunction,
+					Function: providers.FunctionCall{Name: "get_weather", Arguments: `[]`},
+				}},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+		{
+			name: "null tool arguments",
+			msg: providers.Message{
+				Role: providers.RoleAssistant,
+				ToolCalls: []providers.ToolCall{{
+					Type:     toolTypeFunction,
+					Function: providers.FunctionCall{Name: "get_weather", Arguments: `null`},
+				}},
+			},
+			wantErr: errors.ErrInvalidRequest,
+		},
+	}
+
+	runInvalidMessageCases(t, tests)
+}
+
+func TestConvertMessagesRejectsUnresolvedToolResult(t *testing.T) {
+	t.Parallel()
+
+	converted, err := convertMessages([]providers.Message{{
+		Role: providers.RoleTool, Content: "sunny", ToolCallID: "missing",
+	}})
+
+	require.Nil(t, converted)
+	require.ErrorIs(t, err, errors.ErrInvalidRequest)
+}
+
+func TestCompletionEntryPointsRejectInvalidMessages(t *testing.T) {
+	t.Parallel()
+
+	provider := &Provider{}
+	params := providers.CompletionParams{Messages: []providers.Message{{Role: "developer"}}}
+
+	completion, err := provider.Completion(t.Context(), params)
+	require.Nil(t, completion)
+	require.ErrorIs(t, err, errors.ErrInvalidRequest)
+
+	chunks, streamErrors := provider.CompletionStream(t.Context(), params)
+	require.Empty(t, chunks)
+	require.ErrorIs(t, <-streamErrors, errors.ErrInvalidRequest)
 }
 
 func TestNewStreamState(t *testing.T) {

--- a/providers/ollama/ollama_test.go
+++ b/providers/ollama/ollama_test.go
@@ -88,6 +88,47 @@ func TestCapabilities(t *testing.T) {
 	require.True(t, caps.ListModels)
 }
 
+func TestConvertParamsPreservesReasoningAndModelDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		effort   providers.ReasoningEffort
+		wantJSON string
+		wantErr  error
+	}{
+		{name: "unset", wantJSON: "null"},
+		{name: "auto", effort: providers.ReasoningEffortAuto, wantJSON: "null"},
+		{name: "none", effort: providers.ReasoningEffortNone, wantJSON: "false"},
+		{name: "low", effort: providers.ReasoningEffortLow, wantJSON: `"low"`},
+		{name: "medium", effort: providers.ReasoningEffortMedium, wantJSON: `"medium"`},
+		{name: "high", effort: providers.ReasoningEffortHigh, wantJSON: `"high"`},
+		{name: "max", effort: providers.ReasoningEffort("max"), wantJSON: `"max"`},
+		{name: "unsupported", effort: providers.ReasoningEffort("xhigh"), wantErr: errors.ErrUnsupportedParam},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			request, err := (&Provider{}).convertParams(providers.CompletionParams{
+				ReasoningEffort: testCase.effort,
+			})
+			if testCase.wantErr != nil {
+				require.Nil(t, request)
+				require.ErrorIs(t, err, testCase.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Empty(t, request.Options)
+			encoded, err := json.Marshal(request.Think)
+			require.NoError(t, err)
+			require.Equal(t, testCase.wantJSON, string(encoded))
+		})
+	}
+}
+
 func TestConvertMessagesPreservesToolResultNameAndReasoning(t *testing.T) {
 	t.Parallel()
 

--- a/providers/ollama/ollama_test.go
+++ b/providers/ollama/ollama_test.go
@@ -422,7 +422,9 @@ func TestConvertResponseFormat(t *testing.T) {
 	t.Run("nil format returns nil", func(t *testing.T) {
 		t.Parallel()
 
-		result := convertResponseFormat(nil)
+		result, err := convertResponseFormat(nil)
+
+		require.NoError(t, err)
 		require.Nil(t, result)
 	})
 
@@ -430,10 +432,20 @@ func TestConvertResponseFormat(t *testing.T) {
 		t.Parallel()
 
 		format := &providers.ResponseFormat{Type: responseFormatJSON}
-		result := convertResponseFormat(format)
+		result, err := convertResponseFormat(format)
 
+		require.NoError(t, err)
 		require.NotNil(t, result)
 		require.Equal(t, `"json"`, string(result))
+	})
+
+	t.Run("text format uses the model default", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := convertResponseFormat(&providers.ResponseFormat{Type: responseFormatText})
+
+		require.NoError(t, err)
+		require.Nil(t, result)
 	})
 
 	t.Run("json_schema format", func(t *testing.T) {
@@ -444,17 +456,79 @@ func TestConvertResponseFormat(t *testing.T) {
 			JSONSchema: &providers.JSONSchema{
 				Name: "test",
 				Schema: map[string]any{
-					schemaKeyType: schemaTypeObject,
-					schemaKeyProperties: map[string]any{
-						"name": map[string]any{schemaKeyType: "string"},
+					"type": "object",
+					"properties": map[string]any{
+						"name": map[string]any{"type": "string"},
 					},
 				},
 			},
 		}
-		result := convertResponseFormat(format)
+		result, err := convertResponseFormat(format)
 
-		require.NotNil(t, result)
-		require.Contains(t, string(result), schemaKeyProperties)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"type":"object","properties":{"name":{"type":"string"}}}`, string(result))
+	})
+
+	t.Run("rejects missing json schema", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := convertResponseFormat(&providers.ResponseFormat{Type: responseFormatSchema})
+
+		require.Nil(t, result)
+		require.ErrorIs(t, err, errors.ErrInvalidRequest)
+	})
+
+	t.Run("rejects unencodable json schema", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := convertResponseFormat(&providers.ResponseFormat{
+			Type: responseFormatSchema,
+			JSONSchema: &providers.JSONSchema{
+				Schema: map[string]any{"invalid": make(chan int)},
+			},
+		})
+
+		require.Nil(t, result)
+		require.ErrorIs(t, err, errors.ErrInvalidRequest)
+	})
+
+	t.Run("accepts strict json schema", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := convertResponseFormat(&providers.ResponseFormat{
+			Type: responseFormatSchema,
+			JSONSchema: &providers.JSONSchema{
+				Schema: map[string]any{"type": "object"},
+				Strict: new(true),
+			},
+		})
+
+		require.NoError(t, err)
+		require.JSONEq(t, `{"type":"object"}`, string(result))
+	})
+
+	t.Run("rejects disabled strict mode", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := convertResponseFormat(&providers.ResponseFormat{
+			Type: responseFormatSchema,
+			JSONSchema: &providers.JSONSchema{
+				Schema: map[string]any{"type": "object"},
+				Strict: new(false),
+			},
+		})
+
+		require.Nil(t, result)
+		require.ErrorIs(t, err, errors.ErrUnsupportedParam)
+	})
+
+	t.Run("rejects unknown format", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := convertResponseFormat(&providers.ResponseFormat{Type: "yaml"})
+
+		require.Nil(t, result)
+		require.ErrorIs(t, err, errors.ErrUnsupportedParam)
 	})
 }
 


### PR DESCRIPTION
## Summary

Normalize Ollama responses from the fields the current Chat contract and official SDK actually expose, without parsing user-visible content or guessing error categories from free-form text.

## Changes

- Preserve `message.content` exactly and use only `message.thinking` for normalized reasoning.
- Preserve SDK tool-call IDs when present and synthesize the existing positional fallback only when Ollama omits one.
- Use the SDK argument object's JSON serialization directly, including the empty `{}` value.
- Preserve unknown `done_reason` strings instead of rewriting them as `stop`.
- Keep documented HTTP 400 errors as invalid requests instead of treating any message containing `context` as a context-length error.
- Delete the speculative `<think>...</think>` parser, its constants, and related tests.

## Dependency and review range

This branch includes Draft #143, #157, #158, and #159 because GitHub cannot use a contributor-fork branch as the upstream PR base. Review only these owning commits after #159:

- `c9deddb fix(ollama): preserve response wire semantics`
- `dd0b1bd fix(ollama): remove speculative context errors`
- two files, production `+17/-53`, direct tests `+22/-32`

No request conversion, schema, stream transport, SDK dependency, public type, or new capability changes are included.

## Contract basis

- Chat OpenAPI: <https://docs.ollama.com/api/chat>
- Error contract: <https://docs.ollama.com/api/errors>
- Tool calling: <https://docs.ollama.com/capabilities/tool-calling>
- Latest formal Go SDK release checked: `v0.33.2`, commit [`f96e7aa`](https://github.com/ollama/ollama/commit/f96e7aa0513b9973a0ccc71be414c2ecb9d65b1a)
- SDK wire types checked: [`api/types.go`](https://github.com/ollama/ollama/blob/f96e7aa0513b9973a0ccc71be414c2ecb9d65b1a/api/types.go)

The current Chat schema exposes `content`, `thinking`, `done_reason`, and tool calls as separate fields. It does not define `<think>` parsing. The error API exposes an HTTP status and free-form `error` message without a machine-readable context-length code.

No SDK upgrade is needed. The repository's `v0.32.5` response and tool-call types provide the fields used here, and the tests pass against a temporary `v0.33.2` modfile.

## Ablation

Deleting the content parser removes 35 production lines while the dedicated-thinking, literal-content, provider, race, and full tests remain green. Replacing argument map conversion with the SDK's own `String` method removes a lossy marshal branch and retains exact object JSON. Deleting the error-message heuristic leaves the documented status mapping intact.

## Testing

- focused response, tool-call, done-reason, and error tests repeated ten times
- `go test ./providers/ollama -count=1`
- `CGO_ENABLED=1 go test -race ./providers/ollama -count=1`
- `go test ./... -count=1`
- `go mod tidy -diff`
- `go mod verify`
- `golangci-lint run --fix=false ./providers/ollama/...`
- all 112 non-deprecated GolangCI-Lint 2.13.2 linters on the owning diff: four reports, all deliberate partial official-SDK fixtures; no production-code finding
- temporary `v0.33.2` modfile: provider tests pass
- `git diff --check`

No local Ollama daemon or model is available. Live response, tool-call ID, and error-envelope behavior remain incomplete.

## Checklist

- [x] Linting passes
- [x] Tests pass locally
- [x] Current official sources and immutable SDK revision recorded
- [x] Speculative parser and heuristic removed
- [x] No dependency or public API change