### PR TITLE
feat(responses): add portable request and result normalization

### DIFF
--- a/anyllm.go
+++ b/anyllm.go
@@ -53,11 +53,14 @@ const (
 
 // ReasoningEffort levels.
 const (
-	ReasoningEffortAuto   = providers.ReasoningEffortAuto
-	ReasoningEffortHigh   = providers.ReasoningEffortHigh
-	ReasoningEffortLow    = providers.ReasoningEffortLow
-	ReasoningEffortMedium = providers.ReasoningEffortMedium
-	ReasoningEffortNone   = providers.ReasoningEffortNone
+	ReasoningEffortAuto    = providers.ReasoningEffortAuto
+	ReasoningEffortHigh    = providers.ReasoningEffortHigh
+	ReasoningEffortLow     = providers.ReasoningEffortLow
+	ReasoningEffortMax     = providers.ReasoningEffortMax
+	ReasoningEffortMedium  = providers.ReasoningEffortMedium
+	ReasoningEffortMinimal = providers.ReasoningEffortMinimal
+	ReasoningEffortNone    = providers.ReasoningEffortNone
+	ReasoningEffortXHigh   = providers.ReasoningEffortXHigh
 )
 
 // Provider types.
@@ -179,17 +182,17 @@ var (
 
 // Error types.
 type (
-	AuthenticationError           = errors.AuthenticationError
-	BaseError                     = errors.BaseError
-	ContentFilterError            = errors.ContentFilterError
-	ContextLengthError            = errors.ContextLengthError
-	InsufficientFundsError        = errors.InsufficientFundsError
-	InvalidRequestError           = errors.InvalidRequestError
-	MissingAPIKeyError            = errors.MissingAPIKeyError
-	ModelNotFoundError            = errors.ModelNotFoundError
-	ProviderError                 = errors.ProviderError
-	RateLimitError                = errors.RateLimitError
-	UnsupportedOperationError     = errors.UnsupportedOperationError
-	UnsupportedParamError         = errors.UnsupportedParamError
-	UnsupportedProviderError      = errors.UnsupportedProviderError
+	AuthenticationError       = errors.AuthenticationError
+	BaseError                 = errors.BaseError
+	ContentFilterError        = errors.ContentFilterError
+	ContextLengthError        = errors.ContextLengthError
+	InsufficientFundsError    = errors.InsufficientFundsError
+	InvalidRequestError       = errors.InvalidRequestError
+	MissingAPIKeyError        = errors.MissingAPIKeyError
+	ModelNotFoundError        = errors.ModelNotFoundError
+	ProviderError             = errors.ProviderError
+	RateLimitError            = errors.RateLimitError
+	UnsupportedOperationError = errors.UnsupportedOperationError
+	UnsupportedParamError     = errors.UnsupportedParamError
+	UnsupportedProviderError  = errors.UnsupportedProviderError
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/mozilla-ai/any-llm-platform-client-go v0.0.1
 	github.com/ollama/ollama v0.32.5
-	github.com/openai/openai-go v1.12.0
+	github.com/openai/openai-go/v3 v3.42.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/genai v1.66.0
 )

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/mozilla-ai/any-llm-platform-client-go v0.0.1 h1:AXmEYxIEIESUt2LyB6GFD
 github.com/mozilla-ai/any-llm-platform-client-go v0.0.1/go.mod h1:bqmvllQOUir9G2bmglRQDEgsfHCF6jAC339JGWkzH4U=
 github.com/ollama/ollama v0.32.5 h1:5jeKnTJmDTR+xgB8qh68szdXM9zwnMBMtGl890frdzo=
 github.com/ollama/ollama v0.32.5/go.mod h1:b1ydCt2oVg0VAg22WWDgCbwW0AyOaRKAFzlS91NI4OY=
-github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
-github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
+github.com/openai/openai-go/v3 v3.42.0 h1:16Skv1hpEhSm3imZpPGSeEBDUgVJJA9cHryKGGsVYI8=
+github.com/openai/openai-go/v3 v3.42.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/providers/deepseek/deepseek.go
+++ b/providers/deepseek/deepseek.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"slices"
 
-	oaisdk "github.com/openai/openai-go"
-	"github.com/openai/openai-go/packages/param"
+	oaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
@@ -160,17 +160,12 @@ func preprocessParams(params providers.CompletionParams) providers.CompletionPar
 	}
 }
 
-// transformRequest adjusts the OpenAI SDK request for DeepSeek's API.
-// DeepSeek uses max_tokens, not max_completion_tokens.
-// If both are set, MaxCompletionTokens takes precedence over MaxTokens.
-// See: https://api-docs.deepseek.com/api/create-chat-completion
+// transformRequest maps the shared token limit to DeepSeek's max_tokens field.
+// https://api-docs.deepseek.com/api/create-chat-completion
 func transformRequest(req *oaisdk.ChatCompletionNewParams) {
 	if req.MaxCompletionTokens.Valid() {
-		// Set max_tokens using max_completion_tokens value.
 		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
 	}
-
-	// Clear unsupported fields from the request.
 	req.MaxCompletionTokens = param.Opt[int64]{}
 }
 

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/v3"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/errors"
@@ -373,7 +373,7 @@ func capabilities() providers.Capabilities {
 		CompletionImage:     true,
 		CompletionPDF:       true,
 		CompletionReasoning: true,
-		CompletionStreaming:  true,
+		CompletionStreaming: true,
 		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
@@ -703,7 +703,9 @@ func (p *Provider) handleRerankErrorResponse(resp *http.Response) error {
 	case http.StatusTooManyRequests:
 		return errors.NewRateLimitError(providerName, fmt.Errorf("%s", msg))
 	case http.StatusBadGateway:
-		return &UpstreamProviderError{BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider)}
+		return &UpstreamProviderError{
+			BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider),
+		}
 	case http.StatusGatewayTimeout:
 		return &TimeoutError{BaseError: errors.New(errCodeTimeout, providerName, fmt.Errorf("%s", msg), ErrTimeout)}
 	default:

--- a/providers/mistral/mistral.go
+++ b/providers/mistral/mistral.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"slices"
 
-	oaisdk "github.com/openai/openai-go"
-	"github.com/openai/openai-go/packages/param"
+	oaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/providers"
@@ -141,17 +141,13 @@ func patchMessageParams(params providers.CompletionParams) providers.CompletionP
 	return params
 }
 
