### PR TITLE
feat(deepseek): support Vision image URLs

### DIFF
--- a/anyllm.go
+++ b/anyllm.go
@@ -53,11 +53,14 @@ const (
 
 // ReasoningEffort levels.
 const (
-	ReasoningEffortAuto   = providers.ReasoningEffortAuto
-	ReasoningEffortHigh   = providers.ReasoningEffortHigh
-	ReasoningEffortLow    = providers.ReasoningEffortLow
-	ReasoningEffortMedium = providers.ReasoningEffortMedium
-	ReasoningEffortNone   = providers.ReasoningEffortNone
+	ReasoningEffortAuto    = providers.ReasoningEffortAuto
+	ReasoningEffortHigh    = providers.ReasoningEffortHigh
+	ReasoningEffortLow     = providers.ReasoningEffortLow
+	ReasoningEffortMax     = providers.ReasoningEffortMax
+	ReasoningEffortMedium  = providers.ReasoningEffortMedium
+	ReasoningEffortMinimal = providers.ReasoningEffortMinimal
+	ReasoningEffortNone    = providers.ReasoningEffortNone
+	ReasoningEffortXHigh   = providers.ReasoningEffortXHigh
 )
 
 // Provider types.
@@ -179,17 +182,17 @@ var (
 
 // Error types.
 type (
-	AuthenticationError           = errors.AuthenticationError
-	BaseError                     = errors.BaseError
-	ContentFilterError            = errors.ContentFilterError
-	ContextLengthError            = errors.ContextLengthError
-	InsufficientFundsError        = errors.InsufficientFundsError
-	InvalidRequestError           = errors.InvalidRequestError
-	MissingAPIKeyError            = errors.MissingAPIKeyError
-	ModelNotFoundError            = errors.ModelNotFoundError
-	ProviderError                 = errors.ProviderError
-	RateLimitError                = errors.RateLimitError
-	UnsupportedOperationError     = errors.UnsupportedOperationError
-	UnsupportedParamError         = errors.UnsupportedParamError
-	UnsupportedProviderError      = errors.UnsupportedProviderError
+	AuthenticationError       = errors.AuthenticationError
+	BaseError                 = errors.BaseError
+	ContentFilterError        = errors.ContentFilterError
+	ContextLengthError        = errors.ContextLengthError
+	InsufficientFundsError    = errors.InsufficientFundsError
+	InvalidRequestError       = errors.InvalidRequestError
+	MissingAPIKeyError        = errors.MissingAPIKeyError
+	ModelNotFoundError        = errors.ModelNotFoundError
+	ProviderError             = errors.ProviderError
+	RateLimitError            = errors.RateLimitError
+	UnsupportedOperationError = errors.UnsupportedOperationError
+	UnsupportedParamError     = errors.UnsupportedParamError
+	UnsupportedProviderError  = errors.UnsupportedProviderError
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/mozilla-ai/any-llm-platform-client-go v0.0.1
 	github.com/ollama/ollama v0.32.5
-	github.com/openai/openai-go v1.12.0
+	github.com/openai/openai-go/v3 v3.42.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/genai v1.66.0
 )

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/mozilla-ai/any-llm-platform-client-go v0.0.1 h1:AXmEYxIEIESUt2LyB6GFD
 github.com/mozilla-ai/any-llm-platform-client-go v0.0.1/go.mod h1:bqmvllQOUir9G2bmglRQDEgsfHCF6jAC339JGWkzH4U=
 github.com/ollama/ollama v0.32.5 h1:5jeKnTJmDTR+xgB8qh68szdXM9zwnMBMtGl890frdzo=
 github.com/ollama/ollama v0.32.5/go.mod h1:b1ydCt2oVg0VAg22WWDgCbwW0AyOaRKAFzlS91NI4OY=
-github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
-github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
+github.com/openai/openai-go/v3 v3.42.0 h1:16Skv1hpEhSm3imZpPGSeEBDUgVJJA9cHryKGGsVYI8=
+github.com/openai/openai-go/v3 v3.42.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -23,7 +23,7 @@ var ProviderModelMap = map[string]string{
 	"llamafile":  "LLaMA_CPP",
 	"together":   "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
 	"perplexity": "llama-3.1-sonar-small-128k-online",
-	"deepseek":   "deepseek-chat",
+	"deepseek":   "deepseek-v4-flash",
 	"fireworks":  "accounts/fireworks/models/llama-v3p1-8b-instruct",
 	"xai":        "grok-beta",
 	"cerebras":   "llama3.1-8b",
@@ -38,7 +38,7 @@ var ProviderReasoningModelMap = map[string]string{
 	"anthropic": "claude-sonnet-4-20250514",
 	"gemini":    "gemini-3-flash-preview",
 	"mistral":   "magistral-small-latest",
-	"deepseek":  "deepseek-reasoner",
+	"deepseek":  "deepseek-v4-pro",
 	"ollama":    "deepseek-r1",
 	"zai":       "glm-4.7-flash",
 }

--- a/providers/deepseek/chat.go
+++ b/providers/deepseek/chat.go
@@ -1,0 +1,95 @@
+package deepseek
+
+import (
+	"fmt"
+
+	oaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/shared"
+
+	"github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+type deepSeekThinking struct {
+	Type string `json:"type"`
+}
+
+// transformRequest maps normalized controls to DeepSeek's current Chat schema.
+// https://api-docs.deepseek.com/api/create-chat-completion
+func transformRequest(
+	params providers.CompletionParams,
+	req *oaisdk.ChatCompletionNewParams,
+) error {
+	if params.ParallelToolCalls != nil {
+		return errors.NewUnsupportedParamError(providerName, "parallel_tool_calls")
+	}
+	if params.Seed != nil {
+		return errors.NewUnsupportedParamError(providerName, "seed")
+	}
+
+	if req.MaxCompletionTokens.Valid() {
+		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
+	}
+	// DeepSeek documents max_tokens rather than OpenAI's active max_completion_tokens.
+	req.MaxCompletionTokens = param.Opt[int64]{}
+
+	thinking, effort, err := mapReasoningEffort(params.ReasoningEffort)
+	if err != nil {
+		return err
+	}
+
+	// DeepSeek names this field user_id and does not document OpenAI's user.
+	req.User = param.Opt[string]{}
+	req.ReasoningEffort = shared.ReasoningEffort(effort)
+
+	extraFields := make(map[string]any, 2)
+	if params.User != "" {
+		extraFields["user_id"] = params.User
+	}
+	if thinking != "" {
+		extraFields["thinking"] = deepSeekThinking{Type: thinking}
+	}
+	if len(extraFields) > 0 {
+		// openai-go models neither DeepSeek extension; SetExtraFields is the
+		// official SDK's typed request extension boundary.
+		req.SetExtraFields(extraFields)
+	}
+
+	if len(params.Tools) == 0 {
+		return nil
+	}
+	for i, message := range params.Messages {
+		if message.Role != providers.RoleAssistant || message.Reasoning == nil {
+			continue
+		}
+
+		// DeepSeek requires every prior assistant reasoning_content when the
+		// request carries tools, including turns that did not call a tool.
+		req.Messages[i].OfAssistant.SetExtraFields(map[string]any{
+			"reasoning_content": message.Reasoning.Content,
+		})
+	}
+
+	return nil
+}
+
+func mapReasoningEffort(effort providers.ReasoningEffort) (thinking string, mapped string, err error) {
+	switch effort {
+	case "", providers.ReasoningEffortAuto:
+		return "", "", nil
+	case providers.ReasoningEffortNone:
+		return "disabled", "", nil
+	case providers.ReasoningEffortLow:
+		return "enabled", "low", nil
+	case providers.ReasoningEffortMedium, providers.ReasoningEffortHigh, providers.ReasoningEffortXHigh:
+		return "enabled", "high", nil
+	case providers.ReasoningEffortMax:
+		return "enabled", "max", nil
+	default:
+		return "", "", errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("unsupported reasoning_effort %q", effort),
+		)
+	}
+}

--- a/providers/deepseek/chat.go
+++ b/providers/deepseek/chat.go
@@ -27,6 +27,9 @@ func transformRequest(
 	if params.Seed != nil {
 		return errors.NewUnsupportedParamError(providerName, "seed")
 	}
+	if err := transformVisionMessages(params.Messages, req.Messages); err != nil {
+		return err
+	}
 
 	if req.MaxCompletionTokens.Valid() {
 		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
@@ -72,6 +75,57 @@ func transformRequest(
 	}
 
 	return nil
+}
+
+// transformVisionMessages validates DeepSeek's user-only image contract and
+// restores detail values omitted by the generic compatible converter.
+// https://api-docs.deepseek.com/guides/vision
+func transformVisionMessages(
+	messages []providers.Message,
+	reqMessages []oaisdk.ChatCompletionMessageParamUnion,
+) error {
+	for i, message := range messages {
+		if !message.IsMultiModal() {
+			continue
+		}
+		if message.Role != providers.RoleUser {
+			return errors.NewInvalidRequestError(
+				providerName,
+				fmt.Errorf("messages[%d] content parts are only supported for the user role", i),
+			)
+		}
+
+		for j, part := range message.ContentParts() {
+			switch part.Type {
+			case "text":
+				if part.ImageURL != nil {
+					return invalidVisionPart(i, j, "text content cannot include image_url")
+				}
+			case "image_url":
+				if part.ImageURL == nil || part.ImageURL.URL == "" || part.Text != "" {
+					return invalidVisionPart(i, j, "image_url content requires only a non-empty URL")
+				}
+				switch part.ImageURL.Detail {
+				case "", "auto", "low", "high", "original":
+				default:
+					return invalidVisionPart(i, j, fmt.Sprintf("unsupported image detail %q", part.ImageURL.Detail))
+				}
+				reqMessages[i].OfUser.Content.OfArrayOfContentParts[j].OfImageURL.ImageURL.Detail =
+					part.ImageURL.Detail
+			default:
+				return invalidVisionPart(i, j, fmt.Sprintf("unsupported content type %q", part.Type))
+			}
+		}
+	}
+
+	return nil
+}
+
+func invalidVisionPart(messageIndex, partIndex int, reason string) error {
+	return errors.NewInvalidRequestError(
+		providerName,
+		fmt.Errorf("messages[%d].content[%d]: %s", messageIndex, partIndex, reason),
+	)
 }
 
 func mapReasoningEffort(effort providers.ReasoningEffort) (thinking string, mapped string, err error) {

--- a/providers/deepseek/chat_request_test.go
+++ b/providers/deepseek/chat_request_test.go
@@ -185,6 +185,108 @@ func TestCompletionStreamMapsCurrentThinkingRequest(t *testing.T) {
 	require.NotContains(t, body, "user")
 }
 
+func TestCompletionPreservesCurrentVisionImageWire(t *testing.T) {
+	t.Parallel()
+
+	serverURL, requestBody := deepSeekCompletionServer(t, `{
+		"id":"chatcmpl-test","object":"chat.completion","created":1700000000,
+		"model":"deepseek-v4-flash-vision-exp","choices":[{"index":0,
+		"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}]
+	}`)
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.Completion(t.Context(), providers.CompletionParams{
+		Model: "deepseek-v4-flash-vision-exp",
+		Messages: []providers.Message{{
+			Role: providers.RoleUser,
+			Content: []providers.ContentPart{
+				{Type: "text", Text: "Compare these images."},
+				{
+					Type: "image_url",
+					ImageURL: &providers.ImageURL{
+						URL:    "https://example.com/chart.png",
+						Detail: "low",
+					},
+				},
+				{
+					Type: "image_url",
+					ImageURL: &providers.ImageURL{
+						URL:    "data:image/png;base64,iVBORw0KGgo=",
+						Detail: "original",
+					},
+				},
+				{
+					Type: "image_url",
+					ImageURL: &providers.ImageURL{
+						URL:    "https://example.com/screenshot.png",
+						Detail: "high",
+					},
+				},
+				{
+					Type: "image_url",
+					ImageURL: &providers.ImageURL{
+						URL:    "https://example.com/photo.webp",
+						Detail: "auto",
+					},
+				},
+				{
+					Type: "image_url",
+					ImageURL: &providers.ImageURL{
+						URL: "https://example.com/default.gif",
+					},
+				},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	messages, ok := (<-requestBody)["messages"].([]any)
+	require.True(t, ok)
+	message, ok := messages[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, []any{
+		map[string]any{"type": "text", "text": "Compare these images."},
+		map[string]any{
+			"type": "image_url",
+			"image_url": map[string]any{
+				"url":    "https://example.com/chart.png",
+				"detail": "low",
+			},
+		},
+		map[string]any{
+			"type": "image_url",
+			"image_url": map[string]any{
+				"url":    "data:image/png;base64,iVBORw0KGgo=",
+				"detail": "original",
+			},
+		},
+		map[string]any{
+			"type": "image_url",
+			"image_url": map[string]any{
+				"url":    "https://example.com/screenshot.png",
+				"detail": "high",
+			},
+		},
+		map[string]any{
+			"type": "image_url",
+			"image_url": map[string]any{
+				"url":    "https://example.com/photo.webp",
+				"detail": "auto",
+			},
+		},
+		map[string]any{
+			"type": "image_url",
+			"image_url": map[string]any{
+				"url": "https://example.com/default.gif",
+			},
+		},
+	}, message["content"])
+}
+
 func TestCompletionRejectsUnsupportedParamsBeforeTransport(t *testing.T) {
 	t.Parallel()
 
@@ -210,6 +312,74 @@ func TestCompletionRejectsUnsupportedParamsBeforeTransport(t *testing.T) {
 			params: providers.CompletionParams{Seed: new(7)},
 			want:   llmerrors.ErrUnsupportedParam,
 		},
+		{
+			name: "image in system message",
+			params: providers.CompletionParams{Messages: []providers.Message{{
+				Role: providers.RoleSystem,
+				Content: []providers.ContentPart{{
+					Type:     "image_url",
+					ImageURL: &providers.ImageURL{URL: "https://example.com/chart.png"},
+				}},
+			}}},
+			want: llmerrors.ErrInvalidRequest,
+		},
+		{
+			name: "missing image URL",
+			params: providers.CompletionParams{Messages: []providers.Message{{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{{
+					Type:     "image_url",
+					ImageURL: &providers.ImageURL{},
+				}},
+			}}},
+			want: llmerrors.ErrInvalidRequest,
+		},
+		{
+			name: "text part with image URL",
+			params: providers.CompletionParams{Messages: []providers.Message{{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{{
+					Type:     "text",
+					Text:     "Describe this.",
+					ImageURL: &providers.ImageURL{URL: "https://example.com/chart.png"},
+				}},
+			}}},
+			want: llmerrors.ErrInvalidRequest,
+		},
+		{
+			name: "image part with text",
+			params: providers.CompletionParams{Messages: []providers.Message{{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{{
+					Type:     "image_url",
+					Text:     "Describe this.",
+					ImageURL: &providers.ImageURL{URL: "https://example.com/chart.png"},
+				}},
+			}}},
+			want: llmerrors.ErrInvalidRequest,
+		},
+		{
+			name: "unsupported image detail",
+			params: providers.CompletionParams{Messages: []providers.Message{{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{{
+					Type: "image_url",
+					ImageURL: &providers.ImageURL{
+						URL:    "https://example.com/chart.png",
+						Detail: "medium",
+					},
+				}},
+			}}},
+			want: llmerrors.ErrInvalidRequest,
+		},
+		{
+			name: "unsupported content part",
+			params: providers.CompletionParams{Messages: []providers.Message{{
+				Role:    providers.RoleUser,
+				Content: []providers.ContentPart{{Type: "file"}},
+			}}},
+			want: llmerrors.ErrInvalidRequest,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -227,7 +397,9 @@ func TestCompletionRejectsUnsupportedParamsBeforeTransport(t *testing.T) {
 			require.NoError(t, err)
 
 			test.params.Model = "deepseek-v4-pro"
-			test.params.Messages = testutil.SimpleMessages()
+			if len(test.params.Messages) == 0 {
+				test.params.Messages = testutil.SimpleMessages()
+			}
 			_, err = provider.Completion(t.Context(), test.params)
 			require.ErrorIs(t, err, test.want)
 

--- a/providers/deepseek/chat_request_test.go
+++ b/providers/deepseek/chat_request_test.go
@@ -1,0 +1,156 @@
+package deepseek
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+func deepSeekCompletionServer(
+	t *testing.T,
+	response string,
+) (serverURL string, requestBody <-chan map[string]any) {
+	t.Helper()
+
+	captured := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding DeepSeek request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		captured <- body
+
+		w.Header().Set("Content-Type", "application/json")
+		// DeepSeek can send blank keep-alive lines before a non-streaming body.
+		_, err := fmt.Fprint(w, "\n\n", response)
+		if err != nil {
+			t.Errorf("writing DeepSeek response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	return server.URL, captured
+}
+
+func TestCompletionMapsCurrentThinkingRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		effort       providers.ReasoningEffort
+		wantThinking string
+		wantEffort   string
+	}{
+		{name: "provider default", effort: providers.ReasoningEffortAuto},
+		{name: "disabled", effort: providers.ReasoningEffortNone, wantThinking: "disabled"},
+		{name: "low", effort: providers.ReasoningEffortLow, wantThinking: "enabled", wantEffort: "low"},
+		{
+			name:         "medium maps high",
+			effort:       providers.ReasoningEffortMedium,
+			wantThinking: "enabled",
+			wantEffort:   "high",
+		},
+		{name: "high", effort: providers.ReasoningEffortHigh, wantThinking: "enabled", wantEffort: "high"},
+		{name: "xhigh maps high", effort: providers.ReasoningEffortXHigh, wantThinking: "enabled", wantEffort: "high"},
+		{name: "max", effort: providers.ReasoningEffortMax, wantThinking: "enabled", wantEffort: "max"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			serverURL, requestBody := deepSeekCompletionServer(t, `{
+				"id":"chatcmpl-test","object":"chat.completion","created":1700000000,
+				"model":"deepseek-v4-pro","choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}]
+			}`)
+			provider, err := New(
+				config.WithAPIKey("test-key"),
+				config.WithBaseURL(serverURL),
+			)
+			require.NoError(t, err)
+
+			_, err = provider.Completion(t.Context(), providers.CompletionParams{
+				Model: "deepseek-v4-pro",
+				Messages: []providers.Message{
+					{Role: providers.RoleUser, Content: "first"},
+					{
+						Role:      providers.RoleAssistant,
+						Content:   "answer",
+						Reasoning: &providers.Reasoning{Content: "reasoning"},
+					},
+					{Role: providers.RoleUser, Content: "next"},
+				},
+				ReasoningEffort: test.effort,
+				Tools: []providers.Tool{{
+					Type: "function",
+					Function: providers.Function{
+						Name:       "lookup",
+						Parameters: map[string]any{"type": "object"},
+					},
+				}},
+				User: "account_42",
+			})
+			require.NoError(t, err)
+
+			body := <-requestBody
+			require.Equal(t, "account_42", body["user_id"])
+			require.NotContains(t, body, "user")
+			require.NotContains(t, body, "parallel_tool_calls")
+			require.NotContains(t, body, "seed")
+			if test.wantThinking == "" {
+				require.NotContains(t, body, "thinking")
+			} else {
+				require.Equal(t, map[string]any{"type": test.wantThinking}, body["thinking"])
+			}
+			if test.wantEffort == "" {
+				require.NotContains(t, body, "reasoning_effort")
+			} else {
+				require.Equal(t, test.wantEffort, body["reasoning_effort"])
+			}
+
+			messages, ok := body["messages"].([]any)
+			require.True(t, ok)
+			assistant, ok := messages[1].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, "reasoning", assistant["reasoning_content"])
+		})
+	}
+}
+
+func TestCompletionOmitsReasoningReplayWithoutTools(t *testing.T) {
+	t.Parallel()
+
+	serverURL, requestBody := deepSeekCompletionServer(t, `{
+		"id":"chatcmpl-test","object":"chat.completion","created":1700000000,
+		"model":"deepseek-v4-pro","choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}]
+	}`)
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	_, err = provider.Completion(t.Context(), providers.CompletionParams{
+		Model: "deepseek-v4-pro",
+		Messages: []providers.Message{{
+			Role:      providers.RoleAssistant,
+			Content:   "answer",
+			Reasoning: &providers.Reasoning{Content: "ignored reasoning"},
+		}},
+	})
+	require.NoError(t, err)
+
+	messages, ok := (<-requestBody)["messages"].([]any)
+	require.True(t, ok)
+	assistant, ok := messages[0].(map[string]any)
+	require.True(t, ok)
+	require.NotContains(t, assistant, "reasoning_content")
+}

--- a/providers/deepseek/chat_request_test.go
+++ b/providers/deepseek/chat_request_test.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/any-llm-go/config"
+	llmerrors "github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/internal/testutil"
 	"github.com/mozilla-ai/any-llm-go/providers"
 )
 
@@ -153,4 +156,86 @@ func TestCompletionOmitsReasoningReplayWithoutTools(t *testing.T) {
 	assistant, ok := messages[0].(map[string]any)
 	require.True(t, ok)
 	require.NotContains(t, assistant, "reasoning_content")
+}
+
+func TestCompletionStreamMapsCurrentThinkingRequest(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeStreamingServer(t)
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	chunks, errs := provider.CompletionStream(t.Context(), providers.CompletionParams{
+		Model:           "deepseek-v4-flash",
+		Messages:        testutil.SimpleMessages(),
+		ReasoningEffort: providers.ReasoningEffortMax,
+		User:            "account_42",
+	})
+	for range chunks {
+	}
+	require.NoError(t, <-errs)
+
+	body := capturedBody()
+	require.Equal(t, map[string]any{"type": "enabled"}, body["thinking"])
+	require.Equal(t, "max", body["reasoning_effort"])
+	require.Equal(t, "account_42", body["user_id"])
+	require.NotContains(t, body, "user")
+}
+
+func TestCompletionRejectsUnsupportedParamsBeforeTransport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params providers.CompletionParams
+		want   error
+	}{
+		{
+			name: "unknown reasoning effort",
+			params: providers.CompletionParams{
+				ReasoningEffort: providers.ReasoningEffort("unsupported"),
+			},
+			want: llmerrors.ErrInvalidRequest,
+		},
+		{
+			name:   "parallel tool calls",
+			params: providers.CompletionParams{ParallelToolCalls: new(false)},
+			want:   llmerrors.ErrUnsupportedParam,
+		},
+		{
+			name:   "seed",
+			params: providers.CompletionParams{Seed: new(7)},
+			want:   llmerrors.ErrUnsupportedParam,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var requests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				requests.Add(1)
+			}))
+			t.Cleanup(server.Close)
+			provider, err := New(
+				config.WithAPIKey("test-key"),
+				config.WithBaseURL(server.URL),
+			)
+			require.NoError(t, err)
+
+			test.params.Model = "deepseek-v4-pro"
+			test.params.Messages = testutil.SimpleMessages()
+			_, err = provider.Completion(t.Context(), test.params)
+			require.ErrorIs(t, err, test.want)
+
+			chunks, errs := provider.CompletionStream(t.Context(), test.params)
+			for range chunks {
+			}
+			require.ErrorIs(t, <-errs, test.want)
+			require.Zero(t, requests.Load())
+		})
+	}
 }

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -89,8 +89,10 @@ func (p *Provider) CompletionStream(
 // capabilities returns the capabilities for the DeepSeek provider.
 func capabilities() providers.Capabilities {
 	return providers.Capabilities{
-		Completion:          true,
-		CompletionImage:     false, // DeepSeek doesn't support images.
+		Completion: true,
+		// Vision Exp accepts external and inline data URLs.
+		// https://api-docs.deepseek.com/guides/vision
+		CompletionImage:     true,
 		CompletionPDF:       false,
 		CompletionReasoning: true, // DeepSeek V4 supports reasoning.
 		CompletionStreaming: true,

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -8,9 +8,6 @@ import (
 	"fmt"
 	"slices"
 
-	oaisdk "github.com/openai/openai-go/v3"
-	"github.com/openai/openai-go/v3/packages/param"
-
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
 	"github.com/mozilla-ai/any-llm-go/providers/openai"
@@ -95,7 +92,7 @@ func capabilities() providers.Capabilities {
 		Completion:          true,
 		CompletionImage:     false, // DeepSeek doesn't support images.
 		CompletionPDF:       false,
-		CompletionReasoning: true, // DeepSeek R1 supports reasoning.
+		CompletionReasoning: true, // DeepSeek V4 supports reasoning.
 		CompletionStreaming: true,
 		CompletionTools:     true,
 		Embedding:           false, // DeepSeek doesn't host embedding models.
@@ -158,15 +155,6 @@ func preprocessParams(params providers.CompletionParams) providers.CompletionPar
 		User:            params.User,
 		Extra:           params.Extra,
 	}
-}
-
-// transformRequest maps the shared token limit to DeepSeek's max_tokens field.
-// https://api-docs.deepseek.com/api/create-chat-completion
-func transformRequest(req *oaisdk.ChatCompletionNewParams) {
-	if req.MaxCompletionTokens.Valid() {
-		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
-	}
-	req.MaxCompletionTokens = param.Opt[int64]{}
 }
 
 // preprocessMessagesForJSONSchema injects the JSON schema into the last user message.

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"slices"
 
-	oaisdk "github.com/openai/openai-go"
-	"github.com/openai/openai-go/packages/param"
+	oaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
@@ -160,17 +160,12 @@ func preprocessParams(params providers.CompletionParams) providers.CompletionPar
 	}
 }
 
-// transformRequest adjusts the OpenAI SDK request for DeepSeek's API.
-// DeepSeek uses max_tokens, not max_completion_tokens.
-// If both are set, MaxCompletionTokens takes precedence over MaxTokens.
-// See: https://api-docs.deepseek.com/api/create-chat-completion
+// transformRequest maps the shared token limit to DeepSeek's max_tokens field.
+// https://api-docs.deepseek.com/api/create-chat-completion
 func transformRequest(req *oaisdk.ChatCompletionNewParams) {
 	if req.MaxCompletionTokens.Valid() {
-		// Set max_tokens using max_completion_tokens value.
 		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
 	}
-
-	// Clear unsupported fields from the request.
 	req.MaxCompletionTokens = param.Opt[int64]{}
 }
 

--- a/providers/deepseek/deepseek_test.go
+++ b/providers/deepseek/deepseek_test.go
@@ -60,7 +60,7 @@ func TestCapabilities(t *testing.T) {
 	caps := provider.Capabilities()
 
 	require.True(t, caps.Completion)
-	require.False(t, caps.CompletionImage)
+	require.True(t, caps.CompletionImage)
 	require.False(t, caps.CompletionPDF)
 	require.True(t, caps.CompletionReasoning)
 	require.True(t, caps.CompletionStreaming)

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/v3"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/errors"
@@ -373,7 +373,7 @@ func capabilities() providers.Capabilities {
 		CompletionImage:     true,
 		CompletionPDF:       true,
 		CompletionReasoning: true,
-		CompletionStreaming:  true,
+		CompletionStreaming: true,
 		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
@@ -703,7 +703,9 @@ func (p *Provider) handleRerankErrorResponse(resp *http.Response) error {
 	case http.StatusTooManyRequests:
 		return errors.NewRateLimitError(providerName, fmt.Errorf("%s", msg))
 	case http.StatusBadGateway:
-		return &UpstreamProviderError{BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider)}
+		return &UpstreamProviderError{
+			BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider),
+		}
 	case http.StatusGatewayTimeout:
 		return &TimeoutError{BaseError: errors.New(errCodeTimeout, providerName, fmt.Errorf("%s", msg), ErrTimeout)}
 	default:

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -144,11 +144,12 @@ func patchMessageParams(params providers.CompletionParams) providers.CompletionP
 // transformRequest maps the shared token limit to Mistral's max_tokens field
 // and removes fields outside its Chat request schema.
 // https://docs.mistral.ai/api?property=operation-chat_completion_v1_chat_completions_post_request_max_tokens
-func transformRequest(req *oaisdk.ChatCompletionNewParams) {
+func transformRequest(_ providers.CompletionParams, req *oaisdk.ChatCompletionNewParams) error {
 	if req.MaxCompletionTokens.Valid() {
 		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
 	}
 	req.MaxCompletionTokens = param.Opt[int64]{}
 	req.User = param.Opt[string]{}
 	req.ReasoningEffort = ""
+	return nil
 }

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"slices"
 
-	oaisdk "github.com/openai/openai-go"
-	"github.com/openai/openai-go/packages/param"
+	oaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
@@ -141,17 +141,13 @@ func patchMessageParams(params providers.CompletionParams) providers.CompletionP
 	return params
 }
 
-// transformRequest adjusts the OpenAI SDK request for Mistral's API.
-// Mistral uses max_tokens (not max_completion_tokens) and does not accept user or reasoning_effort fields.
-// If both are set, MaxCompletionTokens takes precedence over MaxTokens.
-// See: https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post
+// transformRequest maps the shared token limit to Mistral's max_tokens field
+// and removes fields outside its Chat request schema.
+// https://docs.mistral.ai/api?property=operation-chat_completion_v1_chat_completions_post_request_max_tokens
 func transformRequest(req *oaisdk.ChatCompletionNewParams) {
 	if req.MaxCompletionTokens.Valid() {
-		// Set max_tokens using max_completion_tokens value.
 		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
 	}
-
-	// Clear unsupported fields from the request.
 	req.MaxCompletionTokens = param.Opt[int64]{}
 	req.User = param.Opt[string]{}
 	req.ReasoningEffort = ""

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -7,9 +7,9 @@ import (
 	stderrors "errors"
 	"fmt"
 
-	"github.com/openai/openai-go"
-	"github.com/openai/openai-go/option"
-	"github.com/openai/openai-go/shared"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/shared"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/errors"
@@ -328,13 +328,15 @@ func convertAPIError(name string, apiErr *openai.Error, originalErr error) error
 // convertAssistantMessage converts an assistant message to OpenAI format.
 func convertAssistantMessage(msg providers.Message) openai.ChatCompletionMessageParamUnion {
 	if len(msg.ToolCalls) > 0 {
-		toolCalls := make([]openai.ChatCompletionMessageToolCallParam, 0, len(msg.ToolCalls))
+		toolCalls := make([]openai.ChatCompletionMessageToolCallUnionParam, 0, len(msg.ToolCalls))
 		for _, tc := range msg.ToolCalls {
-			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallParam{
-				ID: tc.ID,
-				Function: openai.ChatCompletionMessageToolCallFunctionParam{
-					Name:      tc.Function.Name,
-					Arguments: tc.Function.Arguments,
+			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnionParam{
+				OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
+					ID: tc.ID,
+					Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
+						Name:      tc.Function.Name,
+						Arguments: tc.Function.Arguments,
+					},
 				},
 			})
 		}
@@ -380,13 +382,16 @@ func convertChunk(chunk *openai.ChatCompletionChunk) providers.ChatCompletionChu
 		choices = append(choices, chunkChoice)
 	}
 
+	// Preserve the existing normalized field even though the v3 SDK marks the
+	// documented response field as deprecated.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	result := providers.ChatCompletionChunk{
 		ID:                chunk.ID,
 		Object:            objectChatCompletionChunk,
 		Created:           chunk.Created,
 		Model:             chunk.Model,
 		Choices:           choices,
-		SystemFingerprint: chunk.SystemFingerprint,
+		SystemFingerprint: chunk.SystemFingerprint, //nolint:staticcheck
 	}
 
 	if chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0 {
@@ -570,13 +575,16 @@ func convertResponse(resp *openai.ChatCompletion) *providers.ChatCompletion {
 		})
 	}
 
+	// Preserve the existing normalized field even though the v3 SDK marks the
+	// documented response field as deprecated.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	result := &providers.ChatCompletion{
 		ID:                resp.ID,
 		Object:            objectChatCompletion,
 		Created:           resp.Created,
 		Model:             resp.Model,
 		Choices:           choices,
-		SystemFingerprint: resp.SystemFingerprint,
+		SystemFingerprint: resp.SystemFingerprint, //nolint:staticcheck
 	}
 
 	if resp.Usage.PromptTokens > 0 || resp.Usage.CompletionTokens > 0 {
@@ -658,7 +666,7 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 		}
 	case providers.ToolChoice:
 		if v.Function != nil {
-			return openai.ChatCompletionToolChoiceOptionParamOfChatCompletionNamedToolChoice(
+			return openai.ToolChoiceOptionFunctionToolChoice(
 				openai.ChatCompletionNamedToolChoiceFunctionParam{
 					Name: v.Function.Name,
 				},
@@ -671,14 +679,16 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 }
 
 // convertTools converts provider tools to OpenAI format.
-func convertTools(tools []providers.Tool) []openai.ChatCompletionToolParam {
-	result := make([]openai.ChatCompletionToolParam, 0, len(tools))
+func convertTools(tools []providers.Tool) []openai.ChatCompletionToolUnionParam {
+	result := make([]openai.ChatCompletionToolUnionParam, 0, len(tools))
 	for _, tool := range tools {
-		result = append(result, openai.ChatCompletionToolParam{
-			Function: openai.FunctionDefinitionParam{
-				Name:        tool.Function.Name,
-				Description: openai.String(tool.Function.Description),
-				Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+		result = append(result, openai.ChatCompletionToolUnionParam{
+			OfFunction: &openai.ChatCompletionFunctionToolParam{
+				Function: openai.FunctionDefinitionParam{
+					Name:        tool.Function.Name,
+					Description: openai.String(tool.Function.Description),
+					Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+				},
 			},
 		})
 	}

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -689,13 +689,17 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 func convertTools(tools []providers.Tool) []openai.ChatCompletionToolUnionParam {
 	result := make([]openai.ChatCompletionToolUnionParam, 0, len(tools))
 	for _, tool := range tools {
+		function := openai.FunctionDefinitionParam{
+			Name:        tool.Function.Name,
+			Description: openai.String(tool.Function.Description),
+			Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+		}
+		if tool.Function.Strict != nil {
+			function.Strict = openai.Bool(*tool.Function.Strict)
+		}
 		result = append(result, openai.ChatCompletionToolUnionParam{
 			OfFunction: &openai.ChatCompletionFunctionToolParam{
-				Function: openai.FunctionDefinitionParam{
-					Name:        tool.Function.Name,
-					Description: openai.String(tool.Function.Description),
-					Parameters:  openai.FunctionParameters(tool.Function.Parameters),
-				},
+				Function: function,
 			},
 		})
 	}

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -517,6 +517,10 @@ func convertParams(params providers.CompletionParams) openai.ChatCompletionNewPa
 		req.TopP = openai.Float(*params.TopP)
 	}
 
+	// OpenAI documents max_completion_tokens as the replacement for the
+	// deprecated max_tokens field. Keep the binding's existing MaxTokens
+	// abstraction on the current wire field.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	if params.MaxTokens != nil {
 		req.MaxCompletionTokens = openai.Int(int64(*params.MaxTokens))
 	}
@@ -551,7 +555,10 @@ func convertParams(params providers.CompletionParams) openai.ChatCompletionNewPa
 		req.User = openai.String(params.User)
 	}
 
-	if params.ReasoningEffort != "" && params.ReasoningEffort != providers.ReasoningEffortNone {
+	// auto is the binding's omission sentinel. OpenAI documents none as an
+	// explicit value, so it must reach the wire unchanged.
+	// https://developers.openai.com/api/docs/guides/latest-model
+	if params.ReasoningEffort != "" && params.ReasoningEffort != providers.ReasoningEffortAuto {
 		req.ReasoningEffort = shared.ReasoningEffort(params.ReasoningEffort)
 	}
 

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -59,6 +59,12 @@ type CompatibleConfig struct {
 	// Capabilities describes what the provider supports.
 	Capabilities providers.Capabilities
 
+	// ChatCompletionRequestTransform is an optional function that modifies the chat
+	// completion request after convertParams() builds it and before it is serialized
+	// to the wire. The pointer refers to a locally-constructed value owned by the
+	// caller; the function must not retain it beyond the call.
+	ChatCompletionRequestTransform func(providers.CompletionParams, *openai.ChatCompletionNewParams) error
+
 	// DefaultAPIKey is used when RequireAPIKey is false (e.g., for local servers).
 	DefaultAPIKey string
 
@@ -67,14 +73,6 @@ type CompatibleConfig struct {
 
 	// Name is the provider name used in error messages.
 	Name string
-
-	// ChatCompletionRequestTransform is an optional function that modifies the chat
-	// completion request after convertParams() builds it and before it is serialized
-	// to the wire. Providers that are not fully OpenAI-compatible use this to adjust
-	// wire-level fields (e.g. swapping max_completion_tokens back to max_tokens).
-	// The pointer refers to a locally-constructed value owned by the caller; the
-	// function must not retain it beyond the call. Nil means no transformation.
-	ChatCompletionRequestTransform func(*openai.ChatCompletionNewParams)
 
 	// RequireAPIKey indicates whether an API key is required.
 	RequireAPIKey bool
@@ -172,8 +170,10 @@ func (p *CompatibleProvider) Completion(
 	}
 
 	req := convertParams(params)
-	if p.compatibleConfig.ChatCompletionRequestTransform != nil {
-		p.compatibleConfig.ChatCompletionRequestTransform(&req)
+	if transform := p.compatibleConfig.ChatCompletionRequestTransform; transform != nil {
+		if err := transform(params, &req); err != nil {
+			return nil, err
+		}
 	}
 
 	resp, err := p.client.Chat.Completions.New(ctx, req)
@@ -202,8 +202,11 @@ func (p *CompatibleProvider) CompletionStream(
 		}
 
 		req := convertParams(params)
-		if p.compatibleConfig.ChatCompletionRequestTransform != nil {
-			p.compatibleConfig.ChatCompletionRequestTransform(&req)
+		if transform := p.compatibleConfig.ChatCompletionRequestTransform; transform != nil {
+			if err := transform(params, &req); err != nil {
+				errs <- err
+				return
+			}
 		}
 		stream := p.client.Chat.Completions.NewStreaming(ctx, req)
 

--- a/providers/openai/compatible_test.go
+++ b/providers/openai/compatible_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -313,6 +314,42 @@ func TestConvertResponseFormat(t *testing.T) {
 		result := convertResponseFormat(format)
 		require.NotNil(t, result.OfText)
 	})
+}
+
+func TestConvertToolsPreservesStrict(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		strict *bool
+	}{
+		{name: "omitted"},
+		{name: "false", strict: new(false)},
+		{name: "true", strict: new(true)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tools := convertTools([]providers.Tool{{
+				Type: "function",
+				Function: providers.Function{
+					Name:       "lookup",
+					Parameters: map[string]any{"type": "object"},
+					Strict:     tc.strict,
+				},
+			}})
+			body, err := json.Marshal(tools)
+			require.NoError(t, err)
+
+			var wire []struct {
+				Function struct {
+					Strict *bool `json:"strict"`
+				} `json:"function"`
+			}
+			require.NoError(t, json.Unmarshal(body, &wire))
+			require.Equal(t, tc.strict, wire[0].Function.Strict)
+		})
+	}
 }
 
 func TestConvertEmbeddingParams(t *testing.T) {

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -9,6 +9,7 @@ import (
 const (
 	defaultBaseURL = "https://api.openai.com/v1"
 	envAPIKey      = "OPENAI_API_KEY"
+	envBaseURL     = "OPENAI_BASE_URL"
 	providerName   = "openai"
 )
 
@@ -31,6 +32,7 @@ type Provider struct {
 func New(opts ...config.Option) (*Provider, error) {
 	base, err := NewCompatible(CompatibleConfig{
 		APIKeyEnvVar:   envAPIKey,
+		BaseURLEnvVar:  envBaseURL,
 		Capabilities:   capabilities(),
 		DefaultBaseURL: defaultBaseURL,
 		Name:           providerName,

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -34,6 +34,21 @@ func TestNew(t *testing.T) {
 		require.NotNil(t, provider)
 	})
 
+	t.Run("reads OPENAI_BASE_URL", func(t *testing.T) {
+		serverURL, _ := testutil.FakeCompletionServer(t)
+		t.Setenv("OPENAI_API_KEY", "env-api-key")
+		t.Setenv("OPENAI_BASE_URL", serverURL)
+
+		provider, err := New()
+		require.NoError(t, err)
+
+		_, err = provider.Completion(t.Context(), providers.CompletionParams{
+			Model:    "test-model",
+			Messages: testutil.SimpleMessages(),
+		})
+		require.NoError(t, err)
+	})
+
 	t.Run("returns error when API key is missing", func(t *testing.T) {
 		t.Setenv("OPENAI_API_KEY", "")
 

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -116,7 +116,7 @@ func TestConvertParams(t *testing.T) {
 		require.Equal(t, 0.9, req.TopP.Value)
 	})
 
-	t.Run("converts max_tokens", func(t *testing.T) {
+	t.Run("maps token limit to max_completion_tokens", func(t *testing.T) {
 		t.Parallel()
 
 		maxTokens := 100
@@ -128,6 +128,7 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
+		require.False(t, req.MaxTokens.Valid())
 		require.Equal(t, int64(100), req.MaxCompletionTokens.Value)
 	})
 
@@ -223,18 +224,43 @@ func TestConvertParams(t *testing.T) {
 		require.NotNil(t, req.ResponseFormat)
 	})
 
-	t.Run("converts reasoning_effort", func(t *testing.T) {
+	t.Run("preserves current reasoning_effort values", func(t *testing.T) {
+		t.Parallel()
+
+		efforts := []providers.ReasoningEffort{
+			providers.ReasoningEffortNone,
+			providers.ReasoningEffortMinimal,
+			providers.ReasoningEffortLow,
+			providers.ReasoningEffortMedium,
+			providers.ReasoningEffortHigh,
+			providers.ReasoningEffortXHigh,
+			providers.ReasoningEffortMax,
+		}
+		for _, effort := range efforts {
+			params := providers.CompletionParams{
+				Model:           "test-model",
+				Messages:        testutil.SimpleMessages(),
+				ReasoningEffort: effort,
+			}
+
+			req := convertParams(params)
+
+			require.Equal(t, string(effort), string(req.ReasoningEffort))
+		}
+	})
+
+	t.Run("omits automatic reasoning_effort sentinel", func(t *testing.T) {
 		t.Parallel()
 
 		params := providers.CompletionParams{
-			Model:           "o1-mini",
+			Model:           "test-model",
 			Messages:        testutil.SimpleMessages(),
-			ReasoningEffort: providers.ReasoningEffortHigh,
+			ReasoningEffort: providers.ReasoningEffortAuto,
 		}
 
 		req := convertParams(params)
 
-		require.NotNil(t, req.ReasoningEffort)
+		require.Empty(t, req.ReasoningEffort)
 	})
 
 	t.Run("converts seed", func(t *testing.T) {
@@ -487,10 +513,33 @@ func TestCompletionSendsMaxCompletionTokensOnWire(t *testing.T) {
 
 	body := capturedBody()
 
-	// OpenAI requires max_completion_tokens (not max_tokens) for current models.
 	require.Contains(t, body, "max_completion_tokens")
 	require.NotContains(t, body, "max_tokens")
 	require.Equal(t, float64(1024), body["max_completion_tokens"])
+}
+
+func TestCompletionPreservesReasoningEffortOnWire(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeCompletionServer(t)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	params := providers.CompletionParams{
+		Model:           "test-model",
+		Messages:        testutil.SimpleMessages(),
+		ReasoningEffort: providers.ReasoningEffortNone,
+	}
+
+	_, err = provider.Completion(context.Background(), params)
+	require.NoError(t, err)
+
+	body := capturedBody()
+	require.Equal(t, "none", body["reasoning_effort"])
 }
 
 func TestCompletionStreamSendsMaxCompletionTokensOnWire(t *testing.T) {
@@ -520,7 +569,6 @@ func TestCompletionStreamSendsMaxCompletionTokensOnWire(t *testing.T) {
 
 	body := capturedBody()
 
-	// OpenAI requires max_completion_tokens (not max_tokens) for current models.
 	require.Contains(t, body, "max_completion_tokens")
 	require.NotContains(t, body, "max_tokens")
 	require.Equal(t, float64(1024), body["max_completion_tokens"])

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/any-llm-go/config"
@@ -362,11 +362,16 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 1)
-		require.Equal(t, "get_weather", result[0].Function.Name)
-		require.Equal(t, "Get the current weather for a location.", result[0].Function.Description.Value)
+		require.NotNil(t, result[0].OfFunction)
+		require.Equal(t, "get_weather", result[0].OfFunction.Function.Name)
+		require.Equal(
+			t,
+			"Get the current weather for a location.",
+			result[0].OfFunction.Function.Description.Value,
+		)
 
 		// FunctionParameters is map[string]any - access directly.
-		params := result[0].Function.Parameters
+		params := result[0].OfFunction.Function.Parameters
 		require.Equal(t, "object", params["type"])
 
 		props, ok := params["properties"].(map[string]any)
@@ -391,10 +396,11 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 1)
-		require.Equal(t, "calculate", result[0].Function.Name)
+		require.NotNil(t, result[0].OfFunction)
+		require.Equal(t, "calculate", result[0].OfFunction.Function.Name)
 
 		// FunctionParameters is map[string]any - access directly.
-		params := result[0].Function.Parameters
+		params := result[0].OfFunction.Function.Parameters
 
 		props, ok := params["properties"].(map[string]any)
 		require.True(t, ok)
@@ -436,8 +442,10 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 2)
-		require.Equal(t, "get_weather", result[0].Function.Name)
-		require.Equal(t, "get_current_date", result[1].Function.Name)
+		require.NotNil(t, result[0].OfFunction)
+		require.NotNil(t, result[1].OfFunction)
+		require.Equal(t, "get_weather", result[0].OfFunction.Function.Name)
+		require.Equal(t, "get_current_date", result[1].OfFunction.Function.Name)
 	})
 }
 

--- a/providers/types.go
+++ b/providers/types.go
@@ -16,11 +16,14 @@ const (
 
 // Reasoning effort levels for extended thinking.
 const (
-	ReasoningEffortAuto   ReasoningEffort = "auto"
-	ReasoningEffortHigh   ReasoningEffort = "high"
-	ReasoningEffortLow    ReasoningEffort = "low"
-	ReasoningEffortMedium ReasoningEffort = "medium"
-	ReasoningEffortNone   ReasoningEffort = "none"
+	ReasoningEffortAuto    ReasoningEffort = "auto"
+	ReasoningEffortHigh    ReasoningEffort = "high"
+	ReasoningEffortLow     ReasoningEffort = "low"
+	ReasoningEffortMax     ReasoningEffort = "max"
+	ReasoningEffortMedium  ReasoningEffort = "medium"
+	ReasoningEffortMinimal ReasoningEffort = "minimal"
+	ReasoningEffortNone    ReasoningEffort = "none"
+	ReasoningEffortXHigh   ReasoningEffort = "xhigh"
 )
 
 // Message roles.
@@ -95,7 +98,7 @@ type Capabilities struct {
 	CompletionImage     bool
 	CompletionPDF       bool
 	CompletionReasoning bool
-	CompletionStreaming  bool
+	CompletionStreaming bool
 	CompletionTools     bool
 	Embedding           bool
 	ListModels          bool

--- a/providers/types.go
+++ b/providers/types.go
@@ -274,6 +274,8 @@ type Function struct {
 	Name        string         `json:"name"`
 	Description string         `json:"description,omitempty"`
 	Parameters  map[string]any `json:"parameters,omitempty"`
+	// Strict requests schema-constrained function arguments when the provider supports it.
+	Strict *bool `json:"strict,omitempty"`
 }
 
 // FunctionCall represents the function being called.


### PR DESCRIPTION
## Summary

- advertise DeepSeek Vision Exp image-input capability
- preserve external URL and inline data URL images with every documented optional detail value
- reject non-user, malformed, or unrepresentable image content before transport

## Scope and dependency

This PR owns only the currently representable DeepSeek Vision Chat request surface. It depends on #150 exact head `d164212fbe523550615c0e4bfa3a6ed9888be7e7` for the DeepSeek request transform boundary. Because the upstream repository cannot use a contributor-fork PR as a base, the GitHub full diff includes the declared #150 and #141 dependency commits.

Owning range: `d164212fbe523550615c0e4bfa3a6ed9888be7e7..1e324baf6e2261a54ec03a602bf429cf8ad973b0`, 4 files, +232/-4. The production commit is +58/-2 and the necessary test commit is +174/-2. There are no coverage-only fixtures.

DeepSeek Files API image parts remain unfinished because the public `ContentPart` type cannot express `file_id`, `file_data`, or `filename`. This PR rejects `type=file` rather than silently dropping it.

## Sources

- DeepSeek Vision guide: https://api-docs.deepseek.com/guides/vision
- Vision Exp release: https://api-docs.deepseek.com/news/news260821
- OpenAI Go v3.56.0 tag commit: `f5b985771236464300abc9395c1c4abda0d65c53`
- OpenAI Python v3.8.0 tag commit: `88391abf981df3ea395ca1b5bf55ec6a4011ea93`

The current DeepSeek guide permits `auto`, `low`, `high`, and `original` detail values and limits image content to user messages. The existing OpenAI Go v3.42.0 dependency already serializes this shape, including DeepSeek's `original` extension, so no SDK upgrade is needed.

## Verification

- `go test ./... -count=1`
- `CGO_ENABLED=1 go test -race ./providers/deepseek ./providers/openai ./providers/mistral -count=1`
- `go mod tidy -diff`
- `go mod verify`
- `golangci-lint run --new-from-rev=d164212fbe523550615c0e4bfa3a6ed9888be7e7 ./providers/...`
- `git diff --check`
- temporary OpenAI Go v3.56.0 modfile overlay: `go test ./providers/deepseek -count=1`
- direct v3.56.0 SDK serialization of omitted, auto, low, high, and original detail

Ablation retained capability and tests while deleting the DeepSeek vision request hook. Basic URLs still flowed through the shared converter, while all non-empty detail values disappeared and six malformed inputs reached transport. The retained hook therefore owns only DeepSeek policy that the shared converter cannot safely apply to every compatible provider.

The fixtures were independently written from the official wire schema. No Fantasy or upstream SDK code, fixture, control flow, or assertion sequence was copied.

Live Vision Exp verification is blocked by the absence of `DEEPSEEK_API_KEY`, so provider-wide alignment remains incomplete.