### PR TITLE
fix(deepseek): preserve Chat cache usage

### DIFF
--- a/anyllm.go
+++ b/anyllm.go
@@ -53,11 +53,14 @@ const (
 
 // ReasoningEffort levels.
 const (
-	ReasoningEffortAuto   = providers.ReasoningEffortAuto
-	ReasoningEffortHigh   = providers.ReasoningEffortHigh
-	ReasoningEffortLow    = providers.ReasoningEffortLow
-	ReasoningEffortMedium = providers.ReasoningEffortMedium
-	ReasoningEffortNone   = providers.ReasoningEffortNone
+	ReasoningEffortAuto    = providers.ReasoningEffortAuto
+	ReasoningEffortHigh    = providers.ReasoningEffortHigh
+	ReasoningEffortLow     = providers.ReasoningEffortLow
+	ReasoningEffortMax     = providers.ReasoningEffortMax
+	ReasoningEffortMedium  = providers.ReasoningEffortMedium
+	ReasoningEffortMinimal = providers.ReasoningEffortMinimal
+	ReasoningEffortNone    = providers.ReasoningEffortNone
+	ReasoningEffortXHigh   = providers.ReasoningEffortXHigh
 )
 
 // Provider types.
@@ -179,17 +182,17 @@ var (
 
 // Error types.
 type (
-	AuthenticationError           = errors.AuthenticationError
-	BaseError                     = errors.BaseError
-	ContentFilterError            = errors.ContentFilterError
-	ContextLengthError            = errors.ContextLengthError
-	InsufficientFundsError        = errors.InsufficientFundsError
-	InvalidRequestError           = errors.InvalidRequestError
-	MissingAPIKeyError            = errors.MissingAPIKeyError
-	ModelNotFoundError            = errors.ModelNotFoundError
-	ProviderError                 = errors.ProviderError
-	RateLimitError                = errors.RateLimitError
-	UnsupportedOperationError     = errors.UnsupportedOperationError
-	UnsupportedParamError         = errors.UnsupportedParamError
-	UnsupportedProviderError      = errors.UnsupportedProviderError
+	AuthenticationError       = errors.AuthenticationError
+	BaseError                 = errors.BaseError
+	ContentFilterError        = errors.ContentFilterError
+	ContextLengthError        = errors.ContextLengthError
+	InsufficientFundsError    = errors.InsufficientFundsError
+	InvalidRequestError       = errors.InvalidRequestError
+	MissingAPIKeyError        = errors.MissingAPIKeyError
+	ModelNotFoundError        = errors.ModelNotFoundError
+	ProviderError             = errors.ProviderError
+	RateLimitError            = errors.RateLimitError
+	UnsupportedOperationError = errors.UnsupportedOperationError
+	UnsupportedParamError     = errors.UnsupportedParamError
+	UnsupportedProviderError  = errors.UnsupportedProviderError
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/mozilla-ai/any-llm-platform-client-go v0.0.1
 	github.com/ollama/ollama v0.32.5
-	github.com/openai/openai-go/v3 v3.42.0
+	github.com/openai/openai-go/v3 v3.43.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/genai v1.66.0
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/mozilla-ai/any-llm-platform-client-go v0.0.1
 	github.com/ollama/ollama v0.32.5
-	github.com/openai/openai-go v1.12.0
+	github.com/openai/openai-go/v3 v3.42.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/genai v1.66.0
 )

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/mozilla-ai/any-llm-platform-client-go v0.0.1 h1:AXmEYxIEIESUt2LyB6GFD
 github.com/mozilla-ai/any-llm-platform-client-go v0.0.1/go.mod h1:bqmvllQOUir9G2bmglRQDEgsfHCF6jAC339JGWkzH4U=
 github.com/ollama/ollama v0.32.5 h1:5jeKnTJmDTR+xgB8qh68szdXM9zwnMBMtGl890frdzo=
 github.com/ollama/ollama v0.32.5/go.mod h1:b1ydCt2oVg0VAg22WWDgCbwW0AyOaRKAFzlS91NI4OY=
-github.com/openai/openai-go/v3 v3.42.0 h1:16Skv1hpEhSm3imZpPGSeEBDUgVJJA9cHryKGGsVYI8=
-github.com/openai/openai-go/v3 v3.42.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
+github.com/openai/openai-go/v3 v3.43.0 h1:C+MFVUMU3TJNgES+Ikt7HF8xcX7J0wynKeR9ST22hZM=
+github.com/openai/openai-go/v3 v3.43.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/mozilla-ai/any-llm-platform-client-go v0.0.1 h1:AXmEYxIEIESUt2LyB6GFD
 github.com/mozilla-ai/any-llm-platform-client-go v0.0.1/go.mod h1:bqmvllQOUir9G2bmglRQDEgsfHCF6jAC339JGWkzH4U=
 github.com/ollama/ollama v0.32.5 h1:5jeKnTJmDTR+xgB8qh68szdXM9zwnMBMtGl890frdzo=
 github.com/ollama/ollama v0.32.5/go.mod h1:b1ydCt2oVg0VAg22WWDgCbwW0AyOaRKAFzlS91NI4OY=
-github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
-github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
+github.com/openai/openai-go/v3 v3.42.0 h1:16Skv1hpEhSm3imZpPGSeEBDUgVJJA9cHryKGGsVYI8=
+github.com/openai/openai-go/v3 v3.42.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -23,7 +23,7 @@ var ProviderModelMap = map[string]string{
 	"llamafile":  "LLaMA_CPP",
 	"together":   "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
 	"perplexity": "llama-3.1-sonar-small-128k-online",
-	"deepseek":   "deepseek-chat",
+	"deepseek":   "deepseek-v4-flash",
 	"fireworks":  "accounts/fireworks/models/llama-v3p1-8b-instruct",
 	"xai":        "grok-beta",
 	"cerebras":   "llama3.1-8b",
@@ -38,7 +38,7 @@ var ProviderReasoningModelMap = map[string]string{
 	"anthropic": "claude-sonnet-4-20250514",
 	"gemini":    "gemini-3-flash-preview",
 	"mistral":   "magistral-small-latest",
-	"deepseek":  "deepseek-reasoner",
+	"deepseek":  "deepseek-v4-pro",
 	"ollama":    "deepseek-r1",
 	"zai":       "glm-4.7-flash",
 }

--- a/providers/deepseek/chat.go
+++ b/providers/deepseek/chat.go
@@ -1,0 +1,95 @@
+package deepseek
+
+import (
+	"fmt"
+
+	oaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/shared"
+
+	"github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+type deepSeekThinking struct {
+	Type string `json:"type"`
+}
+
+// transformRequest maps normalized controls to DeepSeek's current Chat schema.
+// https://api-docs.deepseek.com/api/create-chat-completion
+func transformRequest(
+	params providers.CompletionParams,
+	req *oaisdk.ChatCompletionNewParams,
+) error {
+	if params.ParallelToolCalls != nil {
+		return errors.NewUnsupportedParamError(providerName, "parallel_tool_calls")
+	}
+	if params.Seed != nil {
+		return errors.NewUnsupportedParamError(providerName, "seed")
+	}
+
+	if req.MaxCompletionTokens.Valid() {
+		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
+	}
+	// DeepSeek documents max_tokens rather than OpenAI's active max_completion_tokens.
+	req.MaxCompletionTokens = param.Opt[int64]{}
+
+	thinking, effort, err := mapReasoningEffort(params.ReasoningEffort)
+	if err != nil {
+		return err
+	}
+
+	// DeepSeek names this field user_id and does not document OpenAI's user.
+	req.User = param.Opt[string]{}
+	req.ReasoningEffort = shared.ReasoningEffort(effort)
+
+	extraFields := make(map[string]any, 2)
+	if params.User != "" {
+		extraFields["user_id"] = params.User
+	}
+	if thinking != "" {
+		extraFields["thinking"] = deepSeekThinking{Type: thinking}
+	}
+	if len(extraFields) > 0 {
+		// openai-go models neither DeepSeek extension; SetExtraFields is the
+		// official SDK's typed request extension boundary.
+		req.SetExtraFields(extraFields)
+	}
+
+	if len(params.Tools) == 0 {
+		return nil
+	}
+	for i, message := range params.Messages {
+		if message.Role != providers.RoleAssistant || message.Reasoning == nil {
+			continue
+		}
+
+		// DeepSeek requires every prior assistant reasoning_content when the
+		// request carries tools, including turns that did not call a tool.
+		req.Messages[i].OfAssistant.SetExtraFields(map[string]any{
+			"reasoning_content": message.Reasoning.Content,
+		})
+	}
+
+	return nil
+}
+
+func mapReasoningEffort(effort providers.ReasoningEffort) (thinking string, mapped string, err error) {
+	switch effort {
+	case "", providers.ReasoningEffortAuto:
+		return "", "", nil
+	case providers.ReasoningEffortNone:
+		return "disabled", "", nil
+	case providers.ReasoningEffortLow:
+		return "enabled", "low", nil
+	case providers.ReasoningEffortMedium, providers.ReasoningEffortHigh, providers.ReasoningEffortXHigh:
+		return "enabled", "high", nil
+	case providers.ReasoningEffortMax:
+		return "enabled", "max", nil
+	default:
+		return "", "", errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("unsupported reasoning_effort %q", effort),
+		)
+	}
+}

--- a/providers/deepseek/chat.go
+++ b/providers/deepseek/chat.go
@@ -22,6 +22,10 @@ type deepSeekThinking struct {
 	Type string `json:"type"`
 }
 
+type deepSeekUsage struct {
+	PromptCacheHitTokens int `json:"prompt_cache_hit_tokens"`
+}
+
 // transformRequest maps normalized controls to DeepSeek's current Chat schema.
 // https://api-docs.deepseek.com/api/create-chat-completion
 func transformRequest(
@@ -145,6 +149,12 @@ func transformResponse(source *oaisdk.ChatCompletion, result *providers.ChatComp
 		}
 	}
 
+	usage, err := transformUsage(source.Usage, result.Usage)
+	if err != nil {
+		return fmt.Errorf("decoding DeepSeek usage: %w", err)
+	}
+	result.Usage = usage
+
 	return nil
 }
 
@@ -164,7 +174,40 @@ func transformChunk(source *oaisdk.ChatCompletionChunk, result *providers.ChatCo
 		}
 	}
 