-// transformRequest adjusts the OpenAI SDK request for Mistral's API.
-// Mistral uses max_tokens (not max_completion_tokens) and does not accept user or reasoning_effort fields.
-// If both are set, MaxCompletionTokens takes precedence over MaxTokens.
-// See: https://docs.mistral.ai/api/#tag/chat/operation/chat_completion_v1_chat_completions_post
+// transformRequest maps the shared token limit to Mistral's max_tokens field
+// and removes fields outside its Chat request schema.
+// https://docs.mistral.ai/api?property=operation-chat_completion_v1_chat_completions_post_request_max_tokens
 func transformRequest(req *oaisdk.ChatCompletionNewParams) {
 	if req.MaxCompletionTokens.Valid() {
-		// Set max_tokens using max_completion_tokens value.
 		req.MaxTokens = oaisdk.Int(req.MaxCompletionTokens.Value)
 	}
-
-	// Clear unsupported fields from the request.
 	req.MaxCompletionTokens = param.Opt[int64]{}
 	req.User = param.Opt[string]{}
 	req.ReasoningEffort = ""

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -7,9 +7,9 @@ import (
 	stderrors "errors"
 	"fmt"
 
-	"github.com/openai/openai-go"
-	"github.com/openai/openai-go/option"
-	"github.com/openai/openai-go/shared"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/shared"
 
 	"github.com/mozilla-ai/any-llm-go/config"
 	"github.com/mozilla-ai/any-llm-go/errors"
@@ -328,13 +328,15 @@ func convertAPIError(name string, apiErr *openai.Error, originalErr error) error
 // convertAssistantMessage converts an assistant message to OpenAI format.
 func convertAssistantMessage(msg providers.Message) openai.ChatCompletionMessageParamUnion {
 	if len(msg.ToolCalls) > 0 {
-		toolCalls := make([]openai.ChatCompletionMessageToolCallParam, 0, len(msg.ToolCalls))
+		toolCalls := make([]openai.ChatCompletionMessageToolCallUnionParam, 0, len(msg.ToolCalls))
 		for _, tc := range msg.ToolCalls {
-			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallParam{
-				ID: tc.ID,
-				Function: openai.ChatCompletionMessageToolCallFunctionParam{
-					Name:      tc.Function.Name,
-					Arguments: tc.Function.Arguments,
+			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnionParam{
+				OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
+					ID: tc.ID,
+					Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
+						Name:      tc.Function.Name,
+						Arguments: tc.Function.Arguments,
+					},
 				},
 			})
 		}
@@ -380,13 +382,16 @@ func convertChunk(chunk *openai.ChatCompletionChunk) providers.ChatCompletionChu
 		choices = append(choices, chunkChoice)
 	}
 
+	// Preserve the existing normalized field even though the v3 SDK marks the
+	// documented response field as deprecated.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	result := providers.ChatCompletionChunk{
 		ID:                chunk.ID,
 		Object:            objectChatCompletionChunk,
 		Created:           chunk.Created,
 		Model:             chunk.Model,
 		Choices:           choices,
-		SystemFingerprint: chunk.SystemFingerprint,
+		SystemFingerprint: chunk.SystemFingerprint, //nolint:staticcheck
 	}
 
 	if chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0 {
@@ -570,13 +575,16 @@ func convertResponse(resp *openai.ChatCompletion) *providers.ChatCompletion {
 		})
 	}
 
+	// Preserve the existing normalized field even though the v3 SDK marks the
+	// documented response field as deprecated.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	result := &providers.ChatCompletion{
 		ID:                resp.ID,
 		Object:            objectChatCompletion,
 		Created:           resp.Created,
 		Model:             resp.Model,
 		Choices:           choices,
