### PR TITLE
feat(deepseek): support Files API lifecycle

### DIFF
--- a/anyllm.go
+++ b/anyllm.go
@@ -39,6 +39,13 @@ const (
 	FinishReasonToolCalls     = providers.FinishReasonToolCalls
 )
 
+// File purposes and list ordering.
+const (
+	FilePurposeUserData = providers.FilePurposeUserData
+	FileOrderAsc        = providers.FileOrderAsc
+	FileOrderDesc       = providers.FileOrderDesc
+)
+
 // Batch status constants.
 const (
 	BatchStatusCancelled  = providers.BatchStatusCancelled
@@ -69,6 +76,7 @@ type (
 	Capabilities       = providers.Capabilities
 	CapabilityProvider = providers.CapabilityProvider
 	EmbeddingProvider  = providers.EmbeddingProvider
+	FileProvider       = providers.FileProvider
 	ModelLister        = providers.ModelLister
 	ModerationProvider = providers.ModerationProvider
 	Provider           = providers.Provider
@@ -101,6 +109,11 @@ type (
 	ModerationParams    = providers.ModerationParams
 	ModerationResponse  = providers.ModerationResponse
 	ModerationResult    = providers.ModerationResult
+	UploadFileParams    = providers.UploadFileParams
+	ListFilesOptions    = providers.ListFilesOptions
+	File                = providers.File
+	FileList            = providers.FileList
+	DeletedFile         = providers.DeletedFile
 )
 
 // Message types.

--- a/anyllm.go
+++ b/anyllm.go
@@ -53,11 +53,14 @@ const (
 
 // ReasoningEffort levels.
 const (
-	ReasoningEffortAuto   = providers.ReasoningEffortAuto
-	ReasoningEffortHigh   = providers.ReasoningEffortHigh
-	ReasoningEffortLow    = providers.ReasoningEffortLow
-	ReasoningEffortMedium = providers.ReasoningEffortMedium
-	ReasoningEffortNone   = providers.ReasoningEffortNone
+	ReasoningEffortAuto    = providers.ReasoningEffortAuto
+	ReasoningEffortHigh    = providers.ReasoningEffortHigh
+	ReasoningEffortLow     = providers.ReasoningEffortLow
+	ReasoningEffortMax     = providers.ReasoningEffortMax
+	ReasoningEffortMedium  = providers.ReasoningEffortMedium
+	ReasoningEffortMinimal = providers.ReasoningEffortMinimal
+	ReasoningEffortNone    = providers.ReasoningEffortNone
+	ReasoningEffortXHigh   = providers.ReasoningEffortXHigh
 )
 
 // Provider types.
@@ -179,17 +182,17 @@ var (
 
 // Error types.
 type (
-	AuthenticationError           = errors.AuthenticationError
-	BaseError                     = errors.BaseError
-	ContentFilterError            = errors.ContentFilterError
-	ContextLengthError            = errors.ContextLengthError
-	InsufficientFundsError        = errors.InsufficientFundsError
-	InvalidRequestError           = errors.InvalidRequestError
-	MissingAPIKeyError            = errors.MissingAPIKeyError
-	ModelNotFoundError            = errors.ModelNotFoundError
-	ProviderError                 = errors.ProviderError
-	RateLimitError                = errors.RateLimitError
-	UnsupportedOperationError     = errors.UnsupportedOperationError
-	UnsupportedParamError         = errors.UnsupportedParamError
-	UnsupportedProviderError      = errors.UnsupportedProviderError
+	AuthenticationError       = errors.AuthenticationError
+	BaseError                 = errors.BaseError
+	ContentFilterError        = errors.ContentFilterError
+	ContextLengthError        = errors.ContextLengthError
+	InsufficientFundsError    = errors.InsufficientFundsError
+	InvalidRequestError       = errors.InvalidRequestError
+	MissingAPIKeyError        = errors.MissingAPIKeyError
+	ModelNotFoundError        = errors.ModelNotFoundError
+	ProviderError             = errors.ProviderError
+	RateLimitError            = errors.RateLimitError
+	UnsupportedOperationError = errors.UnsupportedOperationError
+	UnsupportedParamError     = errors.UnsupportedParamError
+	UnsupportedProviderError  = errors.UnsupportedProviderError
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/mozilla-ai/any-llm-platform-client-go v0.0.1
 	github.com/ollama/ollama v0.32.5
-	github.com/openai/openai-go v1.12.0
+	github.com/openai/openai-go/v3 v3.42.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/genai v1.66.0
 )

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/mozilla-ai/any-llm-platform-client-go v0.0.1 h1:AXmEYxIEIESUt2LyB6GFD
 github.com/mozilla-ai/any-llm-platform-client-go v0.0.1/go.mod h1:bqmvllQOUir9G2bmglRQDEgsfHCF6jAC339JGWkzH4U=
 github.com/ollama/ollama v0.32.5 h1:5jeKnTJmDTR+xgB8qh68szdXM9zwnMBMtGl890frdzo=
 github.com/ollama/ollama v0.32.5/go.mod h1:b1ydCt2oVg0VAg22WWDgCbwW0AyOaRKAFzlS91NI4OY=
-github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
-github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
+github.com/openai/openai-go/v3 v3.42.0 h1:16Skv1hpEhSm3imZpPGSeEBDUgVJJA9cHryKGGsVYI8=
+github.com/openai/openai-go/v3 v3.42.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"slices"
 
-	oaisdk "github.com/openai/openai-go"
-	"github.com/openai/openai-go/packages/param"
+	oaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
@@ -160,17 +160,12 @@ func preprocessParams(params providers.CompletionParams) providers.CompletionPar
 	}
 }
 
-// transformRequest adjusts the OpenAI SDK request for DeepSeek's API.
-// DeepSeek uses max_tokens, not max_completion_tokens.
-// If both are set, MaxCompletionTokens takes precedence over MaxTokens.
-// See: https://api-docs.deepseek.com/api/create-chat-completion
+// transformRequest maps the shared token limit to DeepSeek's max_tokens field.
+// https://api-docs.deepseek.com/api/create-chat-completion
 func transformRequest(req *oaisdk.ChatCompletionNewParams) {
 	if req.MaxCompletionTokens.Valid() {
-		// Set max_tokens using max_completion_tokens value.
 		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
 	}
-
-	// Clear unsupported fields from the request.
 	req.MaxCompletionTokens = param.Opt[int64]{}
 }
 

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -40,6 +40,7 @@ const (
 var (
 	_ providers.CapabilityProvider = (*Provider)(nil)
 	_ providers.ErrorConverter     = (*Provider)(nil)
+	_ providers.FileProvider       = (*Provider)(nil)
 	_ providers.ModelLister        = (*Provider)(nil)
 	_ providers.Provider           = (*Provider)(nil)
 )
@@ -99,6 +100,7 @@ func capabilities() providers.Capabilities {
 		CompletionStreaming: true,
 		CompletionTools:     true,
 		Embedding:           false, // DeepSeek doesn't host embedding models.
+		Files:               true,
 		ListModels:          true,
 	}
 }

--- a/providers/deepseek/files.go
+++ b/providers/deepseek/files.go
@@ -1,0 +1,63 @@
+package deepseek
+
+import (
+	"context"
+	stderrors "errors"
+
+	llmerrors "github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+const (
+	minFileExpiration = 3600
+	maxFileExpiration = 2592000
+)
+
+// UploadFile uploads an image for reuse by DeepSeek Vision requests.
+func (p *Provider) UploadFile(ctx context.Context, params providers.UploadFileParams) (*providers.File, error) {
+	if params.File == nil {
+		return nil, invalidFileRequest("file is required")
+	}
+	if params.Purpose != providers.FilePurposeUserData {
+		return nil, invalidFileRequest("purpose must be user_data")
+	}
+	if params.ExpiresAfter != nil &&
+		(*params.ExpiresAfter < minFileExpiration || *params.ExpiresAfter > maxFileExpiration) {
+		return nil, invalidFileRequest("expires_after must be between 3600 and 2592000 seconds")
+	}
+	return p.CompatibleProvider.UploadFile(ctx, params)
+}
+
+// ListFiles lists one page of files uploaded for DeepSeek Vision requests.
+func (p *Provider) ListFiles(ctx context.Context, opts providers.ListFilesOptions) (*providers.FileList, error) {
+	if opts.Limit != nil && (*opts.Limit < 1 || *opts.Limit > 1000) {
+		return nil, invalidFileRequest("limit must be between 1 and 1000")
+	}
+	if opts.Order != "" && opts.Order != providers.FileOrderAsc && opts.Order != providers.FileOrderDesc {
+		return nil, invalidFileRequest("order must be asc or desc")
+	}
+	if opts.Purpose != "" && opts.Purpose != providers.FilePurposeUserData {
+		return nil, invalidFileRequest("purpose must be user_data")
+	}
+	return p.CompatibleProvider.ListFiles(ctx, opts)
+}
+
+// RetrieveFile returns metadata for one DeepSeek file.
+func (p *Provider) RetrieveFile(ctx context.Context, fileID string) (*providers.File, error) {
+	if fileID == "" {
+		return nil, invalidFileRequest("file_id is required")
+	}
+	return p.CompatibleProvider.RetrieveFile(ctx, fileID)
+}
+
+// DeleteFile deletes one DeepSeek file.
+func (p *Provider) DeleteFile(ctx context.Context, fileID string) (*providers.DeletedFile, error) {
+	if fileID == "" {
+		return nil, invalidFileRequest("file_id is required")
+	}
+	return p.CompatibleProvider.DeleteFile(ctx, fileID)
+}
+
+func invalidFileRequest(message string) error {
+	return llmerrors.NewInvalidRequestError(providerName, stderrors.New(message))
+}

--- a/providers/deepseek/files_errors_test.go
+++ b/providers/deepseek/files_errors_test.go
@@ -1,0 +1,141 @@
+package deepseek
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	llmerrors "github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+func TestFileOperationsRejectInvalidDeepSeekParamsBeforeTransport(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	t.Cleanup(server.Close)
+	provider, err := New(config.WithAPIKey("test-key"), config.WithBaseURL(server.URL))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.Zero(t, requests.Load()) })
+
+	for _, tc := range []struct {
+		name string
+		run  func() error
+	}{
+		{name: "missing file", run: func() error {
+			_, err := provider.UploadFile(t.Context(), providers.UploadFileParams{Purpose: providers.FilePurposeUserData})
+			return err
+		}},
+		{name: "wrong purpose", run: func() error {
+			_, err := provider.UploadFile(t.Context(), providers.UploadFileParams{File: strings.NewReader("x"), Purpose: "vision"})
+			return err
+		}},
+		{name: "short expiration", run: func() error {
+			_, err := provider.UploadFile(t.Context(), providers.UploadFileParams{
+				File: strings.NewReader("x"), Purpose: providers.FilePurposeUserData, ExpiresAfter: new(3599),
+			})
+			return err
+		}},
+		{name: "long expiration", run: func() error {
+			_, err := provider.UploadFile(t.Context(), providers.UploadFileParams{
+				File: strings.NewReader("x"), Purpose: providers.FilePurposeUserData, ExpiresAfter: new(2592001),
+			})
+			return err
+		}},
+		{name: "zero list limit", run: func() error {
+			_, err := provider.ListFiles(t.Context(), providers.ListFilesOptions{Limit: new(0)})
+			return err
+		}},
+		{name: "large list limit", run: func() error {
+			_, err := provider.ListFiles(t.Context(), providers.ListFilesOptions{Limit: new(1001)})
+			return err
+		}},
+		{name: "wrong list order", run: func() error {
+			_, err := provider.ListFiles(t.Context(), providers.ListFilesOptions{Order: "newest"})
+			return err
+		}},
+		{name: "wrong list purpose", run: func() error {
+			_, err := provider.ListFiles(t.Context(), providers.ListFilesOptions{Purpose: "vision"})
+			return err
+		}},
+		{name: "missing retrieve id", run: func() error {
+			_, err := provider.RetrieveFile(t.Context(), "")
+			return err
+		}},
+		{name: "missing delete id", run: func() error {
+			_, err := provider.DeleteFile(t.Context(), "")
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.ErrorIs(t, tc.run(), llmerrors.ErrInvalidRequest)
+		})
+	}
+}
+
+func TestFileUploadHonorsCallerContext(t *testing.T) {
+	t.Parallel()
+
+	provider, err := New(config.WithAPIKey("test-key"), config.WithBaseURL("http://127.0.0.1:1"))
+	require.NoError(t, err)
+
+	canceled, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = provider.UploadFile(canceled, providers.UploadFileParams{
+		File: strings.NewReader("x"), Purpose: providers.FilePurposeUserData,
+	})
+	require.ErrorIs(t, err, context.Canceled)
+
+	timedOut, cancelTimeout := context.WithTimeout(t.Context(), time.Nanosecond)
+	t.Cleanup(cancelTimeout)
+	<-timedOut.Done()
+	_, err = provider.UploadFile(timedOut, providers.UploadFileParams{
+		File: strings.NewReader("x"), Purpose: providers.FilePurposeUserData,
+	})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestFileAPIErrorsUseNormalizedErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, err := fmt.Fprint(w, `{"error":{"message":"slow down","type":"rate_limit_error"}}`)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+	provider, err := New(config.WithAPIKey("test-key"), config.WithBaseURL(server.URL))
+	require.NoError(t, err)
+
+	_, err = provider.RetrieveFile(t.Context(), "file-api-one")
+	require.ErrorIs(t, err, llmerrors.ErrRateLimit)
+}
+
+func TestRetrieveFileRejectsMalformedResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := fmt.Fprint(w, `{"id":"file-api-one","bytes":"invalid"}`)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+	provider, err := New(config.WithAPIKey("test-key"), config.WithBaseURL(server.URL))
+	require.NoError(t, err)
+
+	_, err = provider.RetrieveFile(t.Context(), "file-api-one")
+	require.Error(t, err)
+}