+	usage, err := transformUsage(source.Usage, result.Usage)
+	if err != nil {
+		return fmt.Errorf("decoding DeepSeek usage: %w", err)
+	}
+	result.Usage = usage
+
 	return nil
+}
+
+// transformUsage maps DeepSeek's top-level cache fields to the normalized
+// cached-token count. The OpenAI SDK retains these extension fields only in raw JSON.
+// https://api-docs.deepseek.com/guides/kv_cache
+func transformUsage(
+	source oaisdk.CompletionUsage,
+	result *providers.Usage,
+) (*providers.Usage, error) {
+	if source.RawJSON() == "" {
+		return result, nil
+	}
+
+	var usage deepSeekUsage
+	if err := json.Unmarshal([]byte(source.RawJSON()), &usage); err != nil {
+		return nil, err
+	}
+	if result == nil {
+		result = &providers.Usage{
+			PromptTokens:     int(source.PromptTokens),
+			CompletionTokens: int(source.CompletionTokens),
+			TotalTokens:      int(source.TotalTokens),
+		}
+	}
+	result.CachedTokens = usage.PromptCacheHitTokens
+
+	return result, nil
 }
 
 func decodeChatContent(raw string) (deepSeekChatContent, error) {

--- a/providers/deepseek/chat.go
+++ b/providers/deepseek/chat.go
@@ -1,7 +1,9 @@
 package deepseek
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 
 	oaisdk "github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/packages/param"
@@ -10,6 +12,11 @@ import (
 	"github.com/mozilla-ai/any-llm-go/errors"
 	"github.com/mozilla-ai/any-llm-go/providers"
 )
+
+type deepSeekChatContent struct {
+	Content          json.RawMessage `json:"content"`
+	ReasoningContent *string         `json:"reasoning_content"`
+}
 
 type deepSeekThinking struct {
 	Type string `json:"type"`
@@ -74,6 +81,24 @@ func transformRequest(
 	return nil
 }
 
+// transformAPIError follows DeepSeek's published status table instead of
+// applying OpenAI-specific status and error-code assumptions.
+// https://api-docs.deepseek.com/quick_start/error_codes
+func transformAPIError(apiErr *oaisdk.Error, originalErr error) error {
+	switch apiErr.StatusCode {
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		return errors.NewInvalidRequestError(providerName, originalErr)
+	case http.StatusUnauthorized:
+		return errors.NewAuthenticationError(providerName, originalErr)
+	case http.StatusPaymentRequired:
+		return errors.NewInsufficientFundsError(providerName, originalErr)
+	case http.StatusTooManyRequests:
+		return errors.NewRateLimitError(providerName, originalErr)
+	default:
+		return errors.NewProviderError(providerName, originalErr)
+	}
+}
+
 func mapReasoningEffort(effort providers.ReasoningEffort) (thinking string, mapped string, err error) {
 	switch effort {
 	case "", providers.ReasoningEffortAuto:
@@ -92,4 +117,72 @@ func mapReasoningEffort(effort providers.ReasoningEffort) (thinking string, mapp
 			fmt.Errorf("unsupported reasoning_effort %q", effort),
 		)
 	}
+}
+
+// transformResponse preserves DeepSeek's provider-specific reasoning output.
+// https://api-docs.deepseek.com/guides/thinking_mode/
+func transformResponse(source *oaisdk.ChatCompletion, result *providers.ChatCompletion) error {
+	for i, choice := range source.Choices {
+		content, err := decodeChatContent(choice.Message.RawJSON())
+		if err != nil {
+			return fmt.Errorf("decoding DeepSeek choice %d message: %w", i, err)
+		}
+		if len(content.Content) == 0 {
+			return fmt.Errorf("decoding DeepSeek choice %d content: missing required field", i)
+		}
+
+		messageContent, err := decodeOptionalString(content.Content)
+		if err != nil {
+			return fmt.Errorf("decoding DeepSeek choice %d content: %w", i, err)
+		}
+		if messageContent == nil {
+			result.Choices[i].Message.Content = nil
+		} else {
+			result.Choices[i].Message.Content = *messageContent
+		}
+		if content.ReasoningContent != nil {
+			result.Choices[i].Message.Reasoning = &providers.Reasoning{Content: *content.ReasoningContent}
+		}
+	}
+
+	return nil
+}
+
+// transformChunk preserves streamed DeepSeek reasoning deltas.
+// https://api-docs.deepseek.com/guides/thinking_mode/
+func transformChunk(source *oaisdk.ChatCompletionChunk, result *providers.ChatCompletionChunk) error {
+	for i, choice := range source.Choices {
+		content, err := decodeChatContent(choice.Delta.RawJSON())
+		if err != nil {
+			return fmt.Errorf("decoding DeepSeek choice %d delta: %w", i, err)
+		}
+		if _, err := decodeOptionalString(content.Content); err != nil {
+			return fmt.Errorf("decoding DeepSeek choice %d delta content: %w", i, err)
+		}
+		if content.ReasoningContent != nil {
+			result.Choices[i].Delta.Reasoning = &providers.Reasoning{Content: *content.ReasoningContent}
+		}
+	}
+
+	return nil
+}
+
+func decodeChatContent(raw string) (deepSeekChatContent, error) {
+	var content deepSeekChatContent
+	if err := json.Unmarshal([]byte(raw), &content); err != nil {
+		return deepSeekChatContent{}, err
+	}
+	return content, nil
+}
+
+func decodeOptionalString(raw json.RawMessage) (*string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	var value *string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, err
+	}
+	return value, nil
 }

--- a/providers/deepseek/chat_request_test.go
+++ b/providers/deepseek/chat_request_test.go
@@ -1,0 +1,156 @@
+package deepseek
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+func deepSeekCompletionServer(
+	t *testing.T,
+	response string,
+) (serverURL string, requestBody <-chan map[string]any) {
+	t.Helper()
+
+	captured := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding DeepSeek request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		captured <- body
+
+		w.Header().Set("Content-Type", "application/json")
+		// DeepSeek can send blank keep-alive lines before a non-streaming body.
+		_, err := fmt.Fprint(w, "\n\n", response)
+		if err != nil {
+			t.Errorf("writing DeepSeek response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	return server.URL, captured
+}
+
+func TestCompletionMapsCurrentThinkingRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		effort       providers.ReasoningEffort
+		wantThinking string
+		wantEffort   string
+	}{
+		{name: "provider default", effort: providers.ReasoningEffortAuto},
+		{name: "disabled", effort: providers.ReasoningEffortNone, wantThinking: "disabled"},
+		{name: "low", effort: providers.ReasoningEffortLow, wantThinking: "enabled", wantEffort: "low"},
+		{
+			name:         "medium maps high",
+			effort:       providers.ReasoningEffortMedium,
+			wantThinking: "enabled",
+			wantEffort:   "high",
+		},
+		{name: "high", effort: providers.ReasoningEffortHigh, wantThinking: "enabled", wantEffort: "high"},
+		{name: "xhigh maps high", effort: providers.ReasoningEffortXHigh, wantThinking: "enabled", wantEffort: "high"},
+		{name: "max", effort: providers.ReasoningEffortMax, wantThinking: "enabled", wantEffort: "max"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			serverURL, requestBody := deepSeekCompletionServer(t, `{
+				"id":"chatcmpl-test","object":"chat.completion","created":1700000000,
+				"model":"deepseek-v4-pro","choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}]
+			}`)
+			provider, err := New(
+				config.WithAPIKey("test-key"),
+				config.WithBaseURL(serverURL),
+			)
+			require.NoError(t, err)
+
+			_, err = provider.Completion(t.Context(), providers.CompletionParams{
+				Model: "deepseek-v4-pro",
+				Messages: []providers.Message{
+					{Role: providers.RoleUser, Content: "first"},
+					{
+						Role:      providers.RoleAssistant,
+						Content:   "answer",
+						Reasoning: &providers.Reasoning{Content: "reasoning"},
+					},
+					{Role: providers.RoleUser, Content: "next"},
+				},
+				ReasoningEffort: test.effort,
+				Tools: []providers.Tool{{
+					Type: "function",
+					Function: providers.Function{
+						Name:       "lookup",
+						Parameters: map[string]any{"type": "object"},
+					},
+				}},
+				User: "account_42",
+			})
+			require.NoError(t, err)
+
+			body := <-requestBody
+			require.Equal(t, "account_42", body["user_id"])
+			require.NotContains(t, body, "user")
+			require.NotContains(t, body, "parallel_tool_calls")
+			require.NotContains(t, body, "seed")
+			if test.wantThinking == "" {
+				require.NotContains(t, body, "thinking")
+			} else {
+				require.Equal(t, map[string]any{"type": test.wantThinking}, body["thinking"])
+			}
+			if test.wantEffort == "" {
+				require.NotContains(t, body, "reasoning_effort")
+			} else {
+				require.Equal(t, test.wantEffort, body["reasoning_effort"])
+			}
+
+			messages, ok := body["messages"].([]any)
+			require.True(t, ok)
+			assistant, ok := messages[1].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, "reasoning", assistant["reasoning_content"])
+		})
+	}
+}
+
+func TestCompletionOmitsReasoningReplayWithoutTools(t *testing.T) {
+	t.Parallel()
+
+	serverURL, requestBody := deepSeekCompletionServer(t, `{
+		"id":"chatcmpl-test","object":"chat.completion","created":1700000000,
+		"model":"deepseek-v4-pro","choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}]
+	}`)
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.Completion(t.Context(), providers.CompletionParams{
+		Model: "deepseek-v4-pro",
+		Messages: []providers.Message{{
+			Role:      providers.RoleAssistant,
+			Content:   "answer",
+			Reasoning: &providers.Reasoning{Content: "ignored reasoning"},
+		}},
+	})
+	require.NoError(t, err)
+
+	messages, ok := (<-requestBody)["messages"].([]any)
+	require.True(t, ok)
+	assistant, ok := messages[0].(map[string]any)
+	require.True(t, ok)
+	require.NotContains(t, assistant, "reasoning_content")
+}