-		SystemFingerprint: resp.SystemFingerprint,
+		SystemFingerprint: resp.SystemFingerprint, //nolint:staticcheck
 	}
 
 	if resp.Usage.PromptTokens > 0 || resp.Usage.CompletionTokens > 0 {
@@ -658,7 +666,7 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 		}
 	case providers.ToolChoice:
 		if v.Function != nil {
-			return openai.ChatCompletionToolChoiceOptionParamOfChatCompletionNamedToolChoice(
+			return openai.ToolChoiceOptionFunctionToolChoice(
 				openai.ChatCompletionNamedToolChoiceFunctionParam{
 					Name: v.Function.Name,
 				},
@@ -671,14 +679,16 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 }
 
 // convertTools converts provider tools to OpenAI format.
-func convertTools(tools []providers.Tool) []openai.ChatCompletionToolParam {
-	result := make([]openai.ChatCompletionToolParam, 0, len(tools))
+func convertTools(tools []providers.Tool) []openai.ChatCompletionToolUnionParam {
+	result := make([]openai.ChatCompletionToolUnionParam, 0, len(tools))
 	for _, tool := range tools {
-		result = append(result, openai.ChatCompletionToolParam{
-			Function: openai.FunctionDefinitionParam{
-				Name:        tool.Function.Name,
-				Description: openai.String(tool.Function.Description),
-				Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+		result = append(result, openai.ChatCompletionToolUnionParam{
+			OfFunction: &openai.ChatCompletionFunctionToolParam{
+				Function: openai.FunctionDefinitionParam{
+					Name:        tool.Function.Name,
+					Description: openai.String(tool.Function.Description),
+					Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+				},
 			},
 		})
 	}

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -93,6 +93,7 @@ var (
 	_ providers.ErrorConverter     = (*CompatibleProvider)(nil)
 	_ providers.ModelLister        = (*CompatibleProvider)(nil)
 	_ providers.Provider           = (*CompatibleProvider)(nil)
+	_ providers.ResponsesProvider  = (*CompatibleProvider)(nil)
 )
 
 // CompatibleProvider implements the providers.Provider interface for OpenAI-compatible APIs.

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -689,13 +689,17 @@ func convertToolChoice(choice any) openai.ChatCompletionToolChoiceOptionUnionPar
 func convertTools(tools []providers.Tool) []openai.ChatCompletionToolUnionParam {
 	result := make([]openai.ChatCompletionToolUnionParam, 0, len(tools))
 	for _, tool := range tools {
+		function := openai.FunctionDefinitionParam{
+			Name:        tool.Function.Name,
+			Description: openai.String(tool.Function.Description),
+			Parameters:  openai.FunctionParameters(tool.Function.Parameters),
+		}
+		if tool.Function.Strict != nil {
+			function.Strict = openai.Bool(*tool.Function.Strict)
+		}
 		result = append(result, openai.ChatCompletionToolUnionParam{
 			OfFunction: &openai.ChatCompletionFunctionToolParam{
-				Function: openai.FunctionDefinitionParam{
-					Name:        tool.Function.Name,
-					Description: openai.String(tool.Function.Description),
-					Parameters:  openai.FunctionParameters(tool.Function.Parameters),
-				},
+				Function: function,
 			},
 		})
 	}

--- a/providers/openai/compatible.go
+++ b/providers/openai/compatible.go
@@ -517,6 +517,10 @@ func convertParams(params providers.CompletionParams) openai.ChatCompletionNewPa
 		req.TopP = openai.Float(*params.TopP)
 	}
 
+	// OpenAI documents max_completion_tokens as the replacement for the
+	// deprecated max_tokens field. Keep the binding's existing MaxTokens
+	// abstraction on the current wire field.
+	// https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create
 	if params.MaxTokens != nil {
 		req.MaxCompletionTokens = openai.Int(int64(*params.MaxTokens))
 	}
@@ -551,7 +555,10 @@ func convertParams(params providers.CompletionParams) openai.ChatCompletionNewPa
 		req.User = openai.String(params.User)
 	}
 
-	if params.ReasoningEffort != "" && params.ReasoningEffort != providers.ReasoningEffortNone {
+	// auto is the binding's omission sentinel. OpenAI documents none as an
+	// explicit value, so it must reach the wire unchanged.
+	// https://developers.openai.com/api/docs/guides/latest-model
+	if params.ReasoningEffort != "" && params.ReasoningEffort != providers.ReasoningEffortAuto {
 		req.ReasoningEffort = shared.ReasoningEffort(params.ReasoningEffort)
 	}
 

--- a/providers/openai/compatible_test.go
+++ b/providers/openai/compatible_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -313,6 +314,42 @@ func TestConvertResponseFormat(t *testing.T) {
 		result := convertResponseFormat(format)
 		require.NotNil(t, result.OfText)
 	})
+}
+
+func TestConvertToolsPreservesStrict(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		strict *bool
+	}{
+		{name: "omitted"},
+		{name: "false", strict: new(false)},
+		{name: "true", strict: new(true)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tools := convertTools([]providers.Tool{{
+				Type: "function",
+				Function: providers.Function{
+					Name:       "lookup",
+					Parameters: map[string]any{"type": "object"},
+					Strict:     tc.strict,
+				},
+			}})
+			body, err := json.Marshal(tools)
+			require.NoError(t, err)
+
+			var wire []struct {
+				Function struct {
+					Strict *bool `json:"strict"`
+				} `json:"function"`
+			}
+			require.NoError(t, json.Unmarshal(body, &wire))
+			require.Equal(t, tc.strict, wire[0].Function.Strict)
+		})
+	}
 }
 
 func TestConvertEmbeddingParams(t *testing.T) {

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -9,6 +9,7 @@ import (
 const (
 	defaultBaseURL = "https://api.openai.com/v1"
 	envAPIKey      = "OPENAI_API_KEY"
+	envBaseURL     = "OPENAI_BASE_URL"
 	providerName   = "openai"
 )
 
@@ -31,6 +32,7 @@ type Provider struct {
 func New(opts ...config.Option) (*Provider, error) {
 	base, err := NewCompatible(CompatibleConfig{
 		APIKeyEnvVar:   envAPIKey,
+		BaseURLEnvVar:  envBaseURL,
 		Capabilities:   capabilities(),
 		DefaultBaseURL: defaultBaseURL,
 		Name:           providerName,

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -34,6 +34,21 @@ func TestNew(t *testing.T) {
 		require.NotNil(t, provider)
 	})
 
+	t.Run("reads OPENAI_BASE_URL", func(t *testing.T) {
+		serverURL, _ := testutil.FakeCompletionServer(t)
+		t.Setenv("OPENAI_API_KEY", "env-api-key")
+		t.Setenv("OPENAI_BASE_URL", serverURL)
+
+		provider, err := New()
+		require.NoError(t, err)
+
+		_, err = provider.Completion(t.Context(), providers.CompletionParams{
+			Model:    "test-model",
+			Messages: testutil.SimpleMessages(),
+		})
+		require.NoError(t, err)
+	})
+
 	t.Run("returns error when API key is missing", func(t *testing.T) {
 		t.Setenv("OPENAI_API_KEY", "")
 

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -116,7 +116,7 @@ func TestConvertParams(t *testing.T) {
 		require.Equal(t, 0.9, req.TopP.Value)
 	})
 
-	t.Run("converts max_tokens", func(t *testing.T) {
+	t.Run("maps token limit to max_completion_tokens", func(t *testing.T) {
 		t.Parallel()
 
 		maxTokens := 100
@@ -128,6 +128,7 @@ func TestConvertParams(t *testing.T) {
 
 		req := convertParams(params)
 
+		require.False(t, req.MaxTokens.Valid())
 		require.Equal(t, int64(100), req.MaxCompletionTokens.Value)
 	})
 
@@ -223,18 +224,43 @@ func TestConvertParams(t *testing.T) {
 		require.NotNil(t, req.ResponseFormat)
 	})
 
-	t.Run("converts reasoning_effort", func(t *testing.T) {
+	t.Run("preserves current reasoning_effort values", func(t *testing.T) {
+		t.Parallel()
+
+		efforts := []providers.ReasoningEffort{
+			providers.ReasoningEffortNone,
+			providers.ReasoningEffortMinimal,
+			providers.ReasoningEffortLow,
+			providers.ReasoningEffortMedium,
+			providers.ReasoningEffortHigh,
+			providers.ReasoningEffortXHigh,
+			providers.ReasoningEffortMax,
+		}
+		for _, effort := range efforts {
+			params := providers.CompletionParams{
+				Model:           "test-model",
+				Messages:        testutil.SimpleMessages(),
+				ReasoningEffort: effort,
+			}
+
+			req := convertParams(params)
+
+			require.Equal(t, string(effort), string(req.ReasoningEffort))
+		}
+	})
+
+	t.Run("omits automatic reasoning_effort sentinel", func(t *testing.T) {
 		t.Parallel()
 
 		params := providers.CompletionParams{
-			Model:           "o1-mini",
+			Model:           "test-model",
 			Messages:        testutil.SimpleMessages(),
-			ReasoningEffort: providers.ReasoningEffortHigh,
+			ReasoningEffort: providers.ReasoningEffortAuto,
 		}
 
 		req := convertParams(params)
 
-		require.NotNil(t, req.ReasoningEffort)
+		require.Empty(t, req.ReasoningEffort)
 	})
 
 	t.Run("converts seed", func(t *testing.T) {
@@ -487,10 +513,33 @@ func TestCompletionSendsMaxCompletionTokensOnWire(t *testing.T) {
 
 	body := capturedBody()
 
-	// OpenAI requires max_completion_tokens (not max_tokens) for current models.
 	require.Contains(t, body, "max_completion_tokens")
 	require.NotContains(t, body, "max_tokens")
 	require.Equal(t, float64(1024), body["max_completion_tokens"])
+}
+
+func TestCompletionPreservesReasoningEffortOnWire(t *testing.T) {
+	t.Parallel()
+
+	serverURL, capturedBody := testutil.FakeCompletionServer(t)
+
+	provider, err := New(
+		config.WithAPIKey("test-key"),
+		config.WithBaseURL(serverURL),
+	)
+	require.NoError(t, err)
+
+	params := providers.CompletionParams{
+		Model:           "test-model",
+		Messages:        testutil.SimpleMessages(),
+		ReasoningEffort: providers.ReasoningEffortNone,
+	}
+
+	_, err = provider.Completion(context.Background(), params)
+	require.NoError(t, err)
+
+	body := capturedBody()
+	require.Equal(t, "none", body["reasoning_effort"])
 }
 
 func TestCompletionStreamSendsMaxCompletionTokensOnWire(t *testing.T) {
@@ -520,7 +569,6 @@ func TestCompletionStreamSendsMaxCompletionTokensOnWire(t *testing.T) {
 
 	body := capturedBody()
 
-	// OpenAI requires max_completion_tokens (not max_tokens) for current models.
 	require.Contains(t, body, "max_completion_tokens")
 	require.NotContains(t, body, "max_tokens")
 	require.Equal(t, float64(1024), body["max_completion_tokens"])

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mozilla-ai/any-llm-go/config"
@@ -362,11 +362,16 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 1)
-		require.Equal(t, "get_weather", result[0].Function.Name)
-		require.Equal(t, "Get the current weather for a location.", result[0].Function.Description.Value)
+		require.NotNil(t, result[0].OfFunction)
+		require.Equal(t, "get_weather", result[0].OfFunction.Function.Name)
+		require.Equal(
+			t,
+			"Get the current weather for a location.",
+			result[0].OfFunction.Function.Description.Value,
+		)
 
 		// FunctionParameters is map[string]any - access directly.
-		params := result[0].Function.Parameters
+		params := result[0].OfFunction.Function.Parameters
 		require.Equal(t, "object", params["type"])
 
 		props, ok := params["properties"].(map[string]any)
@@ -391,10 +396,11 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 1)
-		require.Equal(t, "calculate", result[0].Function.Name)
+		require.NotNil(t, result[0].OfFunction)
+		require.Equal(t, "calculate", result[0].OfFunction.Function.Name)
 
 		// FunctionParameters is map[string]any - access directly.
-		params := result[0].Function.Parameters
+		params := result[0].OfFunction.Function.Parameters
 
 		props, ok := params["properties"].(map[string]any)
 		require.True(t, ok)
@@ -436,8 +442,10 @@ func TestConvertTools(t *testing.T) {
 		result := convertTools(tools)
 
 		require.Len(t, result, 2)
-		require.Equal(t, "get_weather", result[0].Function.Name)
-		require.Equal(t, "get_current_date", result[1].Function.Name)
+		require.NotNil(t, result[0].OfFunction)
+		require.NotNil(t, result[1].OfFunction)
+		require.Equal(t, "get_weather", result[0].OfFunction.Function.Name)
+		require.Equal(t, "get_current_date", result[1].OfFunction.Function.Name)
 	})
 }
 

--- a/providers/openai/responses.go
+++ b/providers/openai/responses.go
@@ -2,12 +2,16 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
+	openaisdk "github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
 
 	"github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
 )
 
 // CreateResponse sends the official SDK request without narrowing its input,
@@ -26,6 +30,25 @@ func (p *CompatibleProvider) CreateResponse(
 	}
 
 	return resp, nil
+}
+
+// Responses sends the portable request subset and normalizes common output
+// items. CreateResponse remains available for the complete SDK surface.
+func (p *CompatibleProvider) Responses(
+	ctx context.Context,
+	params providers.ResponsesParams,
+) (*providers.ResponsesResult, error) {
+	req, err := convertResponsesParams(p.Name(), params)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := p.CreateResponse(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return normalizeResponse(p.Name(), resp)
 }
 
 // StreamResponse exposes each typed SDK event. A stream that ends without a
@@ -94,6 +117,143 @@ func (p *CompatibleProvider) requireCapability(enabled bool, operation string) e
 	}
 
 	return errors.NewUnsupportedOperationError(p.Name(), operation, nil)
+}
+
+func convertResponsesParams(
+	providerName string,
+	params providers.ResponsesParams,
+) (responses.ResponseNewParams, error) {
+	req := responses.ResponseNewParams{Model: shared.ResponsesModel(params.Model)}
+	if len(params.Input) > 0 {
+		items := make(responses.ResponseInputParam, 0, len(params.Input))
+		for _, item := range params.Input {
+			var role responses.EasyInputMessageRole
+			switch item.Role {
+			case providers.ResponsesInputRoleAssistant:
+				role = responses.EasyInputMessageRoleAssistant
+			case providers.ResponsesInputRoleDeveloper:
+				role = responses.EasyInputMessageRoleDeveloper
+			case providers.ResponsesInputRoleSystem:
+				role = responses.EasyInputMessageRoleSystem
+			case providers.ResponsesInputRoleUser:
+				role = responses.EasyInputMessageRoleUser
+			default:
+				return responses.ResponseNewParams{}, errors.NewInvalidRequestError(
+					providerName,
+					fmt.Errorf("unsupported Responses role %q", item.Role),
+				)
+			}
+			items = append(items, responses.ResponseInputItemParamOfMessage(item.Content, role))
+		}
+		req.Input = responses.ResponseNewParamsInputUnion{OfInputItemList: items}
+	}
+
+	if params.Instructions != nil {
+		req.Instructions = openaisdk.String(*params.Instructions)
+	}
+	if params.MaxOutputTokens != nil {
+		req.MaxOutputTokens = openaisdk.Int(int64(*params.MaxOutputTokens))
+	}
+	if params.ReasoningEffort != "" && params.ReasoningEffort != providers.ReasoningEffortAuto {
+		// OpenAI documents this complete API-wide set. Individual models can
+		// support a subset and remain responsible for model-specific validation.
+		// https://developers.openai.com/api/reference/resources/responses/methods/create
+		switch params.ReasoningEffort {
+		case providers.ReasoningEffortNone,
+			providers.ReasoningEffortMinimal,
+			providers.ReasoningEffortLow,
+			providers.ReasoningEffortMedium,
+			providers.ReasoningEffortHigh,
+			providers.ReasoningEffortXHigh,
+			providers.ReasoningEffortMax:
+		default:
+			return responses.ResponseNewParams{}, errors.NewUnsupportedParamError(
+				providerName,
+				"reasoning_effort",
+			)
+		}
+		req.Reasoning = shared.ReasoningParam{
+			Effort: shared.ReasoningEffort(params.ReasoningEffort),
+		}
+	}
+
+	return req, nil
+}
+
+func normalizeResponse(providerName string, resp *responses.Response) (*providers.ResponsesResult, error) {
+	if !resp.JSON.ID.Valid() || !resp.JSON.Model.Valid() || !resp.JSON.Object.Valid() ||
+		resp.Object != "response" || !resp.JSON.Output.Valid() {
+		return nil, errors.NewProviderError(providerName, fmt.Errorf("malformed Responses API result"))
+	}
+
+	result := &providers.ResponsesResult{
+		ID:     resp.ID,
+		Model:  string(resp.Model),
+		Status: string(resp.Status),
+		// A valid response can contain only tool or reasoning output.
+		OutputText:  resp.OutputText(),
+		OutputItems: normalizeResponseOutput(resp.Output),
+		ProviderRaw: json.RawMessage(resp.RawJSON()),
+	}
+	if resp.JSON.Error.Valid() {
+		result.Error = &providers.ResponsesError{
+			Code:        string(resp.Error.Code),
+			Message:     resp.Error.Message,
+			ProviderRaw: json.RawMessage(resp.Error.RawJSON()),
+		}
+	}
+	if resp.JSON.IncompleteDetails.Valid() {
+		result.IncompleteDetails = &providers.ResponsesIncompleteDetails{
+			Reason:      resp.IncompleteDetails.Reason,
+			ProviderRaw: json.RawMessage(resp.IncompleteDetails.RawJSON()),
+		}
+	}
+	if resp.JSON.Usage.Valid() {
+		result.Usage = &providers.ResponsesUsage{
+			InputTokens:     int(resp.Usage.InputTokens),
+			OutputTokens:    int(resp.Usage.OutputTokens),
+			TotalTokens:     int(resp.Usage.TotalTokens),
+			CachedTokens:    int(resp.Usage.InputTokensDetails.CachedTokens),
+			ReasoningTokens: int(resp.Usage.OutputTokensDetails.ReasoningTokens),
+		}
+	}
+
+	return result, nil
+}
+
+func normalizeResponseOutput(items []responses.ResponseOutputItemUnion) []providers.ResponsesOutputItem {
+	result := make([]providers.ResponsesOutputItem, 0, len(items))
+	for _, item := range items {
+		out := providers.ResponsesOutputItem{
+			Type:        item.Type,
+			ID:          item.ID,
+			Status:      item.Status,
+			ProviderRaw: json.RawMessage(item.RawJSON()),
+		}
+		switch item.Type {
+		case "message":
+			for _, content := range item.Content {
+				out.Content = append(out.Content, providers.ResponsesOutputContent{
+					Type:        content.Type,
+					Text:        content.Text,
+					Refusal:     content.Refusal,
+					ProviderRaw: json.RawMessage(content.RawJSON()),
+				})
+			}
+		case "function_call":
+			call := item.AsFunctionCall()
+			out.Name = call.Name
+			out.CallID = call.CallID
+			out.Arguments = call.Arguments
+		case "reasoning":
+			for _, summary := range item.Summary {
+				out.Summary = append(out.Summary, summary.Text)
+			}
+		}
+		result = append(result, out)
+	}
+
+	return result
 }
 
 func reportResponseStreamError(errs chan<- error, err error) {

--- a/providers/openai/responses.go
+++ b/providers/openai/responses.go
@@ -1,0 +1,104 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/openai/openai-go/v3/responses"
+
+	"github.com/mozilla-ai/any-llm-go/errors"
+)
+
+// CreateResponse sends the official SDK request without narrowing its input,
+// tool, structured-output, or provider extension unions.
+func (p *CompatibleProvider) CreateResponse(
+	ctx context.Context,
+	params responses.ResponseNewParams,
+) (*responses.Response, error) {
+	if err := p.requireCapability(p.Capabilities().Responses, "responses"); err != nil {
+		return nil, err
+	}
+
+	resp, err := p.client.Responses.New(ctx, params)
+	if err != nil {
+		return nil, p.ConvertError(err)
+	}
+
+	return resp, nil
+}
+
+// StreamResponse exposes each typed SDK event. A stream that ends without a
+// documented terminal lifecycle event is reported as truncated.
+func (p *CompatibleProvider) StreamResponse(
+	ctx context.Context,
+	params responses.ResponseNewParams,
+) (<-chan responses.ResponseStreamEventUnion, <-chan error) {
+	events := make(chan responses.ResponseStreamEventUnion)
+	errs := make(chan error, 1)
+
+	go func() {
+		defer close(events)
+		defer close(errs)
+
+		if err := p.requireCapability(p.Capabilities().ResponsesStreaming, "responses streaming"); err != nil {
+			reportResponseStreamError(errs, err)
+			return
+		}
+
+		stream := p.client.Responses.NewStreaming(ctx, params)
+		defer func() {
+			if err := stream.Close(); err != nil {
+				reportResponseStreamError(errs, p.ConvertError(err))
+			}
+		}()
+
+		terminal := false
+		for stream.Next() {
+			event := stream.Current()
+			switch event.Type {
+			case "response.completed", "response.incomplete", "response.failed":
+				terminal = true
+			}
+
+			select {
+			case events <- event:
+			case <-ctx.Done():
+				reportResponseStreamError(errs, ctx.Err())
+				return
+			}
+		}
+
+		if err := ctx.Err(); err != nil {
+			reportResponseStreamError(errs, err)
+			return
+		}
+		if err := stream.Err(); err != nil {
+			reportResponseStreamError(errs, p.ConvertError(err))
+			return
+		}
+		if !terminal {
+			reportResponseStreamError(errs, p.ConvertError(fmt.Errorf(
+				"response stream ended without a terminal event: %w",
+				io.ErrUnexpectedEOF,
+			)))
+		}
+	}()
+
+	return events, errs
+}
+
+func (p *CompatibleProvider) requireCapability(enabled bool, operation string) error {
+	if enabled {
+		return nil
+	}
+
+	return errors.NewUnsupportedOperationError(p.Name(), operation, nil)
+}
+
+func reportResponseStreamError(errs chan<- error, err error) {
+	select {
+	case errs <- err:
+	default:
+	}
+}

--- a/providers/openai/responses_normalized_test.go
+++ b/providers/openai/responses_normalized_test.go
@@ -1,0 +1,136 @@
+package openai
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+const normalizedResponseFixture = `{
+  "id":"resp_123",
+  "object":"response",
+  "created_at":1,
+  "model":"gpt-5.6-sol",
+  "status":"completed",
+  "output":[
+    {
+      "type":"message",
+      "id":"msg_1",
+      "status":"completed",
+      "role":"assistant",
+      "content":[
+        {"type":"output_text","text":"hello","annotations":[],"logprobs":[]},
+        {"type":"refusal","refusal":"cannot"}
+      ]
+    },
+    {
+      "type":"function_call",
+      "id":"call_1",
+      "status":"completed",
+      "call_id":"tool_1",
+      "name":"lookup",
+      "arguments":"{\"id\":1}"
+    },
+    {
+      "type":"reasoning",
+      "id":"reason_1",
+      "status":"completed",
+      "summary":[{"type":"summary_text","text":"checked"}]
+    },
+    {"type":"future_item","id":"future_1","vendor_field":true}
+  ],
+  "usage":{
+    "input_tokens":10,
+    "input_tokens_details":{"cached_tokens":3},
+    "output_tokens":5,
+    "output_tokens_details":{"reasoning_tokens":2},
+    "total_tokens":15
+  },
+  "future_envelope":"preserved"
+}`
+
+func TestResponsesPreservesPortableWireAndStructuredOutput(t *testing.T) {
+	t.Parallel()
+
+	var requestBody json.RawMessage
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v1/responses", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&requestBody))
+		w.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(w, normalizedResponseFixture)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewCompatible(CompatibleConfig{
+		Capabilities:   providers.Capabilities{Responses: true},
+		DefaultAPIKey:  "test-key",
+		DefaultBaseURL: server.URL + "/v1",
+		Name:           "test-provider",
+	})
+	require.NoError(t, err)
+
+	result, err := provider.Responses(t.Context(), providers.ResponsesParams{
+		Input: []providers.ResponsesInputItem{
+			{Role: providers.ResponsesInputRoleDeveloper, Content: "developer"},
+			{Role: providers.ResponsesInputRoleSystem, Content: "system"},
+			{Role: providers.ResponsesInputRoleUser, Content: "user"},
+			{Role: providers.ResponsesInputRoleAssistant, Content: "assistant"},
+		},
+		Instructions:    new(""),
+		MaxOutputTokens: new(123),
+		Model:           "gpt-5.6-sol",
+		ReasoningEffort: providers.ReasoningEffortNone,
+	})
+	require.NoError(t, err)
+
+	require.JSONEq(t, `{
+      "input":[
+        {"role":"developer","content":"developer"},
+        {"role":"system","content":"system"},
+        {"role":"user","content":"user"},
+        {"role":"assistant","content":"assistant"}
+      ],
+      "instructions":"",
+      "max_output_tokens":123,
+      "model":"gpt-5.6-sol",
+      "reasoning":{"effort":"none"}
+    }`, string(requestBody))
+	require.Equal(t, "resp_123", result.ID)
+	require.Equal(t, "gpt-5.6-sol", result.Model)
+	require.Equal(t, "completed", result.Status)
+	require.Equal(t, "hello", result.OutputText)
+	require.Equal(t, &providers.ResponsesUsage{
+		InputTokens:     10,
+		OutputTokens:    5,
+		TotalTokens:     15,
+		CachedTokens:    3,
+		ReasoningTokens: 2,
+	}, result.Usage)
+	require.Len(t, result.OutputItems, 4)
+	require.Len(t, result.OutputItems[0].Content, 2)
+	require.Equal(t, "output_text", result.OutputItems[0].Content[0].Type)
+	require.Equal(t, "hello", result.OutputItems[0].Content[0].Text)
+	require.JSONEq(t,
+		`{"type":"output_text","text":"hello","annotations":[],"logprobs":[]}`,
+		string(result.OutputItems[0].Content[0].ProviderRaw),
+	)
+	require.Equal(t, "refusal", result.OutputItems[0].Content[1].Type)
+	require.Equal(t, "cannot", result.OutputItems[0].Content[1].Refusal)
+	require.Equal(t, "lookup", result.OutputItems[1].Name)
+	require.Equal(t, "tool_1", result.OutputItems[1].CallID)
+	require.JSONEq(t, `{"id":1}`, result.OutputItems[1].Arguments)
+	require.Equal(t, []string{"checked"}, result.OutputItems[2].Summary)
+	require.JSONEq(t,
+		`{"type":"future_item","id":"future_1","vendor_field":true}`,
+		string(result.OutputItems[3].ProviderRaw),
+	)
+	require.Contains(t, string(result.ProviderRaw), `"future_envelope":"preserved"`)
+}

--- a/providers/openai/responses_normalized_validation_test.go
+++ b/providers/openai/responses_normalized_validation_test.go
@@ -1,0 +1,183 @@
+package openai
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	anyerrors "github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+func TestConvertResponsesParamsPreservesOptionalFieldsAndReasoning(t *testing.T) {
+	t.Parallel()
+
+	req, err := convertResponsesParams("test-provider", providers.ResponsesParams{})
+	require.NoError(t, err)
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+	require.JSONEq(t, `{}`, string(body))
+
+	req, err = convertResponsesParams("test-provider", providers.ResponsesParams{
+		ReasoningEffort: providers.ReasoningEffortAuto,
+	})
+	require.NoError(t, err)
+	body, err = json.Marshal(req)
+	require.NoError(t, err)
+	require.JSONEq(t, `{}`, string(body))
+
+	for _, effort := range []providers.ReasoningEffort{
+		providers.ReasoningEffortNone,
+		providers.ReasoningEffortMinimal,
+		providers.ReasoningEffortLow,
+		providers.ReasoningEffortMedium,
+		providers.ReasoningEffortHigh,
+		providers.ReasoningEffortXHigh,
+		providers.ReasoningEffortMax,
+	} {
+		t.Run(string(effort), func(t *testing.T) {
+			t.Parallel()
+
+			params, convertErr := convertResponsesParams("test-provider", providers.ResponsesParams{
+				ReasoningEffort: effort,
+			})
+			require.NoError(t, convertErr)
+			encoded, marshalErr := json.Marshal(params)
+			require.NoError(t, marshalErr)
+			require.JSONEq(t, `{"reasoning":{"effort":"`+string(effort)+`"}}`, string(encoded))
+		})
+	}
+}
+
+func TestResponsesRejectsUnsupportedOrInvalidPortableRequests(t *testing.T) {
+	t.Parallel()
+
+	unsupported, err := NewCompatible(CompatibleConfig{Name: "unsupported"})
+	require.NoError(t, err)
+	result, err := unsupported.Responses(t.Context(), providers.ResponsesParams{})
+	require.Nil(t, result)
+	require.ErrorIs(t, err, anyerrors.ErrUnsupported)
+
+	provider, err := NewCompatible(CompatibleConfig{
+		Capabilities: providers.Capabilities{Responses: true},
+		Name:         "test-provider",
+	})
+	require.NoError(t, err)
+
+	result, err = provider.Responses(t.Context(), providers.ResponsesParams{
+		Input: []providers.ResponsesInputItem{{Role: "unknown"}},
+	})
+	require.Nil(t, result)
+	require.ErrorIs(t, err, anyerrors.ErrInvalidRequest)
+
+	result, err = provider.Responses(t.Context(), providers.ResponsesParams{
+		ReasoningEffort: providers.ReasoningEffort("turbo"),
+	})
+	require.Nil(t, result)
+	require.ErrorIs(t, err, anyerrors.ErrUnsupportedParam)
+}
+
+func TestResponsesPreservesTerminalStatusDetails(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name              string
+		fixture           string
+		wantStatus        string
+		wantError         *providers.ResponsesError
+		wantIncomplete    *providers.ResponsesIncompleteDetails
+		wantProviderError bool
+	}{
+		{
+			name:       "empty completed output is valid",
+			fixture:    `{"id":"resp_123","object":"response","model":"gpt-5.6-sol","status":"completed","output":[]}`,
+			wantStatus: "completed",
+		},
+		{
+			name:       "failed response carries its API error",
+			fixture:    `{"id":"resp_123","object":"response","model":"gpt-5.6-sol","status":"failed","error":{"code":"server_error","message":"generation failed","trace_id":"trace_1"},"output":[]}`,
+			wantStatus: "failed",
+			wantError: &providers.ResponsesError{
+				Code:    "server_error",
+				Message: "generation failed",
+			},
+		},
+		{
+			name:           "incomplete response carries its reason",
+			fixture:        `{"id":"resp_123","object":"response","model":"gpt-5.6-sol","status":"incomplete","incomplete_details":{"reason":"max_output_tokens","future_detail":true},"output":[]}`,
+			wantStatus:     "incomplete",
+			wantIncomplete: &providers.ResponsesIncompleteDetails{Reason: "max_output_tokens"},
+		},
+		{
+			name:       "cancelled response remains inspectable",
+			fixture:    `{"id":"resp_123","object":"response","model":"gpt-5.6-sol","status":"cancelled","output":[]}`,
+			wantStatus: "cancelled",
+		},
+		{
+			name:       "omitted optional status remains inspectable",
+			fixture:    `{"id":"resp_123","object":"response","model":"gpt-5.6-sol","output":[]}`,
+			wantStatus: "",
+		},
+		{
+			name:              "missing response identity and output is malformed",
+			fixture:           `{"id":"resp_123","model":"gpt-5.6-sol"}`,
+			wantProviderError: true,
+		},
+		{
+			name:              "wrong object type is malformed",
+			fixture:           `{"id":"resp_123","object":"chat.completion","model":"gpt-5.6-sol","output":[]}`,
+			wantProviderError: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, writeErr := io.WriteString(w, tc.fixture)
+				require.NoError(t, writeErr)
+			}))
+			t.Cleanup(server.Close)
+
+			provider, err := NewCompatible(CompatibleConfig{
+				Capabilities:   providers.Capabilities{Responses: true},
+				DefaultAPIKey:  "test-key",
+				DefaultBaseURL: server.URL + "/v1",
+				Name:           "test-provider",
+			})
+			require.NoError(t, err)
+
+			result, err := provider.Responses(t.Context(), providers.ResponsesParams{})
+			if tc.wantProviderError {
+				require.Nil(t, result)
+				require.ErrorIs(t, err, anyerrors.ErrProvider)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantStatus, result.Status)
+			require.Empty(t, result.OutputText)
+			require.Empty(t, result.OutputItems)
+			require.Nil(t, result.Usage)
+			if tc.wantError == nil {
+				require.Nil(t, result.Error)
+			} else {
+				require.NotNil(t, result.Error)
+				require.Equal(t, tc.wantError.Code, result.Error.Code)
+				require.Equal(t, tc.wantError.Message, result.Error.Message)
+				require.Contains(t, string(result.Error.ProviderRaw), `"trace_id":"trace_1"`)
+			}
+			if tc.wantIncomplete == nil {
+				require.Nil(t, result.IncompleteDetails)
+			} else {
+				require.NotNil(t, result.IncompleteDetails)
+				require.Equal(t, tc.wantIncomplete.Reason, result.IncompleteDetails.Reason)
+				require.Contains(t, string(result.IncompleteDetails.ProviderRaw), `"future_detail":true`)
+			}
+		})
+	}
+}

--- a/providers/openai/responses_test.go
+++ b/providers/openai/responses_test.go
@@ -1,0 +1,226 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	openaisdk "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/require"
+
+	anyerrors "github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+const responseFixture = `{"id":"resp_123","object":"response","created_at":1,"model":"gpt-5.6-sol","status":"completed","output":[]}`
+
+func TestCreateResponsePreservesSDKParamsAndCapability(t *testing.T) {
+	t.Parallel()
+
+	unsupported, err := NewCompatible(CompatibleConfig{Name: "unsupported"})
+	require.NoError(t, err)
+	got, err := unsupported.CreateResponse(t.Context(), responses.ResponseNewParams{})
+	require.Nil(t, got)
+	var unsupportedErr *anyerrors.UnsupportedOperationError
+	require.ErrorAs(t, err, &unsupportedErr)
+	events, errs := unsupported.StreamResponse(t.Context(), responses.ResponseNewParams{})
+	require.Empty(t, events)
+	require.ErrorAs(t, <-errs, &unsupportedErr)
+
+	var request map[string]json.RawMessage
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v1/responses", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		w.Header().Set("Content-Type", "application/json")
+		_, writeErr := io.WriteString(w, responseFixture)
+		require.NoError(t, writeErr)
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewCompatible(CompatibleConfig{
+		Capabilities:   providers.Capabilities{Responses: true},
+		DefaultAPIKey:  "test-key",
+		DefaultBaseURL: server.URL + "/v1",
+		Name:           "test-provider",
+	})
+	require.NoError(t, err)
+
+	resp, err := provider.CreateResponse(t.Context(), responses.ResponseNewParams{
+		Instructions: openaisdk.String("native"),
+		Temperature:  openaisdk.Float(0.25),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "resp_123", resp.ID)
+	require.Contains(t, request, "instructions")
+	require.Contains(t, request, "temperature")
+	require.NotContains(t, request, "input")
+	require.NotContains(t, request, "model")
+}
+
+func TestStreamResponsePreservesEventsAndTerminalStates(t *testing.T) {
+	t.Parallel()
+
+	for _, terminal := range []string{"response.completed", "response.incomplete", "response.failed"} {
+		t.Run(terminal, func(t *testing.T) {
+			t.Parallel()
+
+			var request map[string]json.RawMessage
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, err := io.WriteString(w,
+					"data: {\"type\":\"future.event\",\"sequence_number\":1,\"future_field\":true}\n\n"+
+						"data: {\"type\":\""+terminal+"\",\"sequence_number\":2,\"response\":"+responseFixture+"}\n\n",
+				)
+				require.NoError(t, err)
+			}))
+			t.Cleanup(server.Close)
+
+			provider, err := NewCompatible(CompatibleConfig{
+				Capabilities:   providers.Capabilities{ResponsesStreaming: true},
+				DefaultAPIKey:  "test-key",
+				DefaultBaseURL: server.URL + "/v1",
+				Name:           "test-provider",
+			})
+			require.NoError(t, err)
+
+			events, errs := provider.StreamResponse(t.Context(), responses.ResponseNewParams{})
+			var types []string
+			for event := range events {
+				types = append(types, event.Type)
+				if event.Type == "future.event" {
+					require.Contains(t, event.RawJSON(), `"future_field":true`)
+				}
+			}
+			require.NoError(t, <-errs)
+			require.Equal(t, []string{"future.event", terminal}, types)
+			require.JSONEq(t, `true`, string(request["stream"]))
+		})
+	}
+}
+
+func TestStreamResponseReportsTruncationAndCancellation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("clean EOF without terminal event", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, err := io.WriteString(w, "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n")
+			require.NoError(t, err)
+		}))
+		t.Cleanup(server.Close)
+
+		provider, err := NewCompatible(CompatibleConfig{
+			Capabilities:   providers.Capabilities{ResponsesStreaming: true},
+			DefaultAPIKey:  "test-key",
+			DefaultBaseURL: server.URL + "/v1",
+			Name:           "test-provider",
+		})
+		require.NoError(t, err)
+
+		events, errs := provider.StreamResponse(t.Context(), responses.ResponseNewParams{})
+		for range events {
+		}
+		require.ErrorIs(t, <-errs, io.ErrUnexpectedEOF)
+	})
+
+	t.Run("caller cancellation", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			<-r.Context().Done()
+		}))
+		t.Cleanup(server.Close)
+
+		provider, err := NewCompatible(CompatibleConfig{
+			Capabilities:   providers.Capabilities{ResponsesStreaming: true},
+			DefaultAPIKey:  "test-key",
+			DefaultBaseURL: server.URL + "/v1",
+			Name:           "test-provider",
+		})
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancel()
+		events, errs := provider.StreamResponse(ctx, responses.ResponseNewParams{})
+		for range events {
+		}
+		require.ErrorIs(t, <-errs, context.DeadlineExceeded)
+	})
+}
+
+func TestResponseTransportMapsAPIErrors(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, err := io.WriteString(
+			w,
+			`{"error":{"message":"slow down","type":"rate_limit_error","code":"rate_limit_exceeded"}}`,
+		)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := NewCompatible(CompatibleConfig{
+		Capabilities: providers.Capabilities{
+			Responses:          true,
+			ResponsesStreaming: true,
+		},
+		DefaultAPIKey:  "test-key",
+		DefaultBaseURL: server.URL + "/v1",
+		Name:           "test-provider",
+	})
+	require.NoError(t, err)
+
+	resp, err := provider.CreateResponse(t.Context(), responses.ResponseNewParams{})
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, anyerrors.ErrRateLimit)
+
+	events, errs := provider.StreamResponse(t.Context(), responses.ResponseNewParams{})
+	for range events {
+	}
+	require.ErrorIs(t, <-errs, anyerrors.ErrRateLimit)
+}
+
+func TestCreateResponseHonorsCallerTimeout(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(release) })
+
+	provider, err := NewCompatible(CompatibleConfig{
+		Capabilities:   providers.Capabilities{Responses: true},
+		DefaultAPIKey:  "test-key",
+		DefaultBaseURL: server.URL + "/v1",
+		Name:           "test-provider",
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	result, err := provider.CreateResponse(ctx, responses.ResponseNewParams{})
+	require.Nil(t, result)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}

--- a/providers/responses.go
+++ b/providers/responses.go
@@ -1,0 +1,101 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// ResponsesProvider is an optional interface for providers that expose the
+// portable Responses request and result contract.
+type ResponsesProvider interface {
+	Provider
+	Responses(ctx context.Context, params ResponsesParams) (*ResponsesResult, error)
+}
+
+// ResponsesInputRole is a message role accepted by the portable Responses input.
+type ResponsesInputRole string
+
+const (
+	ResponsesInputRoleAssistant ResponsesInputRole = "assistant"
+	ResponsesInputRoleDeveloper ResponsesInputRole = "developer"
+	ResponsesInputRoleSystem    ResponsesInputRole = "system"
+	ResponsesInputRoleUser      ResponsesInputRole = "user"
+)
+
+// ResponsesInputItem is a text message sent through the portable Responses API.
+type ResponsesInputItem struct {
+	Content string             `json:"content"`
+	Role    ResponsesInputRole `json:"role"`
+}
+
+// ResponsesParams contains the portable subset of a Responses request.
+// OpenAI permits Model and Input to be omitted. Provider implementations may
+// enforce stricter documented requirements.
+// https://developers.openai.com/api/reference/resources/responses/methods/create
+type ResponsesParams struct {
+	Input           []ResponsesInputItem `json:"input,omitempty"`
+	Instructions    *string              `json:"instructions,omitempty"`
+	MaxOutputTokens *int                 `json:"max_output_tokens,omitempty"`
+	Model           string               `json:"model,omitempty"`
+	ReasoningEffort ReasoningEffort      `json:"reasoning_effort,omitempty"`
+}
+
+// ResponsesResult is a portable Responses result. ProviderRaw retains fields
+// outside the normalized subset.
+type ResponsesResult struct {
+	ID                string                      `json:"id"`
+	Model             string                      `json:"model"`
+	Status            string                      `json:"status,omitempty"`
+	Error             *ResponsesError             `json:"error,omitempty"`
+	IncompleteDetails *ResponsesIncompleteDetails `json:"incomplete_details,omitempty"`
+	OutputText        string                      `json:"output_text"`
+	OutputItems       []ResponsesOutputItem       `json:"output_items,omitempty"`
+	Usage             *ResponsesUsage             `json:"usage,omitempty"`
+	ProviderRaw       json.RawMessage             `json:"provider_raw,omitempty"`
+}
+
+// ResponsesError describes a response whose generation status is failed.
+// ProviderRaw retains provider-specific error details.
+type ResponsesError struct {
+	Code        string          `json:"code"`
+	Message     string          `json:"message"`
+	ProviderRaw json.RawMessage `json:"provider_raw,omitempty"`
+}
+
+// ResponsesIncompleteDetails describes why generation stopped before completion.
+// Providers can add reasons, so Reason intentionally remains an open string.
+type ResponsesIncompleteDetails struct {
+	Reason      string          `json:"reason"`
+	ProviderRaw json.RawMessage `json:"provider_raw,omitempty"`
+}
+
+// ResponsesOutputItem contains the portable fields for one Responses output
+// item. ProviderRaw retains the complete item, including unknown item types.
+type ResponsesOutputItem struct {
+	Type        string                   `json:"type"`
+	ID          string                   `json:"id,omitempty"`
+	Status      string                   `json:"status,omitempty"`
+	Content     []ResponsesOutputContent `json:"content,omitempty"`
+	Name        string                   `json:"name,omitempty"`
+	CallID      string                   `json:"call_id,omitempty"`
+	Arguments   string                   `json:"arguments,omitempty"`
+	Summary     []string                 `json:"summary,omitempty"`
+	ProviderRaw json.RawMessage          `json:"provider_raw,omitempty"`
+}
+
+// ResponsesOutputContent contains one portable message content part.
+type ResponsesOutputContent struct {
+	Type        string          `json:"type"`
+	Text        string          `json:"text,omitempty"`
+	Refusal     string          `json:"refusal,omitempty"`
+	ProviderRaw json.RawMessage `json:"provider_raw,omitempty"`
+}
+
+// ResponsesUsage contains token usage reported by a Responses result.
+type ResponsesUsage struct {
+	InputTokens     int `json:"input_tokens"`
+	OutputTokens    int `json:"output_tokens"`
+	TotalTokens     int `json:"total_tokens"`
+	CachedTokens    int `json:"cached_tokens,omitempty"`
+	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
+}

--- a/providers/types.go
+++ b/providers/types.go
@@ -16,11 +16,14 @@ const (
 
 // Reasoning effort levels for extended thinking.
 const (
-	ReasoningEffortAuto   ReasoningEffort = "auto"
-	ReasoningEffortHigh   ReasoningEffort = "high"
-	ReasoningEffortLow    ReasoningEffort = "low"
-	ReasoningEffortMedium ReasoningEffort = "medium"
-	ReasoningEffortNone   ReasoningEffort = "none"
+	ReasoningEffortAuto    ReasoningEffort = "auto"
+	ReasoningEffortHigh    ReasoningEffort = "high"
+	ReasoningEffortLow     ReasoningEffort = "low"
+	ReasoningEffortMax     ReasoningEffort = "max"
+	ReasoningEffortMedium  ReasoningEffort = "medium"
+	ReasoningEffortMinimal ReasoningEffort = "minimal"
+	ReasoningEffortNone    ReasoningEffort = "none"
+	ReasoningEffortXHigh   ReasoningEffort = "xhigh"
 )
 
 // Message roles.
@@ -95,7 +98,7 @@ type Capabilities struct {
 	CompletionImage     bool
 	CompletionPDF       bool
 	CompletionReasoning bool
-	CompletionStreaming  bool
+	CompletionStreaming bool
 	CompletionTools     bool
 	Embedding           bool
 	ListModels          bool

--- a/providers/types.go
+++ b/providers/types.go
@@ -104,6 +104,8 @@ type Capabilities struct {
 	ListModels          bool
 	Moderation          bool
 	Rerank              bool
+	Responses           bool
+	ResponsesStreaming  bool
 }
 
 // ChatCompletion represents a chat completion response in OpenAI format.

--- a/providers/types.go
+++ b/providers/types.go
@@ -274,6 +274,8 @@ type Function struct {
 	Name        string         `json:"name"`
 	Description string         `json:"description,omitempty"`
 	Parameters  map[string]any `json:"parameters,omitempty"`
+	// Strict requests schema-constrained function arguments when the provider supports it.
+	Strict *bool `json:"strict,omitempty"`
 }
 
 // FunctionCall represents the function being called.


### PR DESCRIPTION
## Summary

- define a provider-neutral subset for Responses text-message requests
- normalize ordered text, refusal, function-call, reasoning-summary, usage, failed, and incomplete result fields
- retain raw JSON at envelope, item, content, error, and incomplete-detail boundaries for compatible-provider extensions and future union members

This PR depends on #141 and #173. GitHub's cumulative diff includes their eight commits because an upstream PR cannot use a contributor-fork branch as its base. The owning range is `224924555d4e9fc85e02e11233c81341e7576fde..f42aad1ff56676e4acbf8363a88ee1f33a3220d7`: five files, 262 production lines, and 319 necessary contract-test lines.

## Contract evidence

OpenAI's current [create reference](https://developers.openai.com/api/reference/resources/responses/methods/create) defines optional model/input/instructions/max-output fields, all seven explicit reasoning effort values, open output unions, response status, nullable error, and incomplete details. The [streaming event reference](https://developers.openai.com/api/reference/resources/responses/streaming-events/) independently confirms completed, failed, and incomplete terminal envelopes.

The latest formal openai-go release checked for this PR is [v3.56.0](https://github.com/openai/openai-go/releases/tag/v3.56.0), commit `f5b985771236464300abc9395c1c4abda0d65c53`. No SDK update is required: focused tests also pass with v3.0.0, so the existing #141 minimum remains sufficient.

The tests use independently written literal HTTP fixtures. They do not copy OpenAI SDK or Fantasy code, fixtures, control flow, or assertion sequences. Both repositories are Apache-2.0 licensed.

## Validation

- `go test ./... -count=1`
- `CGO_ENABLED=1 go test -race ./providers/openai ./providers -count=1`
- `golangci-lint run ./...`
- `go mod tidy -diff`
- `go mod verify`
- focused tests with temporary modfiles for openai-go v3.0.0 and v3.56.0
- `git diff --check`

Live OpenAI and compatible-provider smoke tests remain unavailable without credentials, so the PR stays Draft.

## Checklist

- [x] Tests added
- [x] No dependency update
- [x] Signed commits
- [x] AI assistance disclosed

AI assistance: Amp was used for implementation, research, and test execution.