--- a/providers/deepseek/files_test.go
+++ b/providers/deepseek/files_test.go
@@ -1,0 +1,154 @@
+package deepseek
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/any-llm-go/config"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+type namedFileReader struct {
+	*bytes.Reader
+}
+
+func (namedFileReader) Filename() string {
+	return "chart.png"
+}
+
+func TestFileLifecycleUsesDeepSeekContract(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "POST /files":
+			require.NoError(t, r.ParseMultipartForm(1<<20))
+			require.Equal(t, "user_data", r.FormValue("purpose"))
+			require.Equal(t, "created_at", r.FormValue("expires_after[anchor]"))
+			require.Equal(t, "3600", r.FormValue("expires_after[seconds]"))
+			file, header, err := r.FormFile("file")
+			require.NoError(t, err)
+			defer func() { require.NoError(t, file.Close()) }()
+			require.Equal(t, "chart.png", header.Filename)
+			content, err := io.ReadAll(file)
+			require.NoError(t, err)
+			require.Equal(t, []byte("image bytes"), content)
+			_, err = fmt.Fprint(w, `{
+				"id":"file-api-one","object":"file","bytes":11,"created_at":1700000000,
+				"filename":"chart.png","purpose":"user_data","expires_at":1700003600,
+				"future_field":"ignored"
+			}`)
+			require.NoError(t, err)
+		case "GET /files":
+			require.Equal(t, "file-api-cursor", r.URL.Query().Get("after"))
+			require.Equal(t, "2", r.URL.Query().Get("limit"))
+			require.Equal(t, "desc", r.URL.Query().Get("order"))
+			require.Equal(t, "user_data", r.URL.Query().Get("purpose"))
+			_, err := fmt.Fprint(w, `{
+				"object":"list","data":[{"id":"file-api-one","object":"file","bytes":11,
+				"created_at":1700000000,"filename":"chart.png","purpose":"user_data"}],
+				"first_id":"file-api-one","last_id":"file-api-one","has_more":false
+			}`)
+			require.NoError(t, err)
+		case "GET /files/file-api-one":
+			_, err := fmt.Fprint(w, `{
+				"id":"file-api-one","object":"file","bytes":11,"created_at":1700000000,
+				"filename":"chart.png","purpose":"user_data"
+			}`)
+			require.NoError(t, err)
+		case "DELETE /files/file-api-one":
+			_, err := fmt.Fprint(w, `{"id":"file-api-one","object":"file","deleted":true}`)
+			require.NoError(t, err)
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	provider, err := New(config.WithAPIKey("test-key"), config.WithBaseURL(server.URL))
+	require.NoError(t, err)
+
+	uploaded, err := provider.UploadFile(t.Context(), providers.UploadFileParams{
+		File:         namedFileReader{Reader: bytes.NewReader([]byte("image bytes"))},
+		Purpose:      providers.FilePurposeUserData,
+		ExpiresAfter: new(3600),
+	})
+	require.NoError(t, err)
+	require.Equal(t, &providers.File{
+		ID: "file-api-one", Object: "file", Bytes: 11, CreatedAt: 1700000000,
+		Filename: "chart.png", Purpose: providers.FilePurposeUserData, ExpiresAt: new(int64(1700003600)),
+	}, uploaded)
+
+	files, err := provider.ListFiles(t.Context(), providers.ListFilesOptions{
+		After: "file-api-cursor", Limit: new(2), Order: providers.FileOrderDesc,
+		Purpose: providers.FilePurposeUserData,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "list", files.Object)
+	require.Equal(t, "file-api-one", files.FirstID)
+	require.Equal(t, "file-api-one", files.LastID)
+	require.False(t, files.HasMore)
+	require.Len(t, files.Data, 1)
+
+	retrieved, err := provider.RetrieveFile(t.Context(), "file-api-one")
+	require.NoError(t, err)
+	require.Equal(t, "chart.png", retrieved.Filename)
+	require.Nil(t, retrieved.ExpiresAt)
+
+	deleted, err := provider.DeleteFile(t.Context(), "file-api-one")
+	require.NoError(t, err)
+	require.Equal(t, &providers.DeletedFile{ID: "file-api-one", Object: "file", Deleted: true}, deleted)
+}
+
+func TestFileUploadOmitsExpirationFieldsForPermanentFiles(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseMultipartForm(1<<20))
+		require.Empty(t, r.FormValue("expires_after[anchor]"))
+		require.Empty(t, r.FormValue("expires_after[seconds]"))
+		w.Header().Set("Content-Type", "application/json")
+		_, err := fmt.Fprint(w, `{
+			"id":"file-api-one","object":"file","bytes":1,"created_at":1700000000,
+			"filename":"image.png","purpose":"user_data"
+		}`)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+	provider, err := New(config.WithAPIKey("test-key"), config.WithBaseURL(server.URL))
+	require.NoError(t, err)
+
+	file, err := provider.UploadFile(t.Context(), providers.UploadFileParams{
+		File: strings.NewReader("x"), Purpose: providers.FilePurposeUserData,
+	})
+	require.NoError(t, err)
+	require.Nil(t, file.ExpiresAt)
+}
+
+func TestListFilesAcceptsDocumentedLimitBoundaries(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Contains(t, []string{"1", "1000"}, r.URL.Query().Get("limit"))
+		w.Header().Set("Content-Type", "application/json")
+		_, err := fmt.Fprint(w, `{"object":"list","data":[],"has_more":false}`)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+	provider, err := New(config.WithAPIKey("test-key"), config.WithBaseURL(server.URL))
+	require.NoError(t, err)
+
+	for _, limit := range []int{1, 1000} {
+		files, err := provider.ListFiles(t.Context(), providers.ListFilesOptions{Limit: new(limit)})
+		require.NoError(t, err)
+		require.Empty(t, files.Data)
+	}
+}

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/v3"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/errors"
@@ -373,7 +373,7 @@ func capabilities() providers.Capabilities {
 		CompletionImage:     true,
 		CompletionPDF:       true,
 		CompletionReasoning: true,
-		CompletionStreaming:  true,
+		CompletionStreaming: true,
 		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
@@ -703,7 +703,9 @@ func (p *Provider) handleRerankErrorResponse(resp *http.Response) error {
 	case http.StatusTooManyRequests:
 		return errors.NewRateLimitError(providerName, fmt.Errorf("%s", msg))
 	case http.StatusBadGateway:
-		return &UpstreamProviderError{BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider)}
+		return &UpstreamProviderError{
+			BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider),
+		}
 	case http.StatusGatewayTimeout:
 		return &TimeoutError{BaseError: errors.New(errCodeTimeout, providerName, fmt.Errorf("%s", msg), ErrTimeout)}
 	default:

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"slices"
 