--- a/providers/deepseek/chat_request_test.go
+++ b/providers/deepseek/chat_request_test.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/any-llm-go/config"
+	llmerrors "github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/internal/testutil"
 	"github.com/mozilla-ai/any-llm-go/providers"
 )
 
@@ -153,4 +156,86 @@ func TestCompletionOmitsReasoningReplayWithoutTools(t *testing.T) {
 	assistant, ok := messages[0].(map[string]any)
 	require.True(t, ok)
 	require.NotContains(t, assistant, "reasoning_content")
+}
+
+func TestCompletionStreamMapsCurrentThinkingRequest(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeStreamingServer(t)
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	chunks, errs := provider.CompletionStream(t.Context(), providers.CompletionParams{
+		Model:           "deepseek-v4-flash",
+		Messages:        testutil.SimpleMessages(),
+		ReasoningEffort: providers.ReasoningEffortMax,
+		User:            "account_42",
+	})
+	for range chunks {
+	}
+	require.NoError(t, <-errs)
+
+	body := capturedBody()
+	require.Equal(t, map[string]any{"type": "enabled"}, body["thinking"])
+	require.Equal(t, "max", body["reasoning_effort"])
+	require.Equal(t, "account_42", body["user_id"])
+	require.NotContains(t, body, "user")
+}
+
+func TestCompletionRejectsUnsupportedParamsBeforeTransport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params providers.CompletionParams
+		want   error
+	}{
+		{
+			name: "unknown reasoning effort",
+			params: providers.CompletionParams{
+				ReasoningEffort: providers.ReasoningEffort("unsupported"),
+			},
+			want: llmerrors.ErrInvalidRequest,
+		},
+		{
+			name:   "parallel tool calls",
+			params: providers.CompletionParams{ParallelToolCalls: new(false)},
+			want:   llmerrors.ErrUnsupportedParam,
+		},
+		{
+			name:   "seed",
+			params: providers.CompletionParams{Seed: new(7)},
+			want:   llmerrors.ErrUnsupportedParam,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var requests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				requests.Add(1)
+			}))
+			t.Cleanup(server.Close)
+			provider, err := New(
+				config.WithAPIKey("test-key"),
+				config.WithBaseURL(server.URL),
+			)
+			require.NoError(t, err)
+
+			test.params.Model = "deepseek-v4-pro"
+			test.params.Messages = testutil.SimpleMessages()
+			_, err = provider.Completion(t.Context(), test.params)
+			require.ErrorIs(t, err, test.want)
+
+			chunks, errs := provider.CompletionStream(t.Context(), test.params)
+			for range chunks {
+			}
+			require.ErrorIs(t, <-errs, test.want)
+			require.Zero(t, requests.Load())
+		})
+	}
 }

--- a/providers/deepseek/chat_response_test.go
+++ b/providers/deepseek/chat_response_test.go
@@ -2,11 +2,14 @@ package deepseek
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/any-llm-go/config"
+	llmerrors "github.com/mozilla-ai/any-llm-go/errors"
 	"github.com/mozilla-ai/any-llm-go/internal/testutil"
 	"github.com/mozilla-ai/any-llm-go/providers"
 )
@@ -97,6 +100,102 @@ func TestCompletionRejectsMalformedContent(t *testing.T) {
 				Messages: testutil.SimpleMessages(),
 			})
 			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func TestCompletionStreamPreservesReasoningAndTerminalUsage(t *testing.T) {
+	t.Parallel()
+
+	events := []string{
+		`{"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,"model":"deepseek-v4-pro","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"reasoning"},"finish_reason":null}],"usage":null}`,
+		`{"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,"model":"deepseek-v4-pro","choices":[{"index":0,"delta":{"content":"answer"},"finish_reason":null}],"usage":null}`,
+		`{"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,"model":"deepseek-v4-pro","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":8,"completion_tokens":5,"total_tokens":13,"prompt_cache_hit_tokens":3,"prompt_cache_miss_tokens":5}}`,
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, err := fmt.Fprint(w, ": keep-alive\n\n")
+		if err != nil {
+			t.Errorf("writing DeepSeek keep-alive: %v", err)
+			return
+		}
+		for _, event := range events {
+			_, err = fmt.Fprintf(w, "data: %s\n\n", event)
+			if err != nil {
+				t.Errorf("writing DeepSeek stream event: %v", err)
+				return
+			}
+		}
+		_, err = fmt.Fprint(w, "data: [DONE]\n\n")
+		if err != nil {
+			t.Errorf("writing DeepSeek stream terminator: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(server.URL),
+	)
+	require.NoError(t, err)
+
+	chunkChannel, errChannel := provider.CompletionStream(t.Context(), providers.CompletionParams{
+		Model:    "deepseek-v4-pro",
+		Messages: testutil.SimpleMessages(),
+	})
+	chunks := make([]providers.ChatCompletionChunk, 0, len(events))
+	for chunk := range chunkChannel {
+		chunks = append(chunks, chunk)
+	}
+	require.NoError(t, <-errChannel)
+	require.Len(t, chunks, len(events))
+	require.NotNil(t, chunks[0].Choices[0].Delta.Reasoning)
+	require.Equal(t, "reasoning", chunks[0].Choices[0].Delta.Reasoning.Content)
+	require.Equal(t, "answer", chunks[1].Choices[0].Delta.Content)
+	require.Equal(t, "stop", chunks[2].Choices[0].FinishReason)
+	require.Equal(t, &providers.Usage{PromptTokens: 8, CompletionTokens: 5, TotalTokens: 13}, chunks[2].Usage)
+}
+
+func TestCompletionMapsDocumentedDeepSeekErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status int
+		want   error
+	}{
+		{status: http.StatusBadRequest, want: llmerrors.ErrInvalidRequest},
+		{status: http.StatusUnauthorized, want: llmerrors.ErrAuthentication},
+		{status: http.StatusPaymentRequired, want: llmerrors.ErrInsufficientFunds},
+		{status: http.StatusUnprocessableEntity, want: llmerrors.ErrInvalidRequest},
+		{status: http.StatusTooManyRequests, want: llmerrors.ErrRateLimit},
+		{status: http.StatusInternalServerError, want: llmerrors.ErrProvider},
+		{status: http.StatusServiceUnavailable, want: llmerrors.ErrProvider},
+		{status: http.StatusNotFound, want: llmerrors.ErrProvider},
+	}
+	for _, test := range tests {
+		t.Run(http.StatusText(test.status), func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(test.status)
+				_, err := fmt.Fprint(w, `{"error":{"message":"request failed","type":"invalid_request_error"}}`)
+				if err != nil {
+					t.Errorf("writing DeepSeek error: %v", err)
+				}
+			}))
+			t.Cleanup(server.Close)
+			provider, err := New(
+				config.WithAPIKey("test-key"),
+				config.WithBaseURL(server.URL),
+			)
+			require.NoError(t, err)
+
+			_, err = provider.Completion(t.Context(), providers.CompletionParams{
+				Model:    "deepseek-v4-pro",
+				Messages: testutil.SimpleMessages(),
+			})
+			require.Error(t, err)
+			require.ErrorIs(t, err, test.want)
 		})
 	}
 }

