### PR TITLE
fix(mistral): preserve thinking stream chunks

### DIFF
--- a/anyllm.go
+++ b/anyllm.go
@@ -53,11 +53,14 @@ const (
 
 // ReasoningEffort levels.
 const (
-	ReasoningEffortAuto   = providers.ReasoningEffortAuto
-	ReasoningEffortHigh   = providers.ReasoningEffortHigh
-	ReasoningEffortLow    = providers.ReasoningEffortLow
-	ReasoningEffortMedium = providers.ReasoningEffortMedium
-	ReasoningEffortNone   = providers.ReasoningEffortNone
+	ReasoningEffortAuto    = providers.ReasoningEffortAuto
+	ReasoningEffortHigh    = providers.ReasoningEffortHigh
+	ReasoningEffortLow     = providers.ReasoningEffortLow
+	ReasoningEffortMax     = providers.ReasoningEffortMax
+	ReasoningEffortMedium  = providers.ReasoningEffortMedium
+	ReasoningEffortMinimal = providers.ReasoningEffortMinimal
+	ReasoningEffortNone    = providers.ReasoningEffortNone
+	ReasoningEffortXHigh   = providers.ReasoningEffortXHigh
 )
 
 // Provider types.
@@ -179,17 +182,17 @@ var (
 
 // Error types.
 type (
-	AuthenticationError           = errors.AuthenticationError
-	BaseError                     = errors.BaseError
-	ContentFilterError            = errors.ContentFilterError
-	ContextLengthError            = errors.ContextLengthError
-	InsufficientFundsError        = errors.InsufficientFundsError
-	InvalidRequestError           = errors.InvalidRequestError
-	MissingAPIKeyError            = errors.MissingAPIKeyError
-	ModelNotFoundError            = errors.ModelNotFoundError
-	ProviderError                 = errors.ProviderError
-	RateLimitError                = errors.RateLimitError
-	UnsupportedOperationError     = errors.UnsupportedOperationError
-	UnsupportedParamError         = errors.UnsupportedParamError
-	UnsupportedProviderError      = errors.UnsupportedProviderError
+	AuthenticationError       = errors.AuthenticationError
+	BaseError                 = errors.BaseError
+	ContentFilterError        = errors.ContentFilterError
+	ContextLengthError        = errors.ContextLengthError
+	InsufficientFundsError    = errors.InsufficientFundsError
+	InvalidRequestError       = errors.InvalidRequestError
+	MissingAPIKeyError        = errors.MissingAPIKeyError
+	ModelNotFoundError        = errors.ModelNotFoundError
+	ProviderError             = errors.ProviderError
+	RateLimitError            = errors.RateLimitError
+	UnsupportedOperationError = errors.UnsupportedOperationError
+	UnsupportedParamError     = errors.UnsupportedParamError
+	UnsupportedProviderError  = errors.UnsupportedProviderError
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/mozilla-ai/any-llm-platform-client-go v0.0.1
 	github.com/ollama/ollama v0.32.5
-	github.com/openai/openai-go v1.12.0
+	github.com/openai/openai-go/v3 v3.42.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/genai v1.66.0
 )

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/mozilla-ai/any-llm-platform-client-go v0.0.1 h1:AXmEYxIEIESUt2LyB6GFD
 github.com/mozilla-ai/any-llm-platform-client-go v0.0.1/go.mod h1:bqmvllQOUir9G2bmglRQDEgsfHCF6jAC339JGWkzH4U=
 github.com/ollama/ollama v0.32.5 h1:5jeKnTJmDTR+xgB8qh68szdXM9zwnMBMtGl890frdzo=
 github.com/ollama/ollama v0.32.5/go.mod h1:b1ydCt2oVg0VAg22WWDgCbwW0AyOaRKAFzlS91NI4OY=
-github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
-github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
+github.com/openai/openai-go/v3 v3.42.0 h1:16Skv1hpEhSm3imZpPGSeEBDUgVJJA9cHryKGGsVYI8=
+github.com/openai/openai-go/v3 v3.42.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"slices"
 
-	oaisdk "github.com/openai/openai-go"
-	"github.com/openai/openai-go/packages/param"
+	oaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
@@ -160,17 +160,12 @@ func preprocessParams(params providers.CompletionParams) providers.CompletionPar
 	}
 }
 
-// transformRequest adjusts the OpenAI SDK request for DeepSeek's API.
-// DeepSeek uses max_tokens, not max_completion_tokens.
-// If both are set, MaxCompletionTokens takes precedence over MaxTokens.
-// See: https://api-docs.deepseek.com/api/create-chat-completion
+// transformRequest maps the shared token limit to DeepSeek's max_tokens field.
+// https://api-docs.deepseek.com/api/create-chat-completion
 func transformRequest(req *oaisdk.ChatCompletionNewParams) {
 	if req.MaxCompletionTokens.Valid() {
-		// Set max_tokens using max_completion_tokens value.
 		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
 	}
-
-	// Clear unsupported fields from the request.
 	req.MaxCompletionTokens = param.Opt[int64]{}
 }
 

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/v3"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/errors"
@@ -373,7 +373,7 @@ func capabilities() providers.Capabilities {
 		CompletionImage:     true,
 		CompletionPDF:       true,
 		CompletionReasoning: true,
-		CompletionStreaming:  true,
+		CompletionStreaming: true,
 		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
@@ -703,7 +703,9 @@ func (p *Provider) handleRerankErrorResponse(resp *http.Response) error {
 	case http.StatusTooManyRequests:
 		return errors.NewRateLimitError(providerName, fmt.Errorf("%s", msg))
 	case http.StatusBadGateway:
-		return &UpstreamProviderError{BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider)}
+		return &UpstreamProviderError{
+			BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider),
+		}
 	case http.StatusGatewayTimeout:
 		return &TimeoutError{BaseError: errors.New(errCodeTimeout, providerName, fmt.Errorf("%s", msg), ErrTimeout)}
 	default:

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -4,7 +4,6 @@ package mistral
 
 import (
 	"context"
-	"slices"
 
 	oaisdk "github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/packages/param"
@@ -93,7 +92,7 @@ func capabilities() providers.Capabilities {
 		Completion:          true,
 		CompletionImage:     true, // Pixtral models support vision.
 		CompletionPDF:       false,
-		CompletionReasoning: true, // Magistral models support reasoning.
+		CompletionReasoning: true, // Current Mistral models support adjustable reasoning.
 		CompletionStreaming: true,
 		CompletionTools:     true,
 		Embedding:           true, // mistral-embed model.
@@ -134,10 +133,15 @@ func patchMessages(messages []providers.Message) []providers.Message {
 	return result
 }
 
-// patchMessageParams handles Mistral's message-level requirements.
-// Mistral requires an assistant message between tool results and user messages.
+// patchMessageParams handles Mistral fields before shared request conversion.
 func patchMessageParams(params providers.CompletionParams) providers.CompletionParams {
-	params.Messages = patchMessages(slices.Clone(params.Messages))
+	params.Messages = patchMessages(params.Messages)
+	// Mistral calls its highest documented effort xhigh. Map the binding's
+	// provider-neutral max value instead of sending an invalid wire enum.
+	// https://docs.mistral.ai/api/endpoint/chat
+	if params.ReasoningEffort == providers.ReasoningEffortMax {
+		params.ReasoningEffort = providers.ReasoningEffortXHigh
+	}
 	return params
 }
 
@@ -150,5 +154,4 @@ func transformRequest(req *oaisdk.ChatCompletionNewParams) {
 	}
 	req.MaxCompletionTokens = param.Opt[int64]{}
 	req.User = param.Opt[string]{}
-	req.ReasoningEffort = ""
 }

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -53,6 +53,7 @@ func New(opts ...config.Option) (*Provider, error) {
 		APIKeyEnvVar:                    envAPIKey,
 		BaseURLEnvVar:                   "",
 		Capabilities:                    capabilities(),
+		ChatCompletionChunkTransform:    transformChunk,
 		ChatCompletionRequestTransform:  transformRequest,
 		ChatCompletionResponseTransform: transformResponse,
 		DefaultAPIKey:                   "",

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"slices"
 
-	oaisdk "github.com/openai/openai-go"
-	"github.com/openai/openai-go/packages/param"
+	oaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
@@ -141,17 +141,13 @@ func patchMessageParams(params providers.CompletionParams) providers.CompletionP
 	return params
 }
 
-// transformRequest adjusts the OpenAI SDK request for Mistral's API.
-// Mistral uses max_tokens (not max_completion_tokens) and does not accept user or reasoning_effort fields.
-// If both are set, MaxCompletionTokens takes precedence over MaxTokens.
-// See: https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post
+// transformRequest maps the shared token limit to Mistral's max_tokens field
+// and removes fields outside its Chat request schema.
+// https://docs.mistral.ai/api?property=operation-chat_completion_v1_chat_completions_post_request_max_tokens
 func transformRequest(req *oaisdk.ChatCompletionNewParams) {
 	if req.MaxCompletionTokens.Valid() {
-		// Set max_tokens using max_completion_tokens value.
 		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
 	}
-
-	// Clear unsupported fields from the request.
 	req.MaxCompletionTokens = param.Opt[int64]{}
 	req.User = param.Opt[string]{}
 	req.ReasoningEffort = ""

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -50,14 +50,15 @@ type Provider struct {
 // New creates a new Mistral provider.
 func New(opts ...config.Option) (*Provider, error) {
 	base, err := openai.NewCompatible(openai.CompatibleConfig{
-		APIKeyEnvVar:                   envAPIKey,
-		BaseURLEnvVar:                  "",
-		Capabilities:                   capabilities(),
-		ChatCompletionRequestTransform: transformRequest,
-		DefaultAPIKey:                  "",
-		DefaultBaseURL:                 defaultBaseURL,
-		Name:                           providerName,
-		RequireAPIKey:                  true,
+		APIKeyEnvVar:                    envAPIKey,
+		BaseURLEnvVar:                   "",
+		Capabilities:                    capabilities(),
+		ChatCompletionRequestTransform:  transformRequest,
+		ChatCompletionResponseTransform: transformResponse,
+		DefaultAPIKey:                   "",
+		DefaultBaseURL:                  defaultBaseURL,
+		Name:                            providerName,
+		RequireAPIKey:                   true,
 	}, opts...)
 	if err != nil {
 		return nil, err

--- a/providers/mistral/mistral_test.go
+++ b/providers/mistral/mistral_test.go
@@ -289,30 +289,50 @@ func TestCompletionStripsUserField(t *testing.T) {
 	require.NotContains(t, body, "user")
 }
 
-func TestCompletionStripsReasoningEffort(t *testing.T) {
+func TestCompletionMapsReasoningEffort(t *testing.T) {
 	t.Parallel()
 
-	serverURL, capturedBody := testutil.FakeCompletionServer(t)
+	for _, testCase := range []struct {
+		effort  providers.ReasoningEffort
+		want    string
+		present bool
+	}{
+		{effort: providers.ReasoningEffortNone, want: "none", present: true},
+		{effort: providers.ReasoningEffortMinimal, want: "minimal", present: true},
+		{effort: providers.ReasoningEffortLow, want: "low", present: true},
+		{effort: providers.ReasoningEffortMedium, want: "medium", present: true},
+		{effort: providers.ReasoningEffortHigh, want: "high", present: true},
+		{effort: providers.ReasoningEffortXHigh, want: "xhigh", present: true},
+		{effort: providers.ReasoningEffortMax, want: "xhigh", present: true},
+		{effort: providers.ReasoningEffortAuto, want: "", present: false},
+	} {
+		t.Run(string(testCase.effort), func(t *testing.T) {
+			t.Parallel()
 
-	provider, err := New(
-		config.WithAPIKey("test-key"),
-		config.WithBaseURL(serverURL),
-	)
-	require.NoError(t, err)
+			serverURL, capturedBody := testutil.FakeCompletionServer(t)
+			provider, err := New(
+				config.WithAPIKey("test-key"),
+				config.WithBaseURL(serverURL),
+			)
+			require.NoError(t, err)
 
-	params := providers.CompletionParams{
-		Model:           "magistral-small-latest",
-		Messages:        testutil.SimpleMessages(),
-		ReasoningEffort: providers.ReasoningEffortHigh,
+			_, err = provider.Completion(t.Context(), providers.CompletionParams{
+				Model:           "mistral-small-latest",
+				Messages:        testutil.SimpleMessages(),
+				ReasoningEffort: testCase.effort,
+			})
+			require.NoError(t, err)
+
+			// The current Mistral Chat schema accepts efforts from none through xhigh.
+			// https://docs.mistral.ai/api/endpoint/chat
+			got, present := capturedBody()["reasoning_effort"]
+			require.Equal(t, testCase.present, present)
+
+			if testCase.present {
+				require.Equal(t, testCase.want, got)
+			}
+		})
 	}
-
-	_, err = provider.Completion(context.Background(), params)
-	require.NoError(t, err)
-
-	body := capturedBody()
-
-	// Mistral doesn't support reasoning_effort; it must not appear on the wire.
-	require.NotContains(t, body, "reasoning_effort")
 }
 
 func TestCompletionStreamSendsMaxTokensOnWire(t *testing.T) {

--- a/providers/mistral/reasoning.go
+++ b/providers/mistral/reasoning.go
@@ -1,0 +1,282 @@
+package mistral
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+
+	oaisdk "github.com/openai/openai-go/v3"
+
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+type responseMessage struct {
+	Content json.RawMessage `json:"content"`
+}
+
+// Keep current documented fields typed even where mistralai v2.9.4 drops or
+// coerces malformed optional values while selecting a union variant.
+// https://docs.mistral.ai/api/endpoint/chat
+type chunkDiscriminator struct {
+	Type string `json:"type"`
+}
+
+type textContentChunk struct {
+	Text *string `json:"text"`
+}
+
+type thinkingContentChunk struct {
+	Closed    *bool              `json:"closed"`
+	Signature *string            `json:"signature"`
+	Thinking  *[]json.RawMessage `json:"thinking"`
+}
+
+type thinkingTextChunk struct {
+	Text *string `json:"text"`
+}
+
+type thinkingReferenceChunk struct {
+	ReferenceIDs *[]json.RawMessage `json:"reference_ids"`
+}
+
+type thinkingToolReferenceChunk struct {
+	Description *string `json:"description"`
+	Favicon     *string `json:"favicon"`
+	Title       *string `json:"title"`
+	Tool        *string `json:"tool"`
+	URL         *string `json:"url"`
+}
+
+type chunkProjection struct {
+	answer         *string
+	reasoningParts []string
+	thinking       bool
+}
+
+// transformResponse projects Mistral's content union while retaining the
+// complete array required for multi-turn replay.
+// https://docs.mistral.ai/studio-api/conversations/reasoning
+func transformResponse(source *oaisdk.ChatCompletion, result *providers.ChatCompletion) error {
+	for choiceIndex, choice := range source.Choices {
+		var message responseMessage
+		err := json.Unmarshal([]byte(choice.Message.RawJSON()), &message)
+		if err != nil {
+			return fmt.Errorf("decoding Mistral choice %d message: %w", choiceIndex, err)
+		}
+
+		content, reasoning, chunked, err := decodeContent(message.Content)
+		if err != nil {
+			return fmt.Errorf("decoding Mistral choice %d content: %w", choiceIndex, err)
+		}
+
+		if !chunked {
+			continue
+		}
+
+		if content == nil {
+			result.Choices[choiceIndex].Message.Content = nil
+		} else {
+			result.Choices[choiceIndex].Message.Content = *content
+		}
+
+		result.Choices[choiceIndex].Message.Reasoning = reasoning
+	}
+
+	return nil
+}
+
+func decodeContent(
+	raw json.RawMessage,
+) (*string, *providers.Reasoning, bool, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return nil, nil, false, nil
+	}
+
+	var rawChunks []json.RawMessage
+	err := json.Unmarshal(trimmed, &rawChunks)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("decoding content chunks: %w", err)
+	}
+
+	var (
+		answerBuilder  strings.Builder
+		content        *string
+		hasAnswer      bool
+		hasThinking    bool
+		reasoning      *providers.Reasoning
+		reasoningParts []string
+	)
+
+	for _, rawChunk := range rawChunks {
+		projection, err := decodeContentChunk(rawChunk)
+		if err != nil {
+			return nil, nil, false, err
+		}
+
+		if projection.answer != nil {
+			answerBuilder.WriteString(*projection.answer)
+			hasAnswer = true
+		}
+
+		if projection.thinking {
+			hasThinking = true
+			reasoningParts = append(reasoningParts, projection.reasoningParts...)
+		}
+	}
+
+	if hasAnswer {
+		content = new(answerBuilder.String())
+	}
+
+	if hasThinking {
+		reasoning = &providers.Reasoning{
+			Content:     strings.Join(reasoningParts, "\n"),
+			ProviderRaw: bytes.Clone(raw),
+		}
+	}
+
+	return content, reasoning, true, nil
+}
+
+func decodeContentChunk(raw json.RawMessage) (chunkProjection, error) {
+	var discriminator chunkDiscriminator
+	err := json.Unmarshal(raw, &discriminator)
+	if err != nil {
+		return chunkProjection{}, fmt.Errorf("decoding content chunk: %w", err)
+	}
+
+	switch discriminator.Type {
+	case "text":
+		return decodeTextContentChunk(raw)
+	case "thinking":
+		return decodeThinkingContentChunk(raw)
+	default:
+		return chunkProjection{}, nil
+	}
+}
+
+func decodeTextContentChunk(raw json.RawMessage) (chunkProjection, error) {
+	var chunk textContentChunk
+	err := json.Unmarshal(raw, &chunk)
+	if err != nil {
+		return chunkProjection{}, fmt.Errorf("decoding text content chunk: %w", err)
+	}
+
+	if chunk.Text == nil {
+		return chunkProjection{}, fmt.Errorf("text content chunk is missing text")
+	}
+
+	return chunkProjection{answer: chunk.Text}, nil
+}
+
+func decodeThinkingContentChunk(raw json.RawMessage) (chunkProjection, error) {
+	var chunk thinkingContentChunk
+	err := json.Unmarshal(raw, &chunk)
+	if err != nil {
+		return chunkProjection{}, fmt.Errorf("decoding thinking content chunk: %w", err)
+	}
+
+	if chunk.Thinking == nil {
+		return chunkProjection{}, fmt.Errorf("thinking content chunk is missing thinking")
+	}
+
+	parts := make([]string, 0, len(*chunk.Thinking))
+	for _, rawThinking := range *chunk.Thinking {
+		text, present, decodeErr := decodeThinking(rawThinking)
+		if decodeErr != nil {
+			return chunkProjection{}, decodeErr
+		}
+
+		if present {
+			parts = append(parts, text)
+		}
+	}
+
+	return chunkProjection{reasoningParts: parts, thinking: true}, nil
+}
+
+func decodeThinking(raw json.RawMessage) (string, bool, error) {
+	var discriminator chunkDiscriminator
+	err := json.Unmarshal(raw, &discriminator)
+	if err != nil {
+		return "", false, fmt.Errorf("decoding thinking chunk: %w", err)
+	}
+
+	switch discriminator.Type {
+	case "text":
+		return decodeThinkingTextChunk(raw)
+	case "reference":
+		return decodeThinkingReferenceChunk(raw)
+	case "tool_reference":
+		return decodeThinkingToolReferenceChunk(raw)
+	default:
+		return "", false, fmt.Errorf("unsupported thinking chunk type %q", discriminator.Type)
+	}
+}
+
+func decodeThinkingTextChunk(raw json.RawMessage) (string, bool, error) {
+	var chunk thinkingTextChunk
+	err := json.Unmarshal(raw, &chunk)
+	if err != nil {
+		return "", false, fmt.Errorf("decoding thinking text chunk: %w", err)
+	}
+
+	if chunk.Text == nil {
+		return "", false, fmt.Errorf("thinking text chunk is missing text")
+	}
+
+	return *chunk.Text, true, nil
+}
+
+func decodeThinkingReferenceChunk(raw json.RawMessage) (string, bool, error) {
+	var chunk thinkingReferenceChunk
+	err := json.Unmarshal(raw, &chunk)
+	if err != nil {
+		return "", false, fmt.Errorf("decoding thinking reference chunk: %w", err)
+	}
+
+	if chunk.ReferenceIDs == nil {
+		return "", false, fmt.Errorf("thinking reference chunk is missing reference_ids")
+	}
+
+	for _, referenceID := range *chunk.ReferenceIDs {
+		if !validReferenceID(referenceID) {
+			return "", false, fmt.Errorf("thinking reference_id must be an integer or string")
+		}
+	}
+
+	return "", false, nil
+}
+
+func decodeThinkingToolReferenceChunk(raw json.RawMessage) (string, bool, error) {
+	var chunk thinkingToolReferenceChunk
+	err := json.Unmarshal(raw, &chunk)
+	if err != nil {
+		return "", false, fmt.Errorf("decoding thinking tool_reference chunk: %w", err)
+	}
+
+	if chunk.Tool == nil || chunk.Title == nil {
+		return "", false, fmt.Errorf("thinking tool_reference chunk is missing tool or title")
+	}
+
+	return "", false, nil
+}
+
+func validReferenceID(raw json.RawMessage) bool {
+	var text *string
+	err := json.Unmarshal(raw, &text)
+	if err == nil && text != nil {
+		return true
+	}
+
+	var number *json.Number
+	if json.Unmarshal(raw, &number) != nil || number == nil {
+		return false
+	}
+
+	rational, ok := new(big.Rat).SetString(number.String())
+	return ok && rational.IsInt()
+}

--- a/providers/mistral/reasoning.go
+++ b/providers/mistral/reasoning.go
@@ -87,6 +87,38 @@ func transformResponse(source *oaisdk.ChatCompletion, result *providers.ChatComp
 	return nil
 }
 
+// transformChunk projects Mistral's streamed content union while retaining
+// each complete array for replay in a later assistant message.
+// https://docs.mistral.ai/studio-api/conversations/reasoning
+func transformChunk(source *oaisdk.ChatCompletionChunk, result *providers.ChatCompletionChunk) error {
+	for choiceIndex, choice := range source.Choices {
+		var delta responseMessage
+		err := json.Unmarshal([]byte(choice.Delta.RawJSON()), &delta)
+		if err != nil {
+			return fmt.Errorf("decoding Mistral choice %d delta: %w", choiceIndex, err)
+		}
+
+		content, reasoning, chunked, err := decodeContent(delta.Content)
+		if err != nil {
+			return fmt.Errorf("decoding Mistral choice %d delta content: %w", choiceIndex, err)
+		}
+
+		if !chunked {
+			continue
+		}
+
+		if content == nil {
+			result.Choices[choiceIndex].Delta.Content = ""
+		} else {
+			result.Choices[choiceIndex].Delta.Content = *content
+		}
+
+		result.Choices[choiceIndex].Delta.Reasoning = reasoning
+	}
+
+	return nil
+}
+
 func decodeContent(
 	raw json.RawMessage,
 ) (*string, *providers.Reasoning, bool, error) {

--- a/providers/mistral/reasoning_response_test.go
+++ b/providers/mistral/reasoning_response_test.go
@@ -1,0 +1,190 @@
+package mistral
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	"github.com/mozilla-ai/any-llm-go/internal/testutil"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+const (
+	jsonObjectTypeError    = "cannot unmarshal object"
+	mistralReasoningModel  = "mistral-small-latest"
+	mistralThinkingContent = `[
+	{"type":"thinking","thinking":[
+		{"type":"text","text":"step one","reference_ids":[{}]},
+		{"type":"reference","reference_ids":[1,1.0,1e2,999999999999999999999999,"ref-1"],"text":{}},
+		{"type":"tool_reference","tool":"web_search","title":"source","url":null},
+		{"type":"text","text":"step two"}
+	],"signature":null,"closed":false},
+	{"type":"text","text":"the answer"},
+	{"type":"future_chunk","text":{},"future":true}
+]`
+)
+
+func mistralCompletionServer(t *testing.T, responseContent string) string {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+		responseWriter.Header().Set("Content-Type", "application/json")
+		_, err := fmt.Fprintf(responseWriter, `{
+			"id":"chatcmpl-test",
+			"object":"chat.completion",
+			"created":1700000000,
+			"model":"%s",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":%s},
+				"finish_reason":"stop"
+			}]
+		}`, mistralReasoningModel, responseContent)
+		if err != nil {
+			t.Errorf("writing Mistral response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	return server.URL
+}
+
+func TestCompletionPreservesThinkingChunks(t *testing.T) {
+	t.Parallel()
+
+	// Mistral returns chunk arrays for high reasoning and requires callers to
+	// replay the complete array in later turns.
+	// https://docs.mistral.ai/studio-api/conversations/reasoning
+	serverURL := mistralCompletionServer(t, mistralThinkingContent)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	completion, err := provider.Completion(t.Context(), providers.CompletionParams{
+		Model:    mistralReasoningModel,
+		Messages: testutil.SimpleMessages(),
+	})
+	require.NoError(t, err)
+
+	message := completion.Choices[0].Message
+	require.Equal(t, "the answer", message.Content)
+	require.NotNil(t, message.Reasoning)
+	require.Equal(t, "step one\nstep two", message.Reasoning.Content)
+	require.JSONEq(t, mistralThinkingContent, string(message.Reasoning.ProviderRaw))
+}
+
+func TestCompletionPreservesReasoningWithoutAnswer(t *testing.T) {
+	t.Parallel()
+
+	const content = `[{"type":"thinking","thinking":[],"closed":false}]`
+	serverURL := mistralCompletionServer(t, content)
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	completion, err := provider.Completion(t.Context(), providers.CompletionParams{
+		Model:    mistralReasoningModel,
+		Messages: testutil.SimpleMessages(),
+	})
+	require.NoError(t, err)
+
+	message := completion.Choices[0].Message
+	require.Nil(t, message.Content)
+	require.NotNil(t, message.Reasoning)
+	require.Empty(t, message.Reasoning.Content)
+	require.JSONEq(t, content, string(message.Reasoning.ProviderRaw))
+}
+
+func TestCompletionRejectsMalformedKnownContentChunks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{name: "text field has wrong type", content: `[{"type":"text","text":1}]`, wantErr: "cannot unmarshal number"},
+		{name: "text field is missing", content: `[{"type":"text"}]`, wantErr: "text content chunk is missing text"},
+		{
+			name:    "thinking field has wrong type",
+			content: `[{"type":"thinking","thinking":{}}]`,
+			wantErr: jsonObjectTypeError,
+		},
+		{
+			name:    "thinking field is missing",
+			content: `[{"type":"thinking"}]`,
+			wantErr: "thinking content chunk is missing thinking",
+		},
+		{
+			name:    "thinking text field is missing",
+			content: `[{"type":"thinking","thinking":[{"type":"text"}]}]`,
+			wantErr: "thinking text chunk is missing text",
+		},
+		{
+			name:    "thinking reference IDs are missing",
+			content: `[{"type":"thinking","thinking":[{"type":"reference"}]}]`,
+			wantErr: "thinking reference chunk is missing reference_ids",
+		},
+		{
+			name:    "thinking reference ID has wrong type",
+			content: `[{"type":"thinking","thinking":[{"type":"reference","reference_ids":[{}]}]}]`,
+			wantErr: "thinking reference_id must be an integer or string",
+		},
+		{
+			name:    "thinking tool title is missing",
+			content: `[{"type":"thinking","thinking":[{"type":"tool_reference","tool":"web_search"}]}]`,
+			wantErr: "thinking tool_reference chunk is missing tool or title",
+		},
+		{
+			name: "thinking tool URL has wrong type",
+			content: `[
+				{"type":"thinking","thinking":[
+					{"type":"tool_reference","tool":"web_search","title":"source","url":{}}
+				]}
+			]`,
+			wantErr: jsonObjectTypeError,
+		},
+		{
+			name:    "thinking signature has wrong type",
+			content: `[{"type":"thinking","thinking":[],"signature":{}}]`,
+			wantErr: jsonObjectTypeError,
+		},
+		{
+			name:    "thinking closed has wrong type",
+			content: `[{"type":"thinking","thinking":[],"closed":"false"}]`,
+			wantErr: "cannot unmarshal string",
+		},
+		{
+			name:    "thinking union is closed",
+			content: `[{"type":"thinking","thinking":[{"type":"future_thinking"}]}]`,
+			wantErr: `unsupported thinking chunk type "future_thinking"`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			serverURL := mistralCompletionServer(t, test.content)
+			provider, err := New(
+				config.WithAPIKey("test-key"),
+				config.WithBaseURL(serverURL),
+			)
+			require.NoError(t, err)
+
+			_, err = provider.Completion(t.Context(), providers.CompletionParams{
+				Model:    mistralReasoningModel,
+				Messages: testutil.SimpleMessages(),
+			})
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}

--- a/providers/mistral/reasoning_stream_failure_test.go
+++ b/providers/mistral/reasoning_stream_failure_test.go
@@ -1,0 +1,120 @@
+package mistral
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	"github.com/mozilla-ai/any-llm-go/internal/testutil"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+func TestCompletionStreamRejectsMalformedEvent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		event   string
+		wantErr string
+	}{
+		{name: "invalid JSON", event: `{"id":`, wantErr: "unexpected end"},
+		{
+			name: "invalid thinking chunk",
+			event: `{
+				"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,
+				"model":"mistral-small-latest","choices":[{"index":0,"delta":{
+					"content":[{"type":"thinking","thinking":[{"type":"text"}]}]
+				},"finish_reason":null}]
+			}`,
+			wantErr: "thinking text chunk is missing text",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			event := test.event
+			if json.Valid([]byte(event)) {
+				event = compactJSON(t, event)
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+				responseWriter.Header().Set("Content-Type", "text/event-stream")
+				_, err := fmt.Fprintf(responseWriter, "data: %s\n\n", event)
+				if err != nil {
+					t.Errorf("writing malformed Mistral stream event: %v", err)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			provider, err := New(
+				config.WithAPIKey("test-key"),
+				config.WithBaseURL(server.URL),
+			)
+			require.NoError(t, err)
+
+			chunks, errs := provider.CompletionStream(t.Context(), providers.CompletionParams{
+				Model:    mistralReasoningModel,
+				Messages: testutil.SimpleMessages(),
+			})
+			for range chunks {
+			}
+			require.ErrorContains(t, <-errs, test.wantErr)
+		})
+	}
+}
+
+func TestCompletionStreamHonorsDeadlineAfterThinkingChunk(t *testing.T) {
+	t.Parallel()
+
+	const rawEvent = `{
+		"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,
+		"model":"mistral-small-latest","choices":[{"index":0,"delta":{
+			"content":[{"type":"thinking","thinking":[
+				{"type":"text","text":"step one"}
+			],"closed":false}]
+		},"finish_reason":null}]
+	}`
+	event := compactJSON(t, rawEvent)
+
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		responseWriter.Header().Set("Content-Type", "text/event-stream")
+		_, err := fmt.Fprintf(responseWriter, "data: %s\n\n", event)
+		if err != nil {
+			t.Errorf("writing Mistral stream event: %v", err)
+			return
+		}
+		if flusher, ok := responseWriter.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-request.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(server.URL),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+	chunks, errs := provider.CompletionStream(ctx, providers.CompletionParams{
+		Model:    mistralReasoningModel,
+		Messages: testutil.SimpleMessages(),
+	})
+	first, ok := <-chunks
+	require.True(t, ok)
+	require.NotNil(t, first.Choices[0].Delta.Reasoning)
+	require.Equal(t, "step one", first.Choices[0].Delta.Reasoning.Content)
+	for range chunks {
+	}
+	require.ErrorIs(t, <-errs, context.DeadlineExceeded)
+}

--- a/providers/mistral/reasoning_stream_test.go
+++ b/providers/mistral/reasoning_stream_test.go
@@ -1,0 +1,137 @@
+package mistral
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	"github.com/mozilla-ai/any-llm-go/internal/testutil"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+func compactJSON(t *testing.T, value string) string {
+	t.Helper()
+
+	var compact bytes.Buffer
+	require.NoError(t, json.Compact(&compact, []byte(value)))
+
+	return compact.String()
+}
+
+func TestCompletionStreamPreservesThinkingChunks(t *testing.T) {
+	t.Parallel()
+
+	// Mistral streams thinking arrays, a mixed thinking-to-answer transition,
+	// then ordinary answer strings.
+	// https://docs.mistral.ai/studio-api/conversations/reasoning
+	events := []string{
+		`{
+			"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,
+			"model":"mistral-small-latest","choices":[{"index":0,"delta":{
+				"role":"assistant","content":[
+					{"type":"thinking","thinking":[
+						{"type":"text","text":"step one","reference_ids":[{}]},
+						{"type":"reference","reference_ids":[1,1e2,999999999999999999999999,"ref-1"],"text":{}}
+					],"signature":null,"closed":false},
+					{"type":"future_chunk","text":{},"future":true}
+				]
+			},"finish_reason":null}]
+		}`,
+		`{
+			"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,
+			"model":"mistral-small-latest","choices":[{"index":0,"delta":{"content":[
+				{"type":"thinking","thinking":[{"type":"text","text":"step two"}],
+				 "signature":"sig-2","closed":true},
+				{"type":"text","text":"the "}
+			]},"finish_reason":null}]
+		}`,
+		`{
+			"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,
+			"model":"mistral-small-latest","choices":[{
+				"index":0,"delta":{"content":"answer"},"finish_reason":null
+			}]
+		}`,
+		`{
+			"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,
+			"model":"mistral-small-latest","choices":[{
+				"index":0,"delta":{},"finish_reason":"error"
+			}]
+		}`,
+	}
+	for i := range events {
+		events[i] = compactJSON(t, events[i])
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, _ *http.Request) {
+		responseWriter.Header().Set("Content-Type", "text/event-stream")
+		for _, event := range events {
+			_, err := fmt.Fprintf(responseWriter, "data: %s\n\n", event)
+			if err != nil {
+				t.Errorf("writing Mistral stream event: %v", err)
+				return
+			}
+		}
+		_, err := fmt.Fprint(responseWriter, "data: [DONE]\n\n")
+		if err != nil {
+			t.Errorf("writing Mistral stream terminator: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(server.URL),
+	)
+	require.NoError(t, err)
+
+	chunkChannel, errChannel := provider.CompletionStream(t.Context(), providers.CompletionParams{
+		Model:    mistralReasoningModel,
+		Messages: testutil.SimpleMessages(),
+	})
+	chunks := make([]providers.ChatCompletionChunk, 0, len(events))
+	for chunk := range chunkChannel {
+		chunks = append(chunks, chunk)
+	}
+	require.NoError(t, <-errChannel)
+	require.Len(t, chunks, len(events))
+
+	first := chunks[0].Choices[0].Delta
+	require.Empty(t, first.Content)
+	require.NotNil(t, first.Reasoning)
+	require.Equal(t, "step one", first.Reasoning.Content)
+	require.JSONEq(
+		t,
+		`[
+			{"type":"thinking","thinking":[
+				{"type":"text","text":"step one","reference_ids":[{}]},
+				{"type":"reference","reference_ids":[1,1e2,999999999999999999999999,"ref-1"],"text":{}}
+			],"signature":null,"closed":false},
+			{"type":"future_chunk","text":{},"future":true}
+		]`,
+		string(first.Reasoning.ProviderRaw),
+	)
+
+	transition := chunks[1].Choices[0].Delta
+	require.Equal(t, "the ", transition.Content)
+	require.NotNil(t, transition.Reasoning)
+	require.Equal(t, "step two", transition.Reasoning.Content)
+	require.JSONEq(
+		t,
+		`[
+			{"type":"thinking","thinking":[{"type":"text","text":"step two"}],
+			 "signature":"sig-2","closed":true},
+			{"type":"text","text":"the "}
+		]`,
+		string(transition.Reasoning.ProviderRaw),
+	)
+
+	require.Equal(t, "answer", chunks[2].Choices[0].Delta.Content)
+	require.Nil(t, chunks[2].Choices[0].Delta.Reasoning)
+	require.Equal(t, "error", chunks[3].Choices[0].FinishReason)
+}

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -7,9 +7,9 @@ import (
 	stderrors "errors"
 	"fmt"
 
-	"github.com/openai/openai-go"
-	"github.com/openai/openai-go/option"
-	"github.com/openai/openai-go/shared"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/shared"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/errors"
@@ -328,13 +328,15 @@ func convertAPIError(name string, apiErr *openai.Error, originalErr error) error
 // convertAssistantMessage converts an assistant message to OpenAI format.
 func convertAssistantMessage(msg providers.Message) openai.ChatCompletionMessageParamUnion {
 	if len(msg.ToolCalls) > 0 {
-		toolCalls := make([]openai.ChatCompletionMessageToolCallParam, 0, len(msg.ToolCalls))
+		toolCalls := make([]openai.ChatCompletionMessageToolCallUnionParam, 0, len(msg.ToolCalls))
 		for _, tc := range msg.ToolCalls {
-			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallParam{
-				ID: tc.ID,
-				Function: openai.ChatCompletionMessageToolCallFunctionParam{
-					Name:      tc.Function.Name,
-					Arguments: tc.Function.Arguments,
+			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnionParam{
+				OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
+					ID: tc.ID,
+					Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
+						Name:      tc.Function.Name,
+						Arguments: tc.Function.Arguments,
+					},
 				},
 			})
 		}
@@ -380,13 +382,16 @@ func convertChunk(chunk *openai.ChatCompletionChunk) providers.ChatCompletionChu
 		choices = append(choices, chunkChoice)
 	}
 
+	// Preserve the existing normalized field even though the v3 SDK marks the
+	// documented response field as deprecated.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	result := providers.ChatCompletionChunk{
 		ID:                chunk.ID,
 		Object:            objectChatCompletionChunk,
 		Created:           chunk.Created,
 		Model:             chunk.Model,
 		Choices:           choices,
-		SystemFingerprint: chunk.SystemFingerprint,
+		SystemFingerprint: chunk.SystemFingerprint, //nolint:staticcheck
 	}
 
 	if chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0 {
@@ -570,13 +575,16 @@ func convertResponse(resp *openai.ChatCompletion) *providers.ChatCompletion {
 		})
 	}
 
+	// Preserve the existing normalized field even though the v3 SDK marks the
+	// documented response field as deprecated.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	result := &providers.ChatCompletion{
 		ID:                resp.ID,
 		Object:            objectChatCompletion,
 		Created:           resp.Created,
 		Model:             resp.Model,
 		Choices:           choices,
-		SystemFingerprint: resp.SystemFingerprint,
+		SystemFingerprint: resp.SystemFingerprint, //nolint:staticcheck
 	}
 
 	if resp.Usage.PromptTokens > 0 || resp.Usage.CompletionTokens > 0 {
@@ -658,7 +666,7 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 		}
 	case providers.ToolChoice:
 		if v.Function != nil {
-			return openai.ChatCompletionToolChoiceOptionParamOfChatCompletionNamedToolChoice(
+			return openai.ToolChoiceOptionFunctionToolChoice(
 				openai.ChatCompletionNamedToolChoiceFunctionParam{
 					Name: v.Function.Name,
 				},
@@ -671,14 +679,16 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 }
 
 // convertTools converts provider tools to OpenAI format.
-func convertTools(tools []providers.Tool) []openai.ChatCompletionToolParam {
-	result := make([]openai.ChatCompletionToolParam, 0, len(tools))
+func convertTools(tools []providers.Tool) []openai.ChatCompletionToolUnionParam {
+	result := make([]openai.ChatCompletionToolUnionParam, 0, len(tools))
 	for _, tool := range tools {
-		result = append(result, openai.ChatCompletionToolParam{
-			Function: openai.FunctionDefinitionParam{
-				Name:        tool.Function.Name,
-				Description: openai.String(tool.Function.Description),
-				Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+		result = append(result, openai.ChatCompletionToolUnionParam{
+			OfFunction: &openai.ChatCompletionFunctionToolParam{
+				Function: openai.FunctionDefinitionParam{
+					Name:        tool.Function.Name,
+					Description: openai.String(tool.Function.Description),
+					Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+				},
 			},
 		})
 	}

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -59,6 +59,10 @@ type CompatibleConfig struct {
 	// Capabilities describes what the provider supports.
 	Capabilities providers.Capabilities
 
+	// ChatCompletionChunkTransform adapts provider-specific streaming fields
+	// after the SDK and shared converter preserve each chunk.
+	ChatCompletionChunkTransform func(*openai.ChatCompletionChunk, *providers.ChatCompletionChunk) error
+
 	// ChatCompletionResponseTransform adapts provider-specific response fields
 	// after the SDK and shared converter preserve the response envelope.
 	ChatCompletionResponseTransform func(*openai.ChatCompletion, *providers.ChatCompletion) error
@@ -222,8 +226,18 @@ func (p *CompatibleProvider) CompletionStream(
 
 		for stream.Next() {
 			chunk := stream.Current()
+			result := convertChunk(&chunk)
+			chunkTransform := p.compatibleConfig.ChatCompletionChunkTransform
+			if chunkTransform != nil {
+				transformErr := chunkTransform(&chunk, &result)
+				if transformErr != nil {
+					errs <- transformErr
+					return
+				}
+			}
+
 			select {
-			case chunks <- convertChunk(&chunk):
+			case chunks <- result:
 			case <-ctx.Done():
 				// Caller cancelled mid-stream; surface ctx.Err() so the
 				// consumer can tell a cancelled stream apart from one

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -517,6 +517,10 @@ func convertParams(params providers.CompletionParams) openai.ChatCompletionNewPa
 		req.TopP = openai.Float(*params.TopP)
 	}
 
+	// OpenAI documents max_completion_tokens as the replacement for the
+	// deprecated max_tokens field. Keep the binding's existing MaxTokens
+	// abstraction on the current wire field.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	if params.MaxTokens != nil {
 		req.MaxCompletionTokens = openai.Int(int64(*params.MaxTokens))
 	}
@@ -551,7 +555,10 @@ func convertParams(params providers.CompletionParams) openai.ChatCompletionNewPa
 		req.User = openai.String(params.User)
 	}
 
-	if params.ReasoningEffort != "" && params.ReasoningEffort != providers.ReasoningEffortNone {
+	// auto is the binding's omission sentinel. OpenAI documents none as an
+	// explicit value, so it must reach the wire unchanged.
+	// https://developers.openai.com/api/docs/guides/latest-model
+	if params.ReasoningEffort != "" && params.ReasoningEffort != providers.ReasoningEffortAuto {
 		req.ReasoningEffort = shared.ReasoningEffort(params.ReasoningEffort)
 	}
 

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -59,6 +59,10 @@ type CompatibleConfig struct {
 	// Capabilities describes what the provider supports.
 	Capabilities providers.Capabilities
 
+	// ChatCompletionResponseTransform adapts provider-specific response fields
+	// after the SDK and shared converter preserve the response envelope.
+	ChatCompletionResponseTransform func(*openai.ChatCompletion, *providers.ChatCompletion) error
+
 	// DefaultAPIKey is used when RequireAPIKey is false (e.g., for local servers).
 	DefaultAPIKey string
 
@@ -181,7 +185,16 @@ func (p *CompatibleProvider) Completion(
 		return nil, p.ConvertError(err)
 	}
 
-	return convertResponse(resp), nil
+	result := convertResponse(resp)
+	responseTransform := p.compatibleConfig.ChatCompletionResponseTransform
+	if responseTransform != nil {
+		err = responseTransform(resp, result)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
 }
 
 // CompletionStream performs a streaming chat completion request.

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -9,6 +9,7 @@ import (
 const (
 	defaultBaseURL = "https://api.openai.com/v1"
 	envAPIKey      = "OPENAI_API_KEY"
+	envBaseURL     = "OPENAI_BASE_URL"
 	providerName   = "openai"
 )
 
@@ -31,6 +32,7 @@ type Provider struct {
 func New(opts ...config.Option) (*Provider, error) {
 	base, err := NewCompatible(CompatibleConfig{
 		APIKeyEnvVar:   envAPIKey,
+		BaseURLEnvVar:  envBaseURL,
 		Capabilities:   capabilities(),
 		DefaultBaseURL: defaultBaseURL,
 		Name:           providerName,

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -34,6 +34,21 @@ func TestNew(t *testing.T) {
 		require.NotNil(t, provider)
 	})
 
+	t.Run("reads OPENAI_BASE_URL", func(t *testing.T) {
+		serverURL, _ := testutil.FakeCompletionServer(t)
+		t.Setenv("OPENAI_API_KEY", "env-api-key")
+		t.Setenv("OPENAI_BASE_URL", serverURL)
+
+		provider, err := New()
+		require.NoError(t, err)
+
+		_, err = provider.Completion(t.Context(), providers.CompletionParams{
+			Model:    "test-model",
+			Messages: testutil.SimpleMessages(),
+		})
+		require.NoError(t, err)
+	})
+
 	t.Run("returns error when API key is missing", func(t *testing.T) {
 		t.Setenv("OPENAI_API_KEY", "")
 

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -116,7 +116,7 @@ func TestConvertParams(t *testing.T) {
 		require.Equal(t, 0.9, req.TopP.Value)
 	})
 
-	t.Run("converts max_tokens", func(t *testing.T) {
+	t.Run("maps token limit to max_completion_tokens", func(t *testing.T) {
 		t.Parallel()
 
 		maxTokens := 100
@@ -128,6 +128,7 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
+		require.False(t, req.MaxTokens.Valid())
 		require.Equal(t, int64(100), req.MaxCompletionTokens.Value)
 	})
 
@@ -223,18 +224,43 @@ func TestConvertParams(t *testing.T) {
 		require.NotNil(t, req.ResponseFormat)
 	})
 
-	t.Run("converts reasoning_effort", func(t *testing.T) {
+	t.Run("preserves current reasoning_effort values", func(t *testing.T) {
+		t.Parallel()
+
+		efforts := []providers.ReasoningEffort{
+			providers.ReasoningEffortNone,
+			providers.ReasoningEffortMinimal,
+			providers.ReasoningEffortLow,
+			providers.ReasoningEffortMedium,
+			providers.ReasoningEffortHigh,
+			providers.ReasoningEffortXHigh,
+			providers.ReasoningEffortMax,
+		}
+		for _, effort := range efforts {
+			params := providers.CompletionParams{
+				Model:           "test-model",
+				Messages:        testutil.SimpleMessages(),
+				ReasoningEffort: effort,
+			}
+
+			req := convertParams(params)
+
+			require.Equal(t, string(effort), string(req.ReasoningEffort))
+		}
+	})
+
+	t.Run("omits automatic reasoning_effort sentinel", func(t *testing.T) {
 		t.Parallel()
 
 		params := providers.CompletionParams{
-			Model:           "o1-mini",
+			Model:           "test-model",
 			Messages:        testutil.SimpleMessages(),
-			ReasoningEffort: providers.ReasoningEffortHigh,
+			ReasoningEffort: providers.ReasoningEffortAuto,
 		}
 
 		req := convertParams(params)
 
-		require.NotNil(t, req.ReasoningEffort)
+		require.Empty(t, req.ReasoningEffort)
 	})
 
 	t.Run("converts seed", func(t *testing.T) {
@@ -487,10 +513,33 @@ func TestCompletionSendsMaxCompletionTokensOnWire(t *testing.T) {
 
 	body := capturedBody()
 
-	// OpenAI requires max_completion_tokens (not max_tokens) for current models.
 	require.Contains(t, body, "max_completion_tokens")
 	require.NotContains(t, body, "max_tokens")
 	require.Equal(t, float64(1024), body["max_completion_tokens"])
+}
+
+func TestCompletionPreservesReasoningEffortOnWire(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeCompletionServer(t)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	params := providers.CompletionParams{
+		Model:           "test-model",
+		Messages:        testutil.SimpleMessages(),
+		ReasoningEffort: providers.ReasoningEffortNone,
+	}
+
+	_, err = provider.Completion(context.Background(), params)
+	require.NoError(t, err)
+
+	body := capturedBody()
+	require.Equal(t, "none", body["reasoning_effort"])
 }
 
 func TestCompletionStreamSendsMaxCompletionTokensOnWire(t *testing.T) {
@@ -520,7 +569,6 @@ func TestCompletionStreamSendsMaxCompletionTokensOnWire(t *testing.T) {
 
 	body := capturedBody()
 
-	// OpenAI requires max_completion_tokens (not max_tokens) for current models.
 	require.Contains(t, body, "max_completion_tokens")
 	require.NotContains(t, body, "max_tokens")
 	require.Equal(t, float64(1024), body["max_completion_tokens"])

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/any-llm-go/config"
@@ -362,11 +362,16 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 1)
-		require.Equal(t, "get_weather", result[0].Function.Name)
-		require.Equal(t, "Get the current weather for a location.", result[0].Function.Description.Value)
+		require.NotNil(t, result[0].OfFunction)
+		require.Equal(t, "get_weather", result[0].OfFunction.Function.Name)
+		require.Equal(
+			t,
+			"Get the current weather for a location.",
+			result[0].OfFunction.Function.Description.Value,
+		)
 
 		// FunctionParameters is map[string]any - access directly.
-		params := result[0].Function.Parameters
+		params := result[0].OfFunction.Function.Parameters
 		require.Equal(t, "object", params["type"])
 
 		props, ok := params["properties"].(map[string]any)
@@ -391,10 +396,11 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 1)
-		require.Equal(t, "calculate", result[0].Function.Name)
+		require.NotNil(t, result[0].OfFunction)
+		require.Equal(t, "calculate", result[0].OfFunction.Function.Name)
 
 		// FunctionParameters is map[string]any - access directly.
-		params := result[0].Function.Parameters
+		params := result[0].OfFunction.Function.Parameters
 
 		props, ok := params["properties"].(map[string]any)
 		require.True(t, ok)
@@ -436,8 +442,10 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 2)
-		require.Equal(t, "get_weather", result[0].Function.Name)
-		require.Equal(t, "get_current_date", result[1].Function.Name)
+		require.NotNil(t, result[0].OfFunction)
+		require.NotNil(t, result[1].OfFunction)
+		require.Equal(t, "get_weather", result[0].OfFunction.Function.Name)
+		require.Equal(t, "get_current_date", result[1].OfFunction.Function.Name)
 	})
 }
 

--- a/providers/types.go
+++ b/providers/types.go
@@ -323,6 +323,10 @@ type ModelsResponse struct {
 // Reasoning represents extended thinking/reasoning content.
 type Reasoning struct {
 	Content string `json:"content,omitempty"`
+	// ProviderRaw retains provider-native blocks that Content cannot represent.
+	// Mistral requires complete assistant content for multi-turn reasoning replay:
+	// https://docs.mistral.ai/studio-api/conversations/reasoning
+	ProviderRaw json.RawMessage `json:"provider_raw,omitempty"`
 }
 
 // ResponseFormat specifies the format of the response.

--- a/providers/types.go
+++ b/providers/types.go
@@ -16,11 +16,14 @@ const (
 
 // Reasoning effort levels for extended thinking.
 const (
-	ReasoningEffortAuto   ReasoningEffort = "auto"
-	ReasoningEffortHigh   ReasoningEffort = "high"
-	ReasoningEffortLow    ReasoningEffort = "low"
-	ReasoningEffortMedium ReasoningEffort = "medium"
-	ReasoningEffortNone   ReasoningEffort = "none"
+	ReasoningEffortAuto    ReasoningEffort = "auto"
+	ReasoningEffortHigh    ReasoningEffort = "high"
+	ReasoningEffortLow     ReasoningEffort = "low"
+	ReasoningEffortMax     ReasoningEffort = "max"
+	ReasoningEffortMedium  ReasoningEffort = "medium"
+	ReasoningEffortMinimal ReasoningEffort = "minimal"
+	ReasoningEffortNone    ReasoningEffort = "none"
+	ReasoningEffortXHigh   ReasoningEffort = "xhigh"
 )
 
 // Message roles.
@@ -95,7 +98,7 @@ type Capabilities struct {
 	CompletionImage     bool
 	CompletionPDF       bool
 	CompletionReasoning bool
-	CompletionStreaming  bool
+	CompletionStreaming bool
 	CompletionTools     bool
 	Embedding           bool
 	ListModels          bool

--- a/providers/types_test.go
+++ b/providers/types_test.go
@@ -88,3 +88,27 @@ func TestToolCallExtraExcludedFromJSON(t *testing.T) {
 	require.Equal(t, "call_123", decoded["id"])
 	require.Equal(t, "function", decoded["type"])
 }
+
+func TestReasoningProviderRawRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	reasoning := Reasoning{
+		Content: "step one",
+		ProviderRaw: json.RawMessage(
+			`[{"type":"thinking","thinking":[{"type":"text","text":"step one"}],"signature":"sig-abc"}]`,
+		),
+	}
+
+	data, err := json.Marshal(reasoning)
+	require.NoError(t, err)
+
+	var decoded Reasoning
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, reasoning, decoded)
+
+	var empty Reasoning
+
+	emptyData, err := json.Marshal(empty)
+	require.NoError(t, err)
+	require.JSONEq(t, `{}`, string(emptyData))
+}


### PR DESCRIPTION
## Summary

- Normalize Mistral streaming Chat chunks whose `delta.content` alternates between documented content arrays and strings.
- Preserve thinking-to-answer transition events without duplicating the shared SSE lifecycle.
- Propagate malformed provider chunks and caller deadlines through the existing error channel.

This PR is Draft. It depends on the response parser in #149. Request replay is separately owned by #161. Live Mistral API verification and exact-head CodeRabbit review remain incomplete.

## Review boundary

Exact head: `d5439e7594efece108258f6b205cb420f1a4ddf6`

The branch contains #149 exact head `889b5d8c54fd82b9e633eac8674826285b359b87` because an upstream PR cannot use a contributor-fork branch as its base. The streaming owning range changes five files: production `+48/-1` and direct contract tests `+257/-0`.

The implementation commit adds one compatible post-decode chunk hook and the 32-line Mistral projection. The main protocol fixture and error/lifecycle cases are separate 137-line and 120-line test commits.

## Official contract and independent evidence

- Reasoning stream and transition contract: <https://docs.mistral.ai/studio-api/conversations/reasoning>
- Chat schema: <https://docs.mistral.ai/api/endpoint/chat>
- Latest official Python SDK audited: [v2.9.4](https://github.com/mistralai/client-python/tree/df37126528859588193a9e954e820b12861ad106)
- Latest official TypeScript SDK audited: [v2.6.4](https://github.com/mistralai/client-ts/tree/7ed5ba7825ed295f1962822f8eb586eb44a3c051)
- Latest official OpenAI Go SDK compatibility check: [v3.55.0](https://github.com/openai/openai-go/tree/20816bd16e21a0b8c57fdd43256187028c979362)

Official `mistralai==2.9.4` independently accepts the four valid event payloads: open thinking with an unknown top-level content chunk, a closing thinking and text transition, ordinary string answer content, and terminal `finish_reason=error`. Intermediate events carry `finish_reason: null`, and the stream ends with `[DONE]`.

The tests also cover malformed SSE JSON, malformed known thinking content, and deadline propagation after a valid thinking event. Expected values do not use the Go converter. No SDK or Fantasy code, fixture, control flow, error catalog, or assertion sequence was copied. All referenced repositories use Apache-2.0; Fantasy's `NOTICE` is not redistributed.

## Ablation and verification

A provider-owned stream wrapper was removed from consideration because it would duplicate the existing HTTP, SSE, cancellation, backpressure, and error-channel lifecycle. The retained hook runs after SDK decoding while `RawJSON()` is available. This PR adds no `any`, cast, dependency upgrade, deprecated parameter, request replay, or non-streaming parser.

Executed on the exact head:

```text
go test ./... -count=1
affected provider race tests
go mod tidy -diff
go mod verify
golangci-lint run --new-from-rev=889b5d8c54fd82b9e633eac8674826285b359b87 ./...
latest OpenAI Go SDK v3.55.0 alternate-modfile tests
git diff --check
git verify-commit for all three owning commits
```

All commands passed. Configured GolangCI-Lint reported `0 issues.` The no-config stable-rule findings are limited to an empty depguard policy, exhaustive initialization of optional requests, a generic function-length threshold for one visible protocol fixture, whitespace rules that conflict with project formatting, intentional channel drains, and private-package protocol tests. No suppression was added.