-	oaisdk "github.com/openai/openai-go"
-	"github.com/openai/openai-go/packages/param"
+	oaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
@@ -141,17 +141,13 @@ func patchMessageParams(params providers.CompletionParams) providers.CompletionP
 	return params
 }
 
-// transformRequest adjusts the OpenAI SDK request for Mistral's API.
-// Mistral uses max_tokens (not max_completion_tokens) and does not accept user or reasoning_effort fields.
-// If both are set, MaxCompletionTokens takes precedence over MaxTokens.
-// See: https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post
+// transformRequest maps the shared token limit to Mistral's max_tokens field
+// and removes fields outside its Chat request schema.
+// https://docs.mistral.ai/api?property=operation-chat_completion_v1_chat_completions_post_request_max_tokens
 func transformRequest(req *oaisdk.ChatCompletionNewParams) {
 	if req.MaxCompletionTokens.Valid() {
-		// Set max_tokens using max_completion_tokens value.
 		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
 	}
-
-	// Clear unsupported fields from the request.
 	req.MaxCompletionTokens = param.Opt[int64]{}
 	req.User = param.Opt[string]{}
 	req.ReasoningEffort = ""

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -7,9 +7,9 @@ import (
 	stderrors "errors"
 	"fmt"
 
-	"github.com/openai/openai-go"
-	"github.com/openai/openai-go/option"
-	"github.com/openai/openai-go/shared"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/shared"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/errors"
@@ -328,13 +328,15 @@ func convertAPIError(name string, apiErr *openai.Error, originalErr error) error
 // convertAssistantMessage converts an assistant message to OpenAI format.
 func convertAssistantMessage(msg providers.Message) openai.ChatCompletionMessageParamUnion {
 	if len(msg.ToolCalls) > 0 {
-		toolCalls := make([]openai.ChatCompletionMessageToolCallParam, 0, len(msg.ToolCalls))
+		toolCalls := make([]openai.ChatCompletionMessageToolCallUnionParam, 0, len(msg.ToolCalls))
 		for _, tc := range msg.ToolCalls {
-			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallParam{
-				ID: tc.ID,
-				Function: openai.ChatCompletionMessageToolCallFunctionParam{
-					Name:      tc.Function.Name,
-					Arguments: tc.Function.Arguments,
+			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnionParam{
+				OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
+					ID: tc.ID,
+					Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
+						Name:      tc.Function.Name,
+						Arguments: tc.Function.Arguments,
+					},
 				},
 			})
 		}
@@ -380,13 +382,16 @@ func convertChunk(chunk *openai.ChatCompletionChunk) providers.ChatCompletionChu
 		choices = append(choices, chunkChoice)
 	}
 
+	// Preserve the existing normalized field even though the v3 SDK marks the
+	// documented response field as deprecated.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	result := providers.ChatCompletionChunk{
 		ID:                chunk.ID,
 		Object:            objectChatCompletionChunk,
 		Created:           chunk.Created,
 		Model:             chunk.Model,
 		Choices:           choices,
-		SystemFingerprint: chunk.SystemFingerprint,
+		SystemFingerprint: chunk.SystemFingerprint, //nolint:staticcheck
 	}
 
 	if chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0 {
@@ -570,13 +575,16 @@ func convertResponse(resp *openai.ChatCompletion) *providers.ChatCompletion {
 		})
 	}
 
+	// Preserve the existing normalized field even though the v3 SDK marks the
+	// documented response field as deprecated.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	result := &providers.ChatCompletion{
 		ID:                resp.ID,
 		Object:            objectChatCompletion,
 		Created:           resp.Created,
 		Model:             resp.Model,
 		Choices:           choices,
-		SystemFingerprint: resp.SystemFingerprint,
+		SystemFingerprint: resp.SystemFingerprint, //nolint:staticcheck
 	}
 
 	if resp.Usage.PromptTokens > 0 || resp.Usage.CompletionTokens > 0 {
@@ -658,7 +666,7 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 		}
 	case providers.ToolChoice:
 		if v.Function != nil {
-			return openai.ChatCompletionToolChoiceOptionParamOfChatCompletionNamedToolChoice(
+			return openai.ToolChoiceOptionFunctionToolChoice(
 				openai.ChatCompletionNamedToolChoiceFunctionParam{
 					Name: v.Function.Name,
 				},
@@ -671,14 +679,16 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 }
 
 // convertTools converts provider tools to OpenAI format.
-func convertTools(tools []providers.Tool) []openai.ChatCompletionToolParam {
-	result := make([]openai.ChatCompletionToolParam, 0, len(tools))
+func convertTools(tools []providers.Tool) []openai.ChatCompletionToolUnionParam {
+	result := make([]openai.ChatCompletionToolUnionParam, 0, len(tools))
 	for _, tool := range tools {
-		result = append(result, openai.ChatCompletionToolParam{
-			Function: openai.FunctionDefinitionParam{
-				Name:        tool.Function.Name,
-				Description: openai.String(tool.Function.Description),
-				Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+		result = append(result, openai.ChatCompletionToolUnionParam{
+			OfFunction: &openai.ChatCompletionFunctionToolParam{
+				Function: openai.FunctionDefinitionParam{
+					Name:        tool.Function.Name,
+					Description: openai.String(tool.Function.Description),
+					Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+				},
 			},
 		})
 	}

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -689,13 +689,17 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 func convertTools(tools []providers.Tool) []openai.ChatCompletionToolUnionParam {
 	result := make([]openai.ChatCompletionToolUnionParam, 0, len(tools))
 	for _, tool := range tools {
+		function := openai.FunctionDefinitionParam{
+			Name:        tool.Function.Name,
+			Description: openai.String(tool.Function.Description),
+			Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+		}
+		if tool.Function.Strict != nil {
+			function.Strict = openai.Bool(*tool.Function.Strict)
+		}
 		result = append(result, openai.ChatCompletionToolUnionParam{
 			OfFunction: &openai.ChatCompletionFunctionToolParam{
-				Function: openai.FunctionDefinitionParam{
-					Name:        tool.Function.Name,
-					Description: openai.String(tool.Function.Description),
-					Parameters:  openai.FunctionParameters(tool.Function.Parameters),
-				},
+				Function: function,
 			},
 		})
 	}

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -517,6 +517,10 @@ func convertParams(params providers.CompletionParams) openai.ChatCompletionNewPa
 		req.TopP = openai.Float(*params.TopP)
 	}
 
+	// OpenAI documents max_completion_tokens as the replacement for the
+	// deprecated max_tokens field. Keep the binding's existing MaxTokens
+	// abstraction on the current wire field.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	if params.MaxTokens != nil {
 		req.MaxCompletionTokens = openai.Int(int64(*params.MaxTokens))
 	}
@@ -551,7 +555,10 @@ func convertParams(params providers.CompletionParams) openai.ChatCompletionNewPa
 		req.User = openai.String(params.User)
 	}
 
-	if params.ReasoningEffort != "" && params.ReasoningEffort != providers.ReasoningEffortNone {
+	// auto is the binding's omission sentinel. OpenAI documents none as an
+	// explicit value, so it must reach the wire unchanged.
+	// https://developers.openai.com/api/docs/guides/latest-model
+	if params.ReasoningEffort != "" && params.ReasoningEffort != providers.ReasoningEffortAuto {
 		req.ReasoningEffort = shared.ReasoningEffort(params.ReasoningEffort)
 	}
 

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -4,11 +4,14 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"fmt"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/pagination"
+	"github.com/openai/openai-go/v3/packages/respjson"
 	"github.com/openai/openai-go/v3/shared"
 
 	"github.com/mozilla-ai/any-llm-go/config"
@@ -91,6 +94,7 @@ var (
 	_ providers.CapabilityProvider = (*CompatibleProvider)(nil)
 	_ providers.EmbeddingProvider  = (*CompatibleProvider)(nil)
 	_ providers.ErrorConverter     = (*CompatibleProvider)(nil)
+	_ providers.FileProvider       = (*CompatibleProvider)(nil)
 	_ providers.ModelLister        = (*CompatibleProvider)(nil)
 	_ providers.Provider           = (*CompatibleProvider)(nil)
 )
@@ -286,6 +290,172 @@ func (p *CompatibleProvider) ListModels(ctx context.Context) (*providers.ModelsR
 		Object: objectList,
 		Data:   models,
 	}, nil
+}
+
+// UploadFile uploads a file through an OpenAI-compatible Files API.
+func (p *CompatibleProvider) UploadFile(
+	ctx context.Context,
+	params providers.UploadFileParams,
+) (*providers.File, error) {
+	if err := p.requireFiles("upload file"); err != nil {
+		return nil, err
+	}
+
+	req := openai.FileNewParams{
+		File:    params.File,
+		Purpose: openai.FilePurpose(params.Purpose),
+	}
+	if params.ExpiresAfter != nil {
+		// DeepSeek documents bracketed multipart fields, while openai-go v3.42.0
+		// serializes this generated nested struct with dotted field names.
+		// https://api-docs.deepseek.com/guides/files_api/#upload-a-file
+		req.SetExtraFields(map[string]any{
+			"expires_after[anchor]":  "created_at",
+			"expires_after[seconds]": fmt.Sprint(*params.ExpiresAfter),
+		})
+	}
+	resp, err := p.client.Files.New(ctx, req)
+	if err != nil {
+		return nil, p.ConvertError(err)
+	}
+	return convertFile(resp)
+}
+
+// ListFiles lists one page from an OpenAI-compatible Files API.
+func (p *CompatibleProvider) ListFiles(
+	ctx context.Context,
+	opts providers.ListFilesOptions,
+) (*providers.FileList, error) {
+	if err := p.requireFiles("list files"); err != nil {
+		return nil, err
+	}
+
+	req := openai.FileListParams{}
+	if opts.After != "" {
+		req.After = openai.String(opts.After)
+	}
+	if opts.Limit != nil {
+		req.Limit = openai.Int(int64(*opts.Limit))
+	}
+	if opts.Order != "" {
+		req.Order = openai.FileListParamsOrder(opts.Order)
+	}
+	if opts.Purpose != "" {
+		req.Purpose = openai.String(opts.Purpose)
+	}
+	resp, err := p.client.Files.List(ctx, req)
+	if err != nil {
+		return nil, p.ConvertError(err)
+	}
+	return convertFileList(resp)
+}
+
+// RetrieveFile returns metadata for an uploaded file.
+func (p *CompatibleProvider) RetrieveFile(ctx context.Context, fileID string) (*providers.File, error) {
+	if err := p.requireFiles("retrieve file"); err != nil {
+		return nil, err
+	}
+	resp, err := p.client.Files.Get(ctx, fileID)
+	if err != nil {
+		return nil, p.ConvertError(err)
+	}
+	return convertFile(resp)
+}
+
+// DeleteFile deletes an uploaded file.
+func (p *CompatibleProvider) DeleteFile(ctx context.Context, fileID string) (*providers.DeletedFile, error) {
+	if err := p.requireFiles("delete file"); err != nil {
+		return nil, err
+	}
+	resp, err := p.client.Files.Delete(ctx, fileID)
+	if err != nil {
+		return nil, p.ConvertError(err)
+	}
+	return convertDeletedFile(resp)
+}
+
+func (p *CompatibleProvider) requireFiles(operation string) error {
+	if p.compatibleConfig.Capabilities.Files {
+		return nil
+	}
+	return errors.NewUnsupportedOperationError(p.Name(), operation, nil)
+}
+
+func convertFile(source *openai.FileObject) (*providers.File, error) {
+	if err := requireFileFields([]fileField{
+		{"id", source.JSON.ID},
+		{"object", source.JSON.Object},
+		{"bytes", source.JSON.Bytes},
+		{"created_at", source.JSON.CreatedAt},
+		{"filename", source.JSON.Filename},
+		{"purpose", source.JSON.Purpose},
+	}); err != nil {
+		return nil, err
+	}
+	result := &providers.File{
+		ID:        source.ID,
+		Object:    string(source.Object),
+		Bytes:     source.Bytes,
+		CreatedAt: source.CreatedAt,
+		Filename:  source.Filename,
+		Purpose:   string(source.Purpose),
+	}
+	if source.JSON.ExpiresAt.Raw() != "" && !source.JSON.ExpiresAt.Valid() {
+		return nil, fmt.Errorf("decoding file: missing or invalid expires_at")
+	}
+	if source.JSON.ExpiresAt.Valid() {
+		result.ExpiresAt = new(source.ExpiresAt)
+	}
+	return result, nil
+}
+
+func convertFileList(source *pagination.CursorPage[openai.FileObject]) (*providers.FileList, error) {
+	var metadata struct {
+		Object  string `json:"object"`
+		FirstID string `json:"first_id"`
+		LastID  string `json:"last_id"`
+	}
+	if err := json.Unmarshal([]byte(source.RawJSON()), &metadata); err != nil {
+		return nil, fmt.Errorf("decoding file list metadata: %w", err)
+	}
+
+	files := make([]providers.File, 0, len(source.Data))
+	for i := range source.Data {
+		file, err := convertFile(&source.Data[i])
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, *file)
+	}
+	return &providers.FileList{
+		Object: metadata.Object, Data: files, FirstID: metadata.FirstID,
+		LastID: metadata.LastID, HasMore: source.HasMore,
+	}, nil
+}
+
+type fileField struct {
+	name  string
+	value respjson.Field
+}
+
+func requireFileFields(fields []fileField) error {
+	for _, field := range fields {
+		if !field.value.Valid() {
+			return fmt.Errorf("decoding file: missing or invalid %s", field.name)
+		}
+	}
+	return nil
+}
+
+func convertDeletedFile(source *openai.FileDeleted) (*providers.DeletedFile, error) {
+	if err := requireFileFields([]fileField{
+		{"id", source.JSON.ID},
+		{"object", source.JSON.Object},
+		{"deleted", source.JSON.Deleted},
+	}); err != nil {
+		return nil, err
+	}
+	return &providers.DeletedFile{ID: source.ID, Object: string(source.Object), Deleted: source.Deleted}, nil
 }
 
 // Name returns the provider name.

--- a/providers/openai/compatible_test.go
+++ b/providers/openai/compatible_test.go
@@ -214,6 +214,19 @@ func TestCompatibleProviderCapabilities(t *testing.T) {
 	require.Equal(t, expectedCaps, caps)
 }
 
+func TestCompatibleProviderRejectsUnsupportedFileManagement(t *testing.T) {
+	t.Parallel()
+
+	provider, err := NewCompatible(CompatibleConfig{Name: "test-provider"})
+	require.NoError(t, err)
+
+	_, err = provider.UploadFile(t.Context(), providers.UploadFileParams{})
+	require.ErrorIs(t, err, errors.ErrUnsupported)
+	var unsupported *errors.UnsupportedOperationError
+	require.ErrorAs(t, err, &unsupported)
+	require.Equal(t, "upload file", unsupported.Operation)
+}
+
 func TestValidateCompletionParams(t *testing.T) {
 	t.Parallel()
 

--- a/providers/openai/compatible_test.go
+++ b/providers/openai/compatible_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -313,6 +314,42 @@ func TestConvertResponseFormat(t *testing.T) {
 		result := convertResponseFormat(format)
 		require.NotNil(t, result.OfText)
 	})
+}
+
+func TestConvertToolsPreservesStrict(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		strict *bool
+	}{
+		{name: "omitted"},
+		{name: "false", strict: new(false)},
+		{name: "true", strict: new(true)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tools := convertTools([]providers.Tool{{
+				Type: "function",
+				Function: providers.Function{
+					Name:       "lookup",
+					Parameters: map[string]any{"type": "object"},
+					Strict:     tc.strict,
+				},
+			}})
+			body, err := json.Marshal(tools)
+			require.NoError(t, err)
+
+			var wire []struct {
+				Function struct {
+					Strict *bool `json:"strict"`
+				} `json:"function"`
+			}
+			require.NoError(t, json.Unmarshal(body, &wire))
+			require.Equal(t, tc.strict, wire[0].Function.Strict)
+		})
+	}
 }
 
 func TestConvertEmbeddingParams(t *testing.T) {

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -55,6 +55,7 @@ func capabilities() providers.Capabilities {
 		CompletionStreaming: true,
 		CompletionTools:     true,
 		Embedding:           true,
+		Files:               true,
 		ListModels:          true,
 	}
 }

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -9,6 +9,7 @@ import (
 const (
 	defaultBaseURL = "https://api.openai.com/v1"
 	envAPIKey      = "OPENAI_API_KEY"
+	envBaseURL     = "OPENAI_BASE_URL"
 	providerName   = "openai"
 )
 
@@ -31,6 +32,7 @@ type Provider struct {
 func New(opts ...config.Option) (*Provider, error) {
 	base, err := NewCompatible(CompatibleConfig{
 		APIKeyEnvVar:   envAPIKey,
+		BaseURLEnvVar:  envBaseURL,
 		Capabilities:   capabilities(),
 		DefaultBaseURL: defaultBaseURL,
 		Name:           providerName,

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -34,6 +34,21 @@ func TestNew(t *testing.T) {
 		require.NotNil(t, provider)
 	})
 
+	t.Run("reads OPENAI_BASE_URL", func(t *testing.T) {
+		serverURL, _ := testutil.FakeCompletionServer(t)
+		t.Setenv("OPENAI_API_KEY", "env-api-key")
+		t.Setenv("OPENAI_BASE_URL", serverURL)
+
+		provider, err := New()
+		require.NoError(t, err)
+
+		_, err = provider.Completion(t.Context(), providers.CompletionParams{
+			Model:    "test-model",
+			Messages: testutil.SimpleMessages(),
+		})
+		require.NoError(t, err)
+	})
+
 	t.Run("returns error when API key is missing", func(t *testing.T) {
 		t.Setenv("OPENAI_API_KEY", "")
 

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -116,7 +116,7 @@ func TestConvertParams(t *testing.T) {
 		require.Equal(t, 0.9, req.TopP.Value)
 	})
 
-	t.Run("converts max_tokens", func(t *testing.T) {
+	t.Run("maps token limit to max_completion_tokens", func(t *testing.T) {
 		t.Parallel()
 
 		maxTokens := 100
@@ -128,6 +128,7 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
+		require.False(t, req.MaxTokens.Valid())
 		require.Equal(t, int64(100), req.MaxCompletionTokens.Value)
 	})
 
@@ -223,18 +224,43 @@ func TestConvertParams(t *testing.T) {
 		require.NotNil(t, req.ResponseFormat)
 	})
 
-	t.Run("converts reasoning_effort", func(t *testing.T) {
+	t.Run("preserves current reasoning_effort values", func(t *testing.T) {
+		t.Parallel()
+
+		efforts := []providers.ReasoningEffort{
+			providers.ReasoningEffortNone,
+			providers.ReasoningEffortMinimal,
+			providers.ReasoningEffortLow,
+			providers.ReasoningEffortMedium,
+			providers.ReasoningEffortHigh,
+			providers.ReasoningEffortXHigh,
+			providers.ReasoningEffortMax,
+		}
+		for _, effort := range efforts {
+			params := providers.CompletionParams{
+				Model:           "test-model",
+				Messages:        testutil.SimpleMessages(),
+				ReasoningEffort: effort,
+			}
+
+			req := convertParams(params)
+
+			require.Equal(t, string(effort), string(req.ReasoningEffort))
+		}
+	})
+
+	t.Run("omits automatic reasoning_effort sentinel", func(t *testing.T) {
 		t.Parallel()
 
 		params := providers.CompletionParams{
-			Model:           "o1-mini",
+			Model:           "test-model",
 			Messages:        testutil.SimpleMessages(),
-			ReasoningEffort: providers.ReasoningEffortHigh,
+			ReasoningEffort: providers.ReasoningEffortAuto,
 		}
 
 		req := convertParams(params)
 
-		require.NotNil(t, req.ReasoningEffort)
+		require.Empty(t, req.ReasoningEffort)
 	})
 
 	t.Run("converts seed", func(t *testing.T) {
@@ -487,10 +513,33 @@ func TestCompletionSendsMaxCompletionTokensOnWire(t *testing.T) {
 
 	body := capturedBody()
 
-	// OpenAI requires max_completion_tokens (not max_tokens) for current models.
 	require.Contains(t, body, "max_completion_tokens")
 	require.NotContains(t, body, "max_tokens")
 	require.Equal(t, float64(1024), body["max_completion_tokens"])
+}
+
+func TestCompletionPreservesReasoningEffortOnWire(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeCompletionServer(t)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	params := providers.CompletionParams{
+		Model:           "test-model",
+		Messages:        testutil.SimpleMessages(),
+		ReasoningEffort: providers.ReasoningEffortNone,
+	}
+
+	_, err = provider.Completion(context.Background(), params)
+	require.NoError(t, err)
+
+	body := capturedBody()
+	require.Equal(t, "none", body["reasoning_effort"])
 }
 
 func TestCompletionStreamSendsMaxCompletionTokensOnWire(t *testing.T) {
@@ -520,7 +569,6 @@ func TestCompletionStreamSendsMaxCompletionTokensOnWire(t *testing.T) {
 
 	body := capturedBody()
 
-	// OpenAI requires max_completion_tokens (not max_tokens) for current models.
 	require.Contains(t, body, "max_completion_tokens")
 	require.NotContains(t, body, "max_tokens")
 	require.Equal(t, float64(1024), body["max_completion_tokens"])

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/any-llm-go/config"
@@ -362,11 +362,16 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 1)
-		require.Equal(t, "get_weather", result[0].Function.Name)
-		require.Equal(t, "Get the current weather for a location.", result[0].Function.Description.Value)
+		require.NotNil(t, result[0].OfFunction)
+		require.Equal(t, "get_weather", result[0].OfFunction.Function.Name)
+		require.Equal(
+			t,
+			"Get the current weather for a location.",
+			result[0].OfFunction.Function.Description.Value,
+		)
 
 		// FunctionParameters is map[string]any - access directly.
-		params := result[0].Function.Parameters
+		params := result[0].OfFunction.Function.Parameters
 		require.Equal(t, "object", params["type"])
 
 		props, ok := params["properties"].(map[string]any)
@@ -391,10 +396,11 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 1)
-		require.Equal(t, "calculate", result[0].Function.Name)
+		require.NotNil(t, result[0].OfFunction)
+		require.Equal(t, "calculate", result[0].OfFunction.Function.Name)
 
 		// FunctionParameters is map[string]any - access directly.
-		params := result[0].Function.Parameters
+		params := result[0].OfFunction.Function.Parameters
 
 		props, ok := params["properties"].(map[string]any)
 		require.True(t, ok)
@@ -436,8 +442,10 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 2)
-		require.Equal(t, "get_weather", result[0].Function.Name)
-		require.Equal(t, "get_current_date", result[1].Function.Name)
+		require.NotNil(t, result[0].OfFunction)
+		require.NotNil(t, result[1].OfFunction)
+		require.Equal(t, "get_weather", result[0].OfFunction.Function.Name)
+		require.Equal(t, "get_current_date", result[1].OfFunction.Function.Name)
 	})
 }
 

--- a/providers/types.go
+++ b/providers/types.go
@@ -16,11 +16,14 @@ const (
 
 // Reasoning effort levels for extended thinking.
 const (
-	ReasoningEffortAuto   ReasoningEffort = "auto"
-	ReasoningEffortHigh   ReasoningEffort = "high"
-	ReasoningEffortLow    ReasoningEffort = "low"
-	ReasoningEffortMedium ReasoningEffort = "medium"
-	ReasoningEffortNone   ReasoningEffort = "none"
+	ReasoningEffortAuto    ReasoningEffort = "auto"
+	ReasoningEffortHigh    ReasoningEffort = "high"
+	ReasoningEffortLow     ReasoningEffort = "low"
+	ReasoningEffortMax     ReasoningEffort = "max"
+	ReasoningEffortMedium  ReasoningEffort = "medium"
+	ReasoningEffortMinimal ReasoningEffort = "minimal"
+	ReasoningEffortNone    ReasoningEffort = "none"
+	ReasoningEffortXHigh   ReasoningEffort = "xhigh"
 )
 
 // Message roles.
@@ -95,7 +98,7 @@ type Capabilities struct {
 	CompletionImage     bool
 	CompletionPDF       bool
 	CompletionReasoning bool
-	CompletionStreaming  bool
+	CompletionStreaming bool
 	CompletionTools     bool
 	Embedding           bool
 	ListModels          bool

--- a/providers/types.go
+++ b/providers/types.go
@@ -4,6 +4,7 @@ package providers
 import (
 	"context"
 	"encoding/json"
+	"io"
 )
 
 // Finish reasons.
@@ -34,6 +35,17 @@ const (
 	RoleUser      = "user"
 )
 
+// File purposes supported by normalized file operations.
+const (
+	FilePurposeUserData = "user_data"
+)
+
+// File list ordering.
+const (
+	FileOrderAsc  = "asc"
+	FileOrderDesc = "desc"
+)
+
 // CapabilityProvider is an optional interface for providers to report capabilities.
 type CapabilityProvider interface {
 	Provider
@@ -44,6 +56,17 @@ type CapabilityProvider interface {
 type EmbeddingProvider interface {
 	Provider
 	Embedding(ctx context.Context, params EmbeddingParams) (*EmbeddingResponse, error)
+}
+
+// FileProvider is an optional interface for providers that manage uploaded files.
+// Check Capabilities.Files before use; compatible providers return ErrUnsupported
+// when their API does not expose file management.
+type FileProvider interface {
+	Provider
+	UploadFile(ctx context.Context, params UploadFileParams) (*File, error)
+	ListFiles(ctx context.Context, opts ListFilesOptions) (*FileList, error)
+	RetrieveFile(ctx context.Context, fileID string) (*File, error)
+	DeleteFile(ctx context.Context, fileID string) (*DeletedFile, error)
 }
 
 // ModerationProvider is an optional interface for providers that support
@@ -101,6 +124,7 @@ type Capabilities struct {
 	CompletionStreaming bool
 	CompletionTools     bool
 	Embedding           bool
+	Files               bool
 	ListModels          bool
 	Moderation          bool
 	Rerank              bool
@@ -205,6 +229,48 @@ type EmbeddingResponse struct {
 type EmbeddingUsage struct {
 	PromptTokens int `json:"prompt_tokens"`
 	TotalTokens  int `json:"total_tokens"`
+}
+
+// UploadFileParams configures an uploaded file and its optional expiration.
+type UploadFileParams struct {
+	File         io.Reader
+	Purpose      string
+	ExpiresAfter *int
+}
+
+// ListFilesOptions controls cursor pagination and filtering for uploaded files.
+type ListFilesOptions struct {
+	After   string
+	Limit   *int
+	Order   string
+	Purpose string
+}
+
+// File describes a remotely stored file.
+type File struct {
+	ID        string `json:"id"`
+	Object    string `json:"object"`
+	Bytes     int64  `json:"bytes"`
+	CreatedAt int64  `json:"created_at"`
+	Filename  string `json:"filename"`
+	Purpose   string `json:"purpose"`
+	ExpiresAt *int64 `json:"expires_at,omitempty"`
+}
+
+// FileList is one page of remotely stored files.
+type FileList struct {
+	Object  string `json:"object"`
+	Data    []File `json:"data"`
+	FirstID string `json:"first_id"`
+	LastID  string `json:"last_id"`
+	HasMore bool   `json:"has_more"`
+}
+
+// DeletedFile confirms deletion of a remotely stored file.
+type DeletedFile struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Deleted bool   `json:"deleted"`
 }
 
 // ModerationParams is the request payload for POST /v1/moderations.

--- a/providers/types.go
+++ b/providers/types.go
@@ -274,6 +274,8 @@ type Function struct {
 	Name        string         `json:"name"`
 	Description string         `json:"description,omitempty"`
 	Parameters  map[string]any `json:"parameters,omitempty"`
+	// Strict requests schema-constrained function arguments when the provider supports it.
+	Strict *bool `json:"strict,omitempty"`
 }
 
 // FunctionCall represents the function being called.


### PR DESCRIPTION
## Summary

Add a normalized file lifecycle boundary and implement DeepSeek OpenAI-compatible file upload, pagination, metadata retrieval, and deletion. This is a Draft because live DeepSeek Files validation and exact-head CodeRabbit review remain unavailable.

## Changes

- Add typed `FileProvider`, file request/response types, and `Capabilities.Files`.
- Reuse the official openai-go Files transport in `CompatibleProvider`, with a capability guard for incompatible providers.
- Enforce DeepSeek `user_data`, expiration, pagination, order, purpose, and file-ID constraints before transport.
- Reject missing or malformed required response fields while accepting unknown fields.
- Preserve DeepSeek list metadata omitted by openai-go `CursorPage`.

This branch depends on the five dependency commits in Draft PR #141. Its five owning commits are in `a8fbfeee85de77133e967bd894c690138aac4079..35086beddde7c8053830724a9584344fd68523ee`. Production changes add 315 lines; direct contract and failure tests add 308 lines. The largest production commit adds 184 lines, and the test coverage is split into 154-line wire and 141-line failure commits.

## Current sources and SDK decision

- DeepSeek Files API: https://api-docs.deepseek.com/guides/files_api/
- Current formal openai-go release: v3.56.0, tag commit `f5b985771236464300abc9395c1c4abda0d65c53`
- Existing dependency: openai-go v3.42.0

No SDK upgrade is needed. The same Files contract tests pass with v3.0.0, the earliest v3 release carrying the used request/response fields, the existing v3.42.0, and current v3.56.0. DeepSeek documents multipart expiration as `expires_after[anchor]` and `expires_after[seconds]`; openai-go serializes the generated nested struct with dotted names, so the implementation uses the SDK extension-field API to send the documented bracketed names.

No Fantasy source, fixture, assertion sequence, or control flow was copied. The implementation follows the repository compatible-provider boundary and uses the official SDK transport.

## Testing

- `go test ./... -count=1`
- `CGO_ENABLED=1 go test -race ./providers/openai ./providers/deepseek -count=1`
- `go mod tidy -diff`
- `go mod verify`
- `golangci-lint run ./...` (`0 issues.`)
- Temporary modfile contract tests with openai-go v3.0.0 and v3.56.0
- `git diff --check`

Deletion ablations independently disabled compatible upload transport, DeepSeek purpose validation, list metadata mapping, and malformed-response validation. Their owning contract tests failed respectively, so those paths remain. No extra transport, pagination abstraction, or provider-specific SDK wrapper was retained.

Live file upload and image reuse remain unverified because no DeepSeek credential/model access is available. Server-enforced image format, 64 MiB size, ten-minute upload, quota, and storage constraints are therefore not claimed as verified.

## Checklist

- [x] Linting passes (`make lint` equivalent command above)
- [x] Tests pass locally (`make test` equivalent command above)
- [x] Documentation updated through exported API comments and divergence source comment
- [x] No breaking changes

AI assistance used GPT-5.6 Sol X-HIGH. All generated changes were reviewed and tested locally.