--- a/providers/deepseek/chat_response_test.go
+++ b/providers/deepseek/chat_response_test.go
@@ -63,6 +63,82 @@ func TestCompletionPreservesNullableContent(t *testing.T) {
 	require.Nil(t, completion.Choices[0].Message.Content)
 }
 
+func TestCompletionPreservesCacheUsage(t *testing.T) {
+	t.Parallel()
+
+	serverURL, _ := deepSeekCompletionServer(t, `{
+		"id":"chatcmpl-test","object":"chat.completion","created":1700000000,
+		"model":"deepseek-v4-pro","choices":[{"index":0,"message":{
+			"role":"assistant","content":"answer"
+		},"finish_reason":"stop"}],"usage":{"prompt_tokens":8,"completion_tokens":5,
+		"total_tokens":13,"prompt_cache_hit_tokens":3,"prompt_cache_miss_tokens":5}
+	}`)
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	completion, err := provider.Completion(t.Context(), providers.CompletionParams{
+		Model:    "deepseek-v4-pro",
+		Messages: testutil.SimpleMessages(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, &providers.Usage{
+		PromptTokens:     8,
+		CompletionTokens: 5,
+		TotalTokens:      13,
+		CachedTokens:     3,
+	}, completion.Usage)
+}
+
+func TestCompletionPreservesPresentZeroCacheUsage(t *testing.T) {
+	t.Parallel()
+
+	serverURL, _ := deepSeekCompletionServer(t, `{
+		"id":"chatcmpl-test","object":"chat.completion","created":1700000000,
+		"model":"deepseek-v4-pro","choices":[{"index":0,"message":{
+			"role":"assistant","content":"answer"
+		},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,
+		"total_tokens":0,"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":0}
+	}`)
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	completion, err := provider.Completion(t.Context(), providers.CompletionParams{
+		Model:    "deepseek-v4-pro",
+		Messages: testutil.SimpleMessages(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, &providers.Usage{}, completion.Usage)
+}
+
+func TestCompletionRejectsMalformedCacheUsage(t *testing.T) {
+	t.Parallel()
+
+	serverURL, _ := deepSeekCompletionServer(t, `{
+		"id":"chatcmpl-test","object":"chat.completion","created":1700000000,
+		"model":"deepseek-v4-pro","choices":[{"index":0,"message":{
+			"role":"assistant","content":"answer"
+		},"finish_reason":"stop"}],"usage":{"prompt_tokens":8,"completion_tokens":5,
+		"total_tokens":13,"prompt_cache_hit_tokens":"3","prompt_cache_miss_tokens":5}
+	}`)
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.Completion(t.Context(), providers.CompletionParams{
+		Model:    "deepseek-v4-pro",
+		Messages: testutil.SimpleMessages(),
+	})
+	require.ErrorContains(t, err, "decoding DeepSeek usage")
+}
+
 func TestCompletionRejectsMalformedContent(t *testing.T) {
 	t.Parallel()
 
@@ -152,7 +228,42 @@ func TestCompletionStreamPreservesReasoningAndTerminalUsage(t *testing.T) {
 	require.Equal(t, "reasoning", chunks[0].Choices[0].Delta.Reasoning.Content)
 	require.Equal(t, "answer", chunks[1].Choices[0].Delta.Content)
 	require.Equal(t, "stop", chunks[2].Choices[0].FinishReason)
-	require.Equal(t, &providers.Usage{PromptTokens: 8, CompletionTokens: 5, TotalTokens: 13}, chunks[2].Usage)
+	require.Equal(t, &providers.Usage{
+		PromptTokens:     8,
+		CompletionTokens: 5,
+		TotalTokens:      13,
+		CachedTokens:     3,
+	}, chunks[2].Usage)
+}
+
+func TestCompletionStreamRejectsMalformedCacheUsage(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, err := fmt.Fprint(w, `data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1700000000,"model":"deepseek-v4-pro","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":8,"completion_tokens":5,"total_tokens":13,"prompt_cache_hit_tokens":"3","prompt_cache_miss_tokens":5}}
+
+data: [DONE]
+
+`)
+		if err != nil {
+			t.Errorf("writing DeepSeek stream: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(server.URL),
+	)
+	require.NoError(t, err)
+
+	chunks, errs := provider.CompletionStream(t.Context(), providers.CompletionParams{
+		Model:    "deepseek-v4-pro",
+		Messages: testutil.SimpleMessages(),
+	})
+	for range chunks {
+	}
+	require.ErrorContains(t, <-errs, "decoding DeepSeek usage")
 }
 
 func TestCompletionMapsDocumentedDeepSeekErrors(t *testing.T) {

--- a/providers/deepseek/chat_response_test.go
+++ b/providers/deepseek/chat_response_test.go
@@ -1,0 +1,102 @@
+package deepseek
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	"github.com/mozilla-ai/any-llm-go/internal/testutil"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+func TestCompletionPreservesReasoningResponse(t *testing.T) {
+	t.Parallel()
+
+	serverURL, _ := deepSeekCompletionServer(t, `{
+		"id":"chatcmpl-test","object":"chat.completion","created":1700000000,
+		"model":"deepseek-v4-pro","choices":[{"index":0,"message":{
+			"role":"assistant","content":"answer","reasoning_content":"","future_field":true
+		},"finish_reason":"insufficient_system_resource"}]
+	}`)
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	completion, err := provider.Completion(t.Context(), providers.CompletionParams{
+		Model:    "deepseek-v4-pro",
+		Messages: testutil.SimpleMessages(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "answer", completion.Choices[0].Message.Content)
+	require.Equal(t, "insufficient_system_resource", completion.Choices[0].FinishReason)
+	require.NotNil(t, completion.Choices[0].Message.Reasoning)
+	require.Empty(t, completion.Choices[0].Message.Reasoning.Content)
+}
+
+func TestCompletionPreservesNullableContent(t *testing.T) {
+	t.Parallel()
+
+	serverURL, _ := deepSeekCompletionServer(t, `{
+		"id":"chatcmpl-test","object":"chat.completion","created":1700000000,
+		"model":"deepseek-v4-pro","choices":[{"index":0,"message":{
+			"role":"assistant","content":null,"reasoning_content":"reasoning"
+		},"finish_reason":"stop"}]
+	}`)
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	completion, err := provider.Completion(t.Context(), providers.CompletionParams{
+		Model:    "deepseek-v4-pro",
+		Messages: testutil.SimpleMessages(),
+	})
+	require.NoError(t, err)
+	require.Nil(t, completion.Choices[0].Message.Content)
+}
+
+func TestCompletionRejectsMalformedContent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		message string
+		want    string
+	}{
+		{name: "missing answer", message: `"reasoning_content":"reasoning"`, want: "missing required field"},
+		{name: "invalid answer", message: `"content":{}`, want: "cannot unmarshal object"},
+		{
+			name:    "invalid reasoning",
+			message: `"content":"answer","reasoning_content":{}`,
+			want:    "cannot unmarshal object",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			serverURL, _ := deepSeekCompletionServer(t, fmt.Sprintf(`{
+				"id":"chatcmpl-test","object":"chat.completion","created":1700000000,
+				"model":"deepseek-v4-pro","choices":[{"index":0,"message":{
+					"role":"assistant",%s
+				},"finish_reason":"stop"}]
+			}`, test.message))
+			provider, err := New(
+				config.WithAPIKey("test-key"),
+				config.WithBaseURL(serverURL),
+			)
+			require.NoError(t, err)
+
+			_, err = provider.Completion(t.Context(), providers.CompletionParams{
+				Model:    "deepseek-v4-pro",
+				Messages: testutil.SimpleMessages(),
+			})
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -50,14 +50,17 @@ type Provider struct {
 // New creates a new DeepSeek provider.
 func New(opts ...config.Option) (*Provider, error) {
 	base, err := openai.NewCompatible(openai.CompatibleConfig{
-		APIKeyEnvVar:                   envAPIKey,
-		BaseURLEnvVar:                  "",
-		Capabilities:                   capabilities(),
-		ChatCompletionRequestTransform: transformRequest,
-		DefaultAPIKey:                  "",
-		DefaultBaseURL:                 defaultBaseURL,
-		Name:                           providerName,
-		RequireAPIKey:                  true,
+		APIKeyEnvVar:                    envAPIKey,
+		APIErrorTransform:               transformAPIError,
+		BaseURLEnvVar:                   "",
+		Capabilities:                    capabilities(),
+		ChatCompletionChunkTransform:    transformChunk,
+		ChatCompletionRequestTransform:  transformRequest,
+		ChatCompletionResponseTransform: transformResponse,
+		DefaultAPIKey:                   "",
+		DefaultBaseURL:                  defaultBaseURL,
+		Name:                            providerName,
+		RequireAPIKey:                   true,
 	}, opts...)
 	if err != nil {
 		return nil, err

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -8,9 +8,6 @@ import (
 	"fmt"
 	"slices"
 
-	oaisdk "github.com/openai/openai-go/v3"
-	"github.com/openai/openai-go/v3/packages/param"
-
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
 	"github.com/mozilla-ai/any-llm-go/providers/openai"
@@ -95,7 +92,7 @@ func capabilities() providers.Capabilities {
 		Completion:          true,
 		CompletionImage:     false, // DeepSeek doesn't support images.
 		CompletionPDF:       false,
-		CompletionReasoning: true, // DeepSeek R1 supports reasoning.
+		CompletionReasoning: true, // DeepSeek V4 supports reasoning.
 		CompletionStreaming: true,
 		CompletionTools:     true,
 		Embedding:           false, // DeepSeek doesn't host embedding models.
@@ -158,15 +155,6 @@ func preprocessParams(params providers.CompletionParams) providers.CompletionPar
 		User:            params.User,
 		Extra:           params.Extra,
 	}
-}
-
-// transformRequest maps the shared token limit to DeepSeek's max_tokens field.
-// https://api-docs.deepseek.com/api/create-chat-completion
-func transformRequest(req *oaisdk.ChatCompletionNewParams) {
-	if req.MaxCompletionTokens.Valid() {
-		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
-	}
-	req.MaxCompletionTokens = param.Opt[int64]{}
 }
 
 // preprocessMessagesForJSONSchema injects the JSON schema into the last user message.

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"slices"
 
-	oaisdk "github.com/openai/openai-go"
-	"github.com/openai/openai-go/packages/param"
+	oaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
@@ -160,17 +160,12 @@ func preprocessParams(params providers.CompletionParams) providers.CompletionPar
 	}
 }
 
-// transformRequest adjusts the OpenAI SDK request for DeepSeek's API.
-// DeepSeek uses max_tokens, not max_completion_tokens.
-// If both are set, MaxCompletionTokens takes precedence over MaxTokens.
-// See: https://api-docs.deepseek.com/api/create-chat-completion
+// transformRequest maps the shared token limit to DeepSeek's max_tokens field.
+// https://api-docs.deepseek.com/api/create-chat-completion
 func transformRequest(req *oaisdk.ChatCompletionNewParams) {
 	if req.MaxCompletionTokens.Valid() {
-		// Set max_tokens using max_completion_tokens value.
 		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
 	}
-
-	// Clear unsupported fields from the request.
 	req.MaxCompletionTokens = param.Opt[int64]{}
 }
 

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/v3"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/errors"
@@ -373,7 +373,7 @@ func capabilities() providers.Capabilities {
 		CompletionImage:     true,
 		CompletionPDF:       true,
 		CompletionReasoning: true,
-		CompletionStreaming:  true,
+		CompletionStreaming: true,
 		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
@@ -703,7 +703,9 @@ func (p *Provider) handleRerankErrorResponse(resp *http.Response) error {
 	case http.StatusTooManyRequests:
 		return errors.NewRateLimitError(providerName, fmt.Errorf("%s", msg))
 	case http.StatusBadGateway:
-		return &UpstreamProviderError{BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider)}
+		return &UpstreamProviderError{
+			BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider),
+		}
 	case http.StatusGatewayTimeout:
 		return &TimeoutError{BaseError: errors.New(errCodeTimeout, providerName, fmt.Errorf("%s", msg), ErrTimeout)}
 	default:

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -144,11 +144,12 @@ func patchMessageParams(params providers.CompletionParams) providers.CompletionP
 // transformRequest maps the shared token limit to Mistral's max_tokens field
 // and removes fields outside its Chat request schema.
 // https://docs.mistral.ai/api?property=operation-chat_completion_v1_chat_completions_post_request_max_tokens
-func transformRequest(req *oaisdk.ChatCompletionNewParams) {
+func transformRequest(_ providers.CompletionParams, req *oaisdk.ChatCompletionNewParams) error {
 	if req.MaxCompletionTokens.Valid() {
 		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
 	}
 	req.MaxCompletionTokens = param.Opt[int64]{}
 	req.User = param.Opt[string]{}
 	req.ReasoningEffort = ""
+	return nil
 }

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"slices"
 
-	oaisdk "github.com/openai/openai-go"
-	"github.com/openai/openai-go/packages/param"
+	oaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
@@ -141,17 +141,13 @@ func patchMessageParams(params providers.CompletionParams) providers.CompletionP
 	return params
 }
 
-// transformRequest adjusts the OpenAI SDK request for Mistral's API.
-// Mistral uses max_tokens (not max_completion_tokens) and does not accept user or reasoning_effort fields.
-// If both are set, MaxCompletionTokens takes precedence over MaxTokens.
-// See: https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post
+// transformRequest maps the shared token limit to Mistral's max_tokens field
+// and removes fields outside its Chat request schema.
+// https://docs.mistral.ai/api?property=operation-chat_completion_v1_chat_completions_post_request_max_tokens
 func transformRequest(req *oaisdk.ChatCompletionNewParams) {
 	if req.MaxCompletionTokens.Valid() {
-		// Set max_tokens using max_completion_tokens value.
 		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
 	}
-
-	// Clear unsupported fields from the request.
 	req.MaxCompletionTokens = param.Opt[int64]{}
 	req.User = param.Opt[string]{}
 	req.ReasoningEffort = ""

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -7,9 +7,9 @@ import (
 	stderrors "errors"
 	"fmt"
 
-	"github.com/openai/openai-go"
-	"github.com/openai/openai-go/option"
-	"github.com/openai/openai-go/shared"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/shared"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/errors"
@@ -328,13 +328,15 @@ func convertAPIError(name string, apiErr *openai.Error, originalErr error) error
 // convertAssistantMessage converts an assistant message to OpenAI format.
 func convertAssistantMessage(msg providers.Message) openai.ChatCompletionMessageParamUnion {
 	if len(msg.ToolCalls) > 0 {
-		toolCalls := make([]openai.ChatCompletionMessageToolCallParam, 0, len(msg.ToolCalls))
+		toolCalls := make([]openai.ChatCompletionMessageToolCallUnionParam, 0, len(msg.ToolCalls))
 		for _, tc := range msg.ToolCalls {
-			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallParam{
-				ID: tc.ID,
-				Function: openai.ChatCompletionMessageToolCallFunctionParam{
-					Name:      tc.Function.Name,
-					Arguments: tc.Function.Arguments,
+			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnionParam{
+				OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
+					ID: tc.ID,
+					Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
+						Name:      tc.Function.Name,
+						Arguments: tc.Function.Arguments,
+					},
 				},
 			})
 		}
@@ -380,13 +382,16 @@ func convertChunk(chunk *openai.ChatCompletionChunk) providers.ChatCompletionChu
 		choices = append(choices, chunkChoice)
 	}
 
+	// Preserve the existing normalized field even though the v3 SDK marks the
+	// documented response field as deprecated.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	result := providers.ChatCompletionChunk{
 		ID:                chunk.ID,
 		Object:            objectChatCompletionChunk,
 		Created:           chunk.Created,
 		Model:             chunk.Model,
 		Choices:           choices,
-		SystemFingerprint: chunk.SystemFingerprint,
+		SystemFingerprint: chunk.SystemFingerprint, //nolint:staticcheck
 	}
 
 	if chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0 {
@@ -570,13 +575,16 @@ func convertResponse(resp *openai.ChatCompletion) *providers.ChatCompletion {
 		})
 	}
 
+	// Preserve the existing normalized field even though the v3 SDK marks the
+	// documented response field as deprecated.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	result := &providers.ChatCompletion{
 		ID:                resp.ID,
 		Object:            objectChatCompletion,
 		Created:           resp.Created,
 		Model:             resp.Model,
 		Choices:           choices,
-		SystemFingerprint: resp.SystemFingerprint,
+		SystemFingerprint: resp.SystemFingerprint, //nolint:staticcheck
 	}
 
 	if resp.Usage.PromptTokens > 0 || resp.Usage.CompletionTokens > 0 {
@@ -658,7 +666,7 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 		}
 	case providers.ToolChoice:
 		if v.Function != nil {
-			return openai.ChatCompletionToolChoiceOptionParamOfChatCompletionNamedToolChoice(
+			return openai.ToolChoiceOptionFunctionToolChoice(
 				openai.ChatCompletionNamedToolChoiceFunctionParam{
 					Name: v.Function.Name,
 				},
@@ -671,14 +679,16 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 }
 
 // convertTools converts provider tools to OpenAI format.
-func convertTools(tools []providers.Tool) []openai.ChatCompletionToolParam {
-	result := make([]openai.ChatCompletionToolParam, 0, len(tools))
+func convertTools(tools []providers.Tool) []openai.ChatCompletionToolUnionParam {
+	result := make([]openai.ChatCompletionToolUnionParam, 0, len(tools))
 	for _, tool := range tools {
-		result = append(result, openai.ChatCompletionToolParam{
-			Function: openai.FunctionDefinitionParam{
-				Name:        tool.Function.Name,
-				Description: openai.String(tool.Function.Description),
-				Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+		result = append(result, openai.ChatCompletionToolUnionParam{
+			OfFunction: &openai.ChatCompletionFunctionToolParam{
+				Function: openai.FunctionDefinitionParam{
+					Name:        tool.Function.Name,
+					Description: openai.String(tool.Function.Description),
+					Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+				},
 			},
 		})
 	}

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -689,13 +689,17 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 func convertTools(tools []providers.Tool) []openai.ChatCompletionToolUnionParam {
 	result := make([]openai.ChatCompletionToolUnionParam, 0, len(tools))
 	for _, tool := range tools {
+		function := openai.FunctionDefinitionParam{
+			Name:        tool.Function.Name,
+			Description: openai.String(tool.Function.Description),
+			Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+		}
+		if tool.Function.Strict != nil {
+			function.Strict = openai.Bool(*tool.Function.Strict)
+		}
 		result = append(result, openai.ChatCompletionToolUnionParam{
 			OfFunction: &openai.ChatCompletionFunctionToolParam{
-				Function: openai.FunctionDefinitionParam{
-					Name:        tool.Function.Name,
-					Description: openai.String(tool.Function.Description),
-					Parameters:  openai.FunctionParameters(tool.Function.Parameters),
-				},
+				Function: function,
 			},
 		})
 	}

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -517,6 +517,10 @@ func convertParams(params providers.CompletionParams) openai.ChatCompletionNewPa
 		req.TopP = openai.Float(*params.TopP)
 	}
 
+	// OpenAI documents max_completion_tokens as the replacement for the
+	// deprecated max_tokens field. Keep the binding's existing MaxTokens
+	// abstraction on the current wire field.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	if params.MaxTokens != nil {
 		req.MaxCompletionTokens = openai.Int(int64(*params.MaxTokens))
 	}
@@ -551,7 +555,10 @@ func convertParams(params providers.CompletionParams) openai.ChatCompletionNewPa
 		req.User = openai.String(params.User)
 	}
 
-	if params.ReasoningEffort != "" && params.ReasoningEffort != providers.ReasoningEffortNone {
+	// auto is the binding's omission sentinel. OpenAI documents none as an
+	// explicit value, so it must reach the wire unchanged.
+	// https://developers.openai.com/api/docs/guides/latest-model
+	if params.ReasoningEffort != "" && params.ReasoningEffort != providers.ReasoningEffortAuto {
 		req.ReasoningEffort = shared.ReasoningEffort(params.ReasoningEffort)
 	}
 

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -50,6 +50,10 @@ const (
 // CompatibleConfig contains the configuration for an OpenAI-compatible provider.
 // Fields are ordered alphabetically.
 type CompatibleConfig struct {
+	// APIErrorTransform maps provider-specific HTTP errors without duplicating
+	// the compatible transport. When set, it owns every decoded API error.
+	APIErrorTransform func(*openai.Error, error) error
+
 	// APIKeyEnvVar is the environment variable for the API key.
 	APIKeyEnvVar string
 
@@ -59,11 +63,19 @@ type CompatibleConfig struct {
 	// Capabilities describes what the provider supports.
 	Capabilities providers.Capabilities
 
+	// ChatCompletionChunkTransform adapts provider-specific streaming fields
+	// after the SDK and shared converters preserve each chunk.
+	ChatCompletionChunkTransform func(*openai.ChatCompletionChunk, *providers.ChatCompletionChunk) error
+
 	// ChatCompletionRequestTransform is an optional function that modifies the chat
 	// completion request after convertParams() builds it and before it is serialized
 	// to the wire. The pointer refers to a locally-constructed value owned by the
 	// caller; the function must not retain it beyond the call.
 	ChatCompletionRequestTransform func(providers.CompletionParams, *openai.ChatCompletionNewParams) error
+
+	// ChatCompletionResponseTransform adapts provider-specific response fields
+	// after the SDK and shared converters preserve the response envelope.
+	ChatCompletionResponseTransform func(*openai.ChatCompletion, *providers.ChatCompletion) error
 
 	// DefaultAPIKey is used when RequireAPIKey is false (e.g., for local servers).
 	DefaultAPIKey string
@@ -181,7 +193,14 @@ func (p *CompatibleProvider) Completion(
 		return nil, p.ConvertError(err)
 	}
 
-	return convertResponse(resp), nil
+	result := convertResponse(resp)
+	if transform := p.compatibleConfig.ChatCompletionResponseTransform; transform != nil {
+		if err := transform(resp, result); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
 }
 
 // CompletionStream performs a streaming chat completion request.
@@ -212,8 +231,15 @@ func (p *CompatibleProvider) CompletionStream(
 
 		for stream.Next() {
 			chunk := stream.Current()
+			result := convertChunk(&chunk)
+			if transform := p.compatibleConfig.ChatCompletionChunkTransform; transform != nil {
+				if err := transform(&chunk, &result); err != nil {
+					errs <- err
+					return
+				}
+			}
 			select {
-			case chunks <- convertChunk(&chunk):
+			case chunks <- result:
 			case <-ctx.Done():
 				// Caller cancelled mid-stream; surface ctx.Err() so the
 				// consumer can tell a cancelled stream apart from one
@@ -242,8 +268,10 @@ func (p *CompatibleProvider) ConvertError(err error) error {
 	name := p.compatibleConfig.Name
 
 	// Check for OpenAI API error type.
-	var apiErr *openai.Error
-	if stderrors.As(err, &apiErr) {
+	if apiErr, ok := stderrors.AsType[*openai.Error](err); ok {
+		if transform := p.compatibleConfig.APIErrorTransform; transform != nil {
+			return transform(apiErr, err)
+		}
 		return convertAPIError(name, apiErr, err)
 	}
 

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -59,6 +59,12 @@ type CompatibleConfig struct {
 	// Capabilities describes what the provider supports.
 	Capabilities providers.Capabilities
 
+	// ChatCompletionRequestTransform is an optional function that modifies the chat
+	// completion request after convertParams() builds it and before it is serialized
+	// to the wire. The pointer refers to a locally-constructed value owned by the
+	// caller; the function must not retain it beyond the call.
+	ChatCompletionRequestTransform func(providers.CompletionParams, *openai.ChatCompletionNewParams) error
+
 	// DefaultAPIKey is used when RequireAPIKey is false (e.g., for local servers).
 	DefaultAPIKey string
 
@@ -67,14 +73,6 @@ type CompatibleConfig struct {
 
 	// Name is the provider name used in error messages.
 	Name string
-
-	// ChatCompletionRequestTransform is an optional function that modifies the chat
-	// completion request after convertParams() builds it and before it is serialized
-	// to the wire. Providers that are not fully OpenAI-compatible use this to adjust
-	// wire-level fields (e.g. swapping max_completion_tokens back to max_tokens).
-	// The pointer refers to a locally-constructed value owned by the caller; the
-	// function must not retain it beyond the call. Nil means no transformation.
-	ChatCompletionRequestTransform func(*openai.ChatCompletionNewParams)
 
 	// RequireAPIKey indicates whether an API key is required.
 	RequireAPIKey bool
@@ -172,8 +170,10 @@ func (p *CompatibleProvider) Completion(
 	}
 
 	req := convertParams(params)
-	if p.compatibleConfig.ChatCompletionRequestTransform != nil {
-		p.compatibleConfig.ChatCompletionRequestTransform(&req)
+	if transform := p.compatibleConfig.ChatCompletionRequestTransform; transform != nil {
+		if err := transform(params, &req); err != nil {
+			return nil, err
+		}
 	}
 
 	resp, err := p.client.Chat.Completions.New(ctx, req)
@@ -202,8 +202,11 @@ func (p *CompatibleProvider) CompletionStream(
 		}
 
 		req := convertParams(params)
-		if p.compatibleConfig.ChatCompletionRequestTransform != nil {
-			p.compatibleConfig.ChatCompletionRequestTransform(&req)
+		if transform := p.compatibleConfig.ChatCompletionRequestTransform; transform != nil {
+			if err := transform(params, &req); err != nil {
+				errs <- err
+				return
+			}
 		}
 		stream := p.client.Chat.Completions.NewStreaming(ctx, req)
 

--- a/providers/openai/compatible_test.go
+++ b/providers/openai/compatible_test.go
@@ -3,15 +3,18 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	oaisdk "github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/internal/testutil"
 	"github.com/mozilla-ai/any-llm-go/providers"
 )
 
@@ -212,6 +215,58 @@ func TestCompatibleProviderCapabilities(t *testing.T) {
 
 	caps := provider.Capabilities()
 	require.Equal(t, expectedCaps, caps)
+}
+
+func TestCompletionReturnsResponseTransformError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := stderrors.New("transform failed")
+	serverURL, _ := testutil.FakeCompletionServer(t)
+	provider, err := NewCompatible(CompatibleConfig{
+		ChatCompletionResponseTransform: func(
+			*oaisdk.ChatCompletion,
+			*providers.ChatCompletion,
+		) error {
+			return wantErr
+		},
+		DefaultAPIKey:  "test-key",
+		DefaultBaseURL: serverURL,
+		Name:           "test-provider",
+	})
+	require.NoError(t, err)
+
+	_, err = provider.Completion(t.Context(), providers.CompletionParams{
+		Model:    "test-model",
+		Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
+	})
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestCompletionStreamReturnsChunkTransformError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := stderrors.New("transform failed")
+	serverURL, _ := testutil.FakeStreamingServer(t)
+	provider, err := NewCompatible(CompatibleConfig{
+		ChatCompletionChunkTransform: func(
+			*oaisdk.ChatCompletionChunk,
+			*providers.ChatCompletionChunk,
+		) error {
+			return wantErr
+		},
+		DefaultAPIKey:  "test-key",
+		DefaultBaseURL: serverURL,
+		Name:           "test-provider",
+	})
+	require.NoError(t, err)
+
+	chunks, errs := provider.CompletionStream(t.Context(), providers.CompletionParams{
+		Model:    "test-model",
+		Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
+	})
+	for range chunks {
+	}
+	require.ErrorIs(t, <-errs, wantErr)
 }
 
 func TestValidateCompletionParams(t *testing.T) {

--- a/providers/openai/compatible_test.go
+++ b/providers/openai/compatible_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -313,6 +314,42 @@ func TestConvertResponseFormat(t *testing.T) {
 		result := convertResponseFormat(format)
 		require.NotNil(t, result.OfText)
 	})
+}
+
+func TestConvertToolsPreservesStrict(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		strict *bool
+	}{
+		{name: "omitted"},
+		{name: "false", strict: new(false)},
+		{name: "true", strict: new(true)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tools := convertTools([]providers.Tool{{
+				Type: "function",
+				Function: providers.Function{
+					Name:       "lookup",
+					Parameters: map[string]any{"type": "object"},
+					Strict:     tc.strict,
+				},
+			}})
+			body, err := json.Marshal(tools)
+			require.NoError(t, err)
+
+			var wire []struct {
+				Function struct {
+					Strict *bool `json:"strict"`
+				} `json:"function"`
+			}
+			require.NoError(t, json.Unmarshal(body, &wire))
+			require.Equal(t, tc.strict, wire[0].Function.Strict)
+		})
+	}
 }
 
 func TestConvertEmbeddingParams(t *testing.T) {

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -9,6 +9,7 @@ import (
 const (
 	defaultBaseURL = "https://api.openai.com/v1"
 	envAPIKey      = "OPENAI_API_KEY"
+	envBaseURL     = "OPENAI_BASE_URL"
 	providerName   = "openai"
 )
 
@@ -31,6 +32,7 @@ type Provider struct {
 func New(opts ...config.Option) (*Provider, error) {
 	base, err := NewCompatible(CompatibleConfig{
 		APIKeyEnvVar:   envAPIKey,
+		BaseURLEnvVar:  envBaseURL,
 		Capabilities:   capabilities(),
 		DefaultBaseURL: defaultBaseURL,
 		Name:           providerName,

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -34,6 +34,21 @@ func TestNew(t *testing.T) {
 		require.NotNil(t, provider)
 	})
 
+	t.Run("reads OPENAI_BASE_URL", func(t *testing.T) {
+		serverURL, _ := testutil.FakeCompletionServer(t)
+		t.Setenv("OPENAI_API_KEY", "env-api-key")
+		t.Setenv("OPENAI_BASE_URL", serverURL)
+
+		provider, err := New()
+		require.NoError(t, err)
+
+		_, err = provider.Completion(t.Context(), providers.CompletionParams{
+			Model:    "test-model",
+			Messages: testutil.SimpleMessages(),
+		})
+		require.NoError(t, err)
+	})
+
 	t.Run("returns error when API key is missing", func(t *testing.T) {
 		t.Setenv("OPENAI_API_KEY", "")
 

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -116,7 +116,7 @@ func TestConvertParams(t *testing.T) {
 		require.Equal(t, 0.9, req.TopP.Value)
 	})
 
-	t.Run("converts max_tokens", func(t *testing.T) {
+	t.Run("maps token limit to max_completion_tokens", func(t *testing.T) {
 		t.Parallel()
 
 		maxTokens := 100
@@ -128,6 +128,7 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
+		require.False(t, req.MaxTokens.Valid())
 		require.Equal(t, int64(100), req.MaxCompletionTokens.Value)
 	})
 
@@ -223,18 +224,43 @@ func TestConvertParams(t *testing.T) {
 		require.NotNil(t, req.ResponseFormat)
 	})
 
-	t.Run("converts reasoning_effort", func(t *testing.T) {
+	t.Run("preserves current reasoning_effort values", func(t *testing.T) {
+		t.Parallel()
+
+		efforts := []providers.ReasoningEffort{
+			providers.ReasoningEffortNone,
+			providers.ReasoningEffortMinimal,
+			providers.ReasoningEffortLow,
+			providers.ReasoningEffortMedium,
+			providers.ReasoningEffortHigh,
+			providers.ReasoningEffortXHigh,
+			providers.ReasoningEffortMax,
+		}
+		for _, effort := range efforts {
+			params := providers.CompletionParams{
+				Model:           "test-model",
+				Messages:        testutil.SimpleMessages(),
+				ReasoningEffort: effort,
+			}
+
+			req := convertParams(params)
+
+			require.Equal(t, string(effort), string(req.ReasoningEffort))
+		}
+	})
+
+	t.Run("omits automatic reasoning_effort sentinel", func(t *testing.T) {
 		t.Parallel()
 
 		params := providers.CompletionParams{
-			Model:           "o1-mini",
+			Model:           "test-model",
 			Messages:        testutil.SimpleMessages(),
-			ReasoningEffort: providers.ReasoningEffortHigh,
+			ReasoningEffort: providers.ReasoningEffortAuto,
 		}
 
 		req := convertParams(params)
 
-		require.NotNil(t, req.ReasoningEffort)
+		require.Empty(t, req.ReasoningEffort)
 	})
 
 	t.Run("converts seed", func(t *testing.T) {
@@ -487,10 +513,33 @@ func TestCompletionSendsMaxCompletionTokensOnWire(t *testing.T) {
 
 	body := capturedBody()
 
-	// OpenAI requires max_completion_tokens (not max_tokens) for current models.
 	require.Contains(t, body, "max_completion_tokens")
 	require.NotContains(t, body, "max_tokens")
 	require.Equal(t, float64(1024), body["max_completion_tokens"])
+}
+
+func TestCompletionPreservesReasoningEffortOnWire(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeCompletionServer(t)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	params := providers.CompletionParams{
+		Model:           "test-model",
+		Messages:        testutil.SimpleMessages(),
+		ReasoningEffort: providers.ReasoningEffortNone,
+	}
+
+	_, err = provider.Completion(context.Background(), params)
+	require.NoError(t, err)
+
+	body := capturedBody()
+	require.Equal(t, "none", body["reasoning_effort"])
 }
 
 func TestCompletionStreamSendsMaxCompletionTokensOnWire(t *testing.T) {
@@ -520,7 +569,6 @@ func TestCompletionStreamSendsMaxCompletionTokensOnWire(t *testing.T) {
 
 	body := capturedBody()
 
-	// OpenAI requires max_completion_tokens (not max_tokens) for current models.
 	require.Contains(t, body, "max_completion_tokens")
 	require.NotContains(t, body, "max_tokens")
 	require.Equal(t, float64(1024), body["max_completion_tokens"])

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/any-llm-go/config"
@@ -362,11 +362,16 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 1)
-		require.Equal(t, "get_weather", result[0].Function.Name)
-		require.Equal(t, "Get the current weather for a location.", result[0].Function.Description.Value)
+		require.NotNil(t, result[0].OfFunction)
+		require.Equal(t, "get_weather", result[0].OfFunction.Function.Name)
+		require.Equal(
+			t,
+			"Get the current weather for a location.",
+			result[0].OfFunction.Function.Description.Value,
+		)
 
 		// FunctionParameters is map[string]any - access directly.
-		params := result[0].Function.Parameters
+		params := result[0].OfFunction.Function.Parameters
 		require.Equal(t, "object", params["type"])
 
 		props, ok := params["properties"].(map[string]any)
@@ -391,10 +396,11 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 1)
-		require.Equal(t, "calculate", result[0].Function.Name)
+		require.NotNil(t, result[0].OfFunction)
+		require.Equal(t, "calculate", result[0].OfFunction.Function.Name)
 
 		// FunctionParameters is map[string]any - access directly.
-		params := result[0].Function.Parameters
+		params := result[0].OfFunction.Function.Parameters
 
 		props, ok := params["properties"].(map[string]any)
 		require.True(t, ok)
@@ -436,8 +442,10 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 2)
-		require.Equal(t, "get_weather", result[0].Function.Name)
-		require.Equal(t, "get_current_date", result[1].Function.Name)
+		require.NotNil(t, result[0].OfFunction)
+		require.NotNil(t, result[1].OfFunction)
+		require.Equal(t, "get_weather", result[0].OfFunction.Function.Name)
+		require.Equal(t, "get_current_date", result[1].OfFunction.Function.Name)
 	})
 }
 

--- a/providers/types.go
+++ b/providers/types.go
@@ -368,6 +368,8 @@ type ToolChoiceFunction struct {
 
 // Usage represents token usage information.
 type Usage struct {
+	// CachedTokens is the subset of PromptTokens served from an input cache.
+	CachedTokens     int `json:"cached_tokens,omitempty"`
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`

--- a/providers/types.go
+++ b/providers/types.go
@@ -16,11 +16,14 @@ const (
 
 // Reasoning effort levels for extended thinking.
 const (
-	ReasoningEffortAuto   ReasoningEffort = "auto"
-	ReasoningEffortHigh   ReasoningEffort = "high"
-	ReasoningEffortLow    ReasoningEffort = "low"
-	ReasoningEffortMedium ReasoningEffort = "medium"
-	ReasoningEffortNone   ReasoningEffort = "none"
+	ReasoningEffortAuto    ReasoningEffort = "auto"
+	ReasoningEffortHigh    ReasoningEffort = "high"
+	ReasoningEffortLow     ReasoningEffort = "low"
+	ReasoningEffortMax     ReasoningEffort = "max"
+	ReasoningEffortMedium  ReasoningEffort = "medium"
+	ReasoningEffortMinimal ReasoningEffort = "minimal"
+	ReasoningEffortNone    ReasoningEffort = "none"
+	ReasoningEffortXHigh   ReasoningEffort = "xhigh"
 )
 
 // Message roles.
@@ -95,7 +98,7 @@ type Capabilities struct {
 	CompletionImage     bool
 	CompletionPDF       bool
 	CompletionReasoning bool
-	CompletionStreaming  bool
+	CompletionStreaming bool
 	CompletionTools     bool
 	Embedding           bool
 	ListModels          bool

--- a/providers/types.go
+++ b/providers/types.go
@@ -274,6 +274,8 @@ type Function struct {
 	Name        string         `json:"name"`
 	Description string         `json:"description,omitempty"`
 	Parameters  map[string]any `json:"parameters,omitempty"`
+	// Strict requests schema-constrained function arguments when the provider supports it.
+	Strict *bool `json:"strict,omitempty"`
 }
 
 // FunctionCall represents the function being called.


### PR DESCRIPTION
## Summary

- preserve DeepSeek `usage.prompt_cache_hit_tokens` as normalized `Usage.CachedTokens`
- keep explicit all-zero usage objects distinct from absent or `null` usage
- reject malformed cache-hit counters in non-streaming responses and terminal SSE chunks

## Scope and dependency

This PR owns only DeepSeek Chat cache-usage normalization and its necessary regressions. It depends on #163 for the provider response and chunk transform boundary. Because the upstream repository cannot use a contributor-fork PR as a base, the GitHub full diff includes the declared #163, #150, and #141 dependency commits.

Owning range: `55e4402f41719ac529d3af97135850ede63fb4f3..0a53942367b0d2a457543bb22cd0d641488fa6fe`, 3 files, +157/-1. The two owning commits are +45 production lines and +112/-1 necessary tests.

No SDK dependency changes are required. DeepSeek's current official schema exposes cache hit and miss counts as provider extensions. OpenAI Go v3.43.0 through current v3.56.0 retain them only in `CompletionUsage.RawJSON()`, which this PR reads through the existing provider hook.

## Sources

- DeepSeek Chat Completion schema: https://api-docs.deepseek.com/api/create-chat-completion
- DeepSeek Context Caching: https://api-docs.deepseek.com/guides/kv_cache
- OpenAI Go v3.56.0 tag commit: `f5b985771236464300abc9395c1c4abda0d65c53`
- OpenAI Python v3.8.0 tag commit: `88391abf981df3ea395ca1b5bf55ec6a4011ea93`

`prompt_tokens` includes both cache hits and misses, so `PromptTokens - CachedTokens` gives misses without adding a duplicate public field. The fixtures were independently written from the official wire schema and do not copy upstream SDK tests.

## Verification

- `go test ./... -count=1`
- `CGO_ENABLED=1 go test -race ./providers/deepseek ./providers/openai ./providers/mistral -count=1`
- `go mod tidy -diff`
- `go mod verify`
- `golangci-lint run --new-from-rev=55e4402f41719ac529d3af97135850ede63fb4f3 ./providers/...`
- `git diff --check`
- temporary modfile override to OpenAI Go v3.56.0: `go test ./providers/deepseek -count=1`
- independent OpenAI Python v3.8.0 parse preserves both DeepSeek cache extension fields

Ablation removed the provider usage transform while retaining the public field and tests. Both response paths lost cache hits, explicit zero usage became nil, and malformed counters passed silently. An earlier whole-envelope parser was then deleted after `CompletionUsage.RawJSON()` proved sufficient.

Live DeepSeek verification is blocked by the absence of `DEEPSEEK_API_KEY`, so the provider-wide status remains incomplete.