### PR TITLE
fix(gemini): preserve thinking controls and cancellation

### DIFF
--- a/anyllm.go
+++ b/anyllm.go
@@ -179,17 +179,17 @@ var (
 
 // Error types.
 type (
-	AuthenticationError           = errors.AuthenticationError
-	BaseError                     = errors.BaseError
-	ContentFilterError            = errors.ContentFilterError
-	ContextLengthError            = errors.ContextLengthError
-	InsufficientFundsError        = errors.InsufficientFundsError
-	InvalidRequestError           = errors.InvalidRequestError
-	MissingAPIKeyError            = errors.MissingAPIKeyError
-	ModelNotFoundError            = errors.ModelNotFoundError
-	ProviderError                 = errors.ProviderError
-	RateLimitError                = errors.RateLimitError
-	UnsupportedOperationError     = errors.UnsupportedOperationError
-	UnsupportedParamError         = errors.UnsupportedParamError
-	UnsupportedProviderError      = errors.UnsupportedProviderError
+	AuthenticationError       = errors.AuthenticationError
+	BaseError                 = errors.BaseError
+	ContentFilterError        = errors.ContentFilterError
+	ContextLengthError        = errors.ContextLengthError
+	InsufficientFundsError    = errors.InsufficientFundsError
+	InvalidRequestError       = errors.InvalidRequestError
+	MissingAPIKeyError        = errors.MissingAPIKeyError
+	ModelNotFoundError        = errors.ModelNotFoundError
+	ProviderError             = errors.ProviderError
+	RateLimitError            = errors.RateLimitError
+	UnsupportedOperationError = errors.UnsupportedOperationError
+	UnsupportedParamError     = errors.UnsupportedParamError
+	UnsupportedProviderError  = errors.UnsupportedProviderError
 )

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -373,7 +373,7 @@ func capabilities() providers.Capabilities {
 		CompletionImage:     true,
 		CompletionPDF:       true,
 		CompletionReasoning: true,
-		CompletionStreaming:  true,
+		CompletionStreaming: true,
 		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
@@ -703,7 +703,9 @@ func (p *Provider) handleRerankErrorResponse(resp *http.Response) error {
 	case http.StatusTooManyRequests:
 		return errors.NewRateLimitError(providerName, fmt.Errorf("%s", msg))
 	case http.StatusBadGateway:
-		return &UpstreamProviderError{BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider)}
+		return &UpstreamProviderError{
+			BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider),
+		}
 	case http.StatusGatewayTimeout:
 		return &TimeoutError{BaseError: errors.New(errCodeTimeout, providerName, fmt.Errorf("%s", msg), ErrTimeout)}
 	default:

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -10,6 +10,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"log"
+	"math"
 	"strings"
 	"time"
 
@@ -25,14 +26,6 @@ const (
 	envAPIKey       = "GEMINI_API_KEY"
 	envAPIKeyGoogle = "GOOGLE_API_KEY"
 	providerName    = "gemini"
-)
-
-// Default thinking budgets for reasoning effort levels.
-// These match the Python any-llm library.
-const (
-	thinkingBudgetHigh   int32 = 24576
-	thinkingBudgetLow    int32 = 1024
-	thinkingBudgetMedium int32 = 8192
 )
 
 // Content part types.
@@ -166,7 +159,10 @@ func (p *Provider) Completion(
 	ctx context.Context,
 	params providers.CompletionParams,
 ) (*providers.ChatCompletion, error) {
-	contents, cfg := p.convertParams(params)
+	contents, cfg, err := p.convertParams(params)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := p.client.Models.GenerateContent(ctx, params.Model, contents, cfg)
 	if err != nil {
@@ -188,31 +184,27 @@ func (p *Provider) CompletionStream(
 		defer close(chunks)
 		defer close(errs)
 
-		contents, cfg := p.convertParams(params)
+		contents, cfg, err := p.convertParams(params)
+		if err != nil {
+			sendStreamError(ctx, errs, err)
+
+			return
+		}
 		state, err := newStreamState(params.Model)
 		if err != nil {
-			select {
-			case errs <- err:
-			case <-ctx.Done():
-			}
+			sendStreamError(ctx, errs, err)
 			return
 		}
 
 		for resp, err := range p.client.Models.GenerateContentStream(ctx, params.Model, contents, cfg) {
 			if err != nil {
-				select {
-				case errs <- p.ConvertError(err):
-				case <-ctx.Done():
-				}
+				sendStreamError(ctx, errs, p.ConvertError(err))
 				return
 			}
 
 			responseChunks, err := state.processResponse(resp)
 			if err != nil {
-				select {
-				case errs <- err:
-				case <-ctx.Done():
-				}
+				sendStreamError(ctx, errs, err)
 				return
 			}
 
@@ -235,6 +227,13 @@ func (p *Provider) CompletionStream(
 	}()
 
 	return chunks, errs
+}
+
+func sendStreamError(ctx context.Context, errs chan<- error, err error) {
+	select {
+	case errs <- err:
+	case <-ctx.Done():
+	}
 }
 
 // ConvertError converts a Gemini SDK error to a unified error type.
@@ -346,7 +345,9 @@ func (p *Provider) Name() string {
 }
 
 // convertParams converts providers.CompletionParams to Gemini request format.
-func (p *Provider) convertParams(params providers.CompletionParams) ([]*genai.Content, *genai.GenerateContentConfig) {
+func (p *Provider) convertParams(
+	params providers.CompletionParams,
+) ([]*genai.Content, *genai.GenerateContentConfig, error) {
 	contents, systemInstruction := convertMessages(params.Messages)
 
 	cfg := &genai.GenerateContentConfig{}
@@ -365,8 +366,8 @@ func (p *Provider) convertParams(params providers.CompletionParams) ([]*genai.Co
 		cfg.TopP = &tp
 	}
 
-	if params.MaxTokens != nil {
-		cfg.MaxOutputTokens = int32(*params.MaxTokens)
+	if err := applyMaxTokens(cfg, params.MaxTokens); err != nil {
+		return nil, nil, err
 	}
 
 	if len(params.Stop) > 0 {
@@ -381,13 +382,32 @@ func (p *Provider) convertParams(params providers.CompletionParams) ([]*genai.Co
 		cfg.ToolConfig = convertToolChoice(params.ToolChoice)
 	}
 
-	applyThinking(cfg, params.ReasoningEffort)
+	if err := applyThinking(cfg, params.Model, params.ReasoningEffort); err != nil {
+		return nil, nil, err
+	}
 
 	if params.ResponseFormat != nil {
 		applyResponseFormat(cfg, params.ResponseFormat)
 	}
 
-	return contents, cfg
+	return contents, cfg, nil
+}
+
+func applyMaxTokens(cfg *genai.GenerateContentConfig, maxTokens *int) error {
+	if maxTokens == nil {
+		return nil
+	}
+
+	if *maxTokens < math.MinInt32 || *maxTokens > math.MaxInt32 {
+		return errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("max_tokens must be between %d and %d", math.MinInt32, math.MaxInt32),
+		)
+	}
+
+	cfg.MaxOutputTokens = int32(*maxTokens)
+
+	return nil
 }
 
 // newStreamState creates a new stream state.
@@ -505,23 +525,6 @@ func applyResponseFormat(cfg *genai.GenerateContentConfig, format *providers.Res
 		cfg.ResponseJsonSchema = format.JSONSchema.Schema
 	case responseFormatJSON:
 		cfg.ResponseMIMEType = responseMIMETypeJSON
-	}
-}
-
-// applyThinking configures thinking/reasoning on the config if applicable.
-func applyThinking(cfg *genai.GenerateContentConfig, effort providers.ReasoningEffort) {
-	if effort == "" || effort == providers.ReasoningEffortNone {
-		return
-	}
-
-	budget, ok := thinkingBudget(effort)
-	if !ok {
-		return
-	}
-
-	cfg.ThinkingConfig = &genai.ThinkingConfig{
-		IncludeThoughts: true,
-		ThinkingBudget:  &budget,
 	}
 }
 
@@ -949,18 +952,4 @@ func thoughtSignatureFromExtra(extra map[string]providers.ProviderData) []byte {
 	}
 
 	return sig
-}
-
-// thinkingBudget returns the token budget for the given reasoning effort.
-func thinkingBudget(effort providers.ReasoningEffort) (int32, bool) {
-	switch effort {
-	case providers.ReasoningEffortLow:
-		return thinkingBudgetLow, true
-	case providers.ReasoningEffortMedium:
-		return thinkingBudgetMedium, true
-	case providers.ReasoningEffortHigh:
-		return thinkingBudgetHigh, true
-	default:
-		return 0, false
-	}
 }

--- a/providers/gemini/gemini.go
+++ b/providers/gemini/gemini.go
@@ -103,10 +103,9 @@ type Provider struct {
 type streamState struct {
 	content      strings.Builder
 	finishReason genai.FinishReason
+	hasToolCalls bool
 	messageID    string
 	model        string
-	reasoning    strings.Builder
-	toolCalls    []providers.ToolCall
 	usage        *providers.Usage
 }
 
@@ -440,7 +439,7 @@ func (s *streamState) finalChunk() *providers.ChatCompletionChunk {
 	chunk := s.chunk(providers.ChunkDelta{})
 
 	finishReason := convertFinishReason(s.finishReason)
-	if len(s.toolCalls) > 0 && finishReason == providers.FinishReasonStop {
+	if s.hasToolCalls && finishReason == providers.FinishReasonStop {
 		finishReason = providers.FinishReasonToolCalls
 	}
 
@@ -489,12 +488,11 @@ func (s *streamState) processResponse(resp *genai.GenerateContentResponse) ([]pr
 				setProviderExtra(&toolCall, providerName, extraKeyThoughtSignature,
 					base64.StdEncoding.EncodeToString(part.ThoughtSignature))
 			}
-			s.toolCalls = append(s.toolCalls, toolCall)
+			s.hasToolCalls = true
 			result = append(result, s.chunk(providers.ChunkDelta{
 				ToolCalls: []providers.ToolCall{toolCall},
 			}))
 		case part.Thought:
-			s.reasoning.WriteString(part.Text)
 			result = append(result, s.chunk(providers.ChunkDelta{
 				Reasoning: &providers.Reasoning{Content: part.Text},
 			}))

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -835,8 +835,14 @@ func TestCompletionThinkingWireContract(t *testing.T) {
 func TestCompletionStreamPreservesAsymmetricGeminiOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = io.WriteString(w, "data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"reason-17\",\"thought\":true},{\"text\":\"answer-29\"}]}}]}\n\n")
-		_, _ = io.WriteString(w, "data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"functionCall\":{\"name\":\"lookup\",\"args\":{\"left\":17,\"right\":\"q29\"}},\"thoughtSignature\":\"AQIDBA==\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":7,\"candidatesTokenCount\":11,\"thoughtsTokenCount\":3}}\n\n")
+		_, _ = io.WriteString(
+			w,
+			"data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"reason-17\",\"thought\":true},{\"text\":\"answer-29\"}]}}]}\n\n",
+		)
+		_, _ = io.WriteString(
+			w,
+			"data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"functionCall\":{\"name\":\"lookup\",\"args\":{\"left\":17,\"right\":\"q29\"}},\"thoughtSignature\":\"AQIDBA==\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":7,\"candidatesTokenCount\":11,\"thoughtsTokenCount\":3}}\n\n",
+		)
 	}))
 	t.Cleanup(server.Close)
 	t.Setenv("GOOGLE_GEMINI_BASE_URL", server.URL)
@@ -878,7 +884,11 @@ func TestCompletionStreamPreservesAsymmetricGeminiOutput(t *testing.T) {
 	require.JSONEq(t, `{"left":17,"right":"q29"}`, toolCalls[0].Function.Arguments)
 	require.Equal(t, "AQIDBA==", toolCalls[0].Extra[providerName][extraKeyThoughtSignature])
 	require.Equal(t, providers.FinishReasonToolCalls, finishReason)
-	require.Equal(t, &providers.Usage{PromptTokens: 7, CompletionTokens: 11, TotalTokens: 18, ReasoningTokens: 3}, usage)
+	require.Equal(
+		t,
+		&providers.Usage{PromptTokens: 7, CompletionTokens: 11, TotalTokens: 18, ReasoningTokens: 3},
+		usage,
+	)
 }
 
 func TestConvertImagePart(t *testing.T) {

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -5,6 +5,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	stderrors "errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -16,6 +21,23 @@ import (
 	"github.com/mozilla-ai/any-llm-go/internal/testutil"
 	"github.com/mozilla-ai/any-llm-go/providers"
 )
+
+func TestSendStreamError(t *testing.T) {
+	t.Parallel()
+
+	err := stderrors.New("stream failed")
+	errs := make(chan error, 1)
+	sendStreamError(t.Context(), errs, err)
+	require.ErrorIs(t, <-errs, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	errs <- err
+
+	sendStreamError(ctx, errs, stderrors.New("cancelled delivery"))
+	require.ErrorIs(t, <-errs, err)
+}
 
 func TestNew(t *testing.T) {
 	t.Run("creates provider with API key", func(t *testing.T) {
@@ -508,61 +530,53 @@ func TestConvertError(t *testing.T) {
 			result := p.ConvertError(tc.err)
 
 			if tc.wantSentinel == nil {
-				require.Nil(t, result)
+				require.NoError(t, result)
 				return
 			}
 
-			require.NotNil(t, result)
-			require.True(
-				t,
-				stderrors.Is(result, tc.wantSentinel),
-				"expected error to match %v, got %v",
-				tc.wantSentinel,
-				result,
-			)
+			require.Error(t, result)
+			require.ErrorIs(t, result, tc.wantSentinel)
 			require.Contains(t, result.Error(), "["+providerName+"]")
 		})
 	}
 }
 
-func TestThinkingBudget(t *testing.T) {
+func TestApplyThinkingLevels(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		effort   providers.ReasoningEffort
-		expected int32
-		ok       bool
+		name   string
+		model  string
+		effort providers.ReasoningEffort
+		wire   string
 	}{
 		{
-			name:     "low effort",
-			effort:   providers.ReasoningEffortLow,
-			expected: thinkingBudgetLow,
-			ok:       true,
+			name: "Gemini 3 minimal", model: "gemini-3-flash", effort: providers.ReasoningEffortMinimal,
+			wire: `{"includeThoughts":true,"thinkingLevel":"MINIMAL"}`,
 		},
 		{
-			name:     "medium effort",
-			effort:   providers.ReasoningEffortMedium,
-			expected: thinkingBudgetMedium,
-			ok:       true,
+			name: "Gemini 3 low", model: "gemini-3-flash", effort: providers.ReasoningEffortLow,
+			wire: `{"includeThoughts":true,"thinkingLevel":"LOW"}`,
 		},
 		{
-			name:     "high effort",
-			effort:   providers.ReasoningEffortHigh,
-			expected: thinkingBudgetHigh,
-			ok:       true,
+			name: "Gemini 3 medium", model: "gemini-3-flash", effort: providers.ReasoningEffortMedium,
+			wire: `{"includeThoughts":true,"thinkingLevel":"MEDIUM"}`,
 		},
 		{
-			name:     "none effort",
-			effort:   providers.ReasoningEffortNone,
-			expected: 0,
-			ok:       false,
+			name:   "3.1 Pro minimal maps to low",
+			model:  "models/gemini-3.1-pro-preview-001",
+			effort: providers.ReasoningEffortMinimal,
+			wire:   `{"includeThoughts":true,"thinkingLevel":"LOW"}`,
 		},
 		{
-			name:     "invalid effort",
-			effort:   "invalid",
-			expected: 0,
-			ok:       false,
+			name: "Gemini 3 maximum", model: "gemini-3-flash", effort: providers.ReasoningEffortMax,
+			wire: `{"includeThoughts":true,"thinkingLevel":"HIGH"}`,
+		},
+		{
+			name:   "custom Gemini 3 uses levels",
+			model:  "publishers/acme/gemini-3.10-custom",
+			effort: providers.ReasoningEffortHigh,
+			wire:   `{"includeThoughts":true,"thinkingLevel":"HIGH"}`,
 		},
 	}
 
@@ -570,51 +584,252 @@ func TestThinkingBudget(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			budget, ok := thinkingBudget(tc.effort)
-			require.Equal(t, tc.ok, ok)
-			require.Equal(t, tc.expected, budget)
+			cfg := &genai.GenerateContentConfig{}
+			require.NoError(t, applyThinking(cfg, tc.model, tc.effort))
+			requireThinkingWire(t, cfg, tc.wire)
 		})
 	}
 }
 
-func TestApplyThinking(t *testing.T) {
+func TestApplyThinkingBudgets(t *testing.T) {
 	t.Parallel()
 
-	t.Run("empty effort does nothing", func(t *testing.T) {
-		t.Parallel()
+	tests := []struct {
+		name   string
+		model  string
+		effort providers.ReasoningEffort
+		wire   string
+	}{
+		{
+			name: "custom model keeps low budget", model: "custom-model", effort: providers.ReasoningEffortLow,
+			wire: `{"includeThoughts":true,"thinkingBudget":1024}`,
+		},
+		{
+			name: "unlisted model keeps high budget", model: "gemini-2.0-flash", effort: providers.ReasoningEffortHigh,
+			wire: `{"includeThoughts":true,"thinkingBudget":24576}`,
+		},
+		{
+			name: "Flash-Lite minimum", model: "gemini-2.5-flash-lite", effort: providers.ReasoningEffortMinimal,
+			wire: `{"includeThoughts":true,"thinkingBudget":1024}`,
+		},
+		{
+			name: "2.5 Flash low", model: "gemini-2.5-flash", effort: providers.ReasoningEffortLow,
+			wire: `{"includeThoughts":true,"thinkingBudget":1024}`,
+		},
+		{
+			name: "2.5 Flash medium", model: "gemini-2.5-flash", effort: providers.ReasoningEffortMedium,
+			wire: `{"includeThoughts":true,"thinkingBudget":8192}`,
+		},
+		{
+			name: "Pro maximum", model: "gemini-2.5-pro", effort: providers.ReasoningEffortMax,
+			wire: `{"includeThoughts":true,"thinkingBudget":32768}`,
+		},
+		{
+			name: "Flash maximum", model: "gemini-2.5-flash", effort: providers.ReasoningEffortXHigh,
+			wire: `{"includeThoughts":true,"thinkingBudget":24576}`,
+		},
+		{
+			name:   "Flash-Lite numeric alias maximum",
+			model:  "gemini-2.5-flash-lite-001-002",
+			effort: providers.ReasoningEffortMax,
+			wire:   `{"includeThoughts":true,"thinkingBudget":24576}`,
+		},
+		{
+			name:   "named Flash alias is not broadened",
+			model:  "gemini-2.5-flash-preview",
+			effort: providers.ReasoningEffortMax,
+			wire:   `{"includeThoughts":true,"thinkingBudget":32768}`,
+		},
+		{
+			name: "none disables Flash", model: "gemini-2.5-flash", effort: providers.ReasoningEffortNone,
+			wire: `{"thinkingBudget":0}`,
+		},
+		{
+			name: "Robotics budget", model: "robotics-er-1.6-preview", effort: providers.ReasoningEffortHigh,
+			wire: `{"includeThoughts":true,"thinkingBudget":24576}`,
+		},
+	}
 
-		cfg := &genai.GenerateContentConfig{}
-		applyThinking(cfg, "")
-		require.Nil(t, cfg.ThinkingConfig)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &genai.GenerateContentConfig{}
+			require.NoError(t, applyThinking(cfg, tc.model, tc.effort))
+			requireThinkingWire(t, cfg, tc.wire)
+		})
+	}
+}
+
+func TestApplyThinkingPreservesDefaults(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		model  string
+		effort providers.ReasoningEffort
+	}{
+		{name: "empty keeps defaults", model: "custom-model"},
+		{name: "auto keeps the Gemini 3 default", model: "gemini-3-flash", effort: providers.ReasoningEffortAuto},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &genai.GenerateContentConfig{}
+			require.NoError(t, applyThinking(cfg, tc.model, tc.effort))
+			require.Nil(t, cfg.ThinkingConfig)
+
+			existing := &genai.ThinkingConfig{IncludeThoughts: true}
+			cfg.ThinkingConfig = existing
+			require.NoError(t, applyThinking(cfg, tc.model, tc.effort))
+			require.Same(t, existing, cfg.ThinkingConfig)
+		})
+	}
+}
+
+func TestConvertParamsThinkingDoesNotMutateCaller(t *testing.T) {
+	t.Parallel()
+
+	params := providers.CompletionParams{
+		Model:           "gemini-2.5-flash",
+		Messages:        []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
+		ReasoningEffort: providers.ReasoningEffortNone,
+		Stop:            []string{"done"},
+	}
+	want, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	provider := &Provider{}
+	_, cfg, err := provider.convertParams(params)
+	require.NoError(t, err)
+	requireThinkingWire(t, cfg, `{"thinkingBudget":0}`)
+
+	got, err := json.Marshal(params)
+	require.NoError(t, err)
+	require.JSONEq(t, string(want), string(got))
+}
+
+func TestApplyThinkingRejectsUnsupported(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		model  string
+		effort providers.ReasoningEffort
+	}{
+		{name: "Gemini 3 rejects invalid effort", model: "gemini-3-flash", effort: "invalid"},
+		{name: "invalid effort is rejected", model: "gemini-2.5-flash", effort: "invalid"},
+		{name: "Gemini 3 cannot disable thinking", model: "gemini-3.1-custom", effort: providers.ReasoningEffortNone},
+		{name: "2.5 Pro numeric alias cannot disable thinking", model: "gemini-2.5-pro-001", effort: providers.ReasoningEffortNone},
+		{name: "3.8 Flash rejects minimal", model: "gemini-3.8-flash", effort: providers.ReasoningEffortMinimal},
+		{name: "3.1 Flash image rejects low", model: "gemini-3.1-flash-image", effort: providers.ReasoningEffortLow},
+		{name: "3.1 Flash Lite image rejects medium", model: "gemini-3.1-flash-lite-image", effort: providers.ReasoningEffortMedium},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &genai.GenerateContentConfig{}
+			err := applyThinking(cfg, tc.model, tc.effort)
+			require.ErrorIs(t, err, errors.ErrUnsupportedParam)
+			require.ErrorContains(t, err, tc.model)
+			require.ErrorContains(t, err, string(tc.effort))
+			require.Nil(t, cfg.ThinkingConfig)
+		})
+	}
+}
+
+func requireThinkingWire(t *testing.T, cfg *genai.GenerateContentConfig, want string) {
+	t.Helper()
+
+	wire, err := json.Marshal(cfg.ThinkingConfig)
+	require.NoError(t, err)
+	require.JSONEq(t, want, string(wire))
+}
+
+func TestCompletionRejectsUnsupportedThinking(t *testing.T) {
+	t.Parallel()
+
+	provider, err := New(config.WithAPIKey("test-key"))
+	require.NoError(t, err)
+
+	_, err = provider.Completion(t.Context(), providers.CompletionParams{
+		Model:           "gemini-2.5-pro",
+		Messages:        []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
+		ReasoningEffort: providers.ReasoningEffortNone,
 	})
+	require.ErrorIs(t, err, errors.ErrUnsupportedParam)
+}
 
-	t.Run("none effort does nothing", func(t *testing.T) {
-		t.Parallel()
+func TestCompletionStreamRejectsUnsupportedThinking(t *testing.T) {
+	t.Parallel()
 
-		cfg := &genai.GenerateContentConfig{}
-		applyThinking(cfg, providers.ReasoningEffortNone)
-		require.Nil(t, cfg.ThinkingConfig)
+	provider, err := New(config.WithAPIKey("test-key"))
+	require.NoError(t, err)
+
+	chunks, errs := provider.CompletionStream(t.Context(), providers.CompletionParams{
+		Model:           "gemini-3.1-custom",
+		Messages:        []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
+		ReasoningEffort: providers.ReasoningEffortNone,
 	})
+	_, ok := <-chunks
+	require.False(t, ok)
+	require.ErrorIs(t, <-errs, errors.ErrUnsupportedParam)
+}
 
-	t.Run("low effort sets thinking config", func(t *testing.T) {
-		t.Parallel()
+func TestCompletionThinkingWireContract(t *testing.T) {
+	body := make(chan []byte, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
 
-		cfg := &genai.GenerateContentConfig{}
-		applyThinking(cfg, providers.ReasoningEffortLow)
-		require.NotNil(t, cfg.ThinkingConfig)
-		require.True(t, cfg.ThinkingConfig.IncludeThoughts)
-		require.Equal(t, thinkingBudgetLow, *cfg.ThinkingConfig.ThinkingBudget)
-	})
+			return
+		}
 
-	t.Run("high effort sets thinking config", func(t *testing.T) {
-		t.Parallel()
+		body <- payload
 
-		cfg := &genai.GenerateContentConfig{}
-		applyThinking(cfg, providers.ReasoningEffortHigh)
-		require.NotNil(t, cfg.ThinkingConfig)
-		require.True(t, cfg.ThinkingConfig.IncludeThoughts)
-		require.Equal(t, thinkingBudgetHigh, *cfg.ThinkingConfig.ThinkingBudget)
-	})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}]}`))
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("GOOGLE_GEMINI_BASE_URL", server.URL)
+
+	provider, err := New(config.WithAPIKey("test-key"))
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name   string
+		model  string
+		effort providers.ReasoningEffort
+		want   string
+	}{
+		{name: "native level", model: "gemini-3.1-custom", effort: providers.ReasoningEffortXHigh, want: `{"includeThoughts":true,"thinkingLevel":"HIGH"}`},
+		{name: "explicit disable", model: "gemini-2.5-flash", effort: providers.ReasoningEffortNone, want: `{"thinkingBudget":0}`},
+		{name: "auto default", model: "gemini-2.5-flash", effort: providers.ReasoningEffortAuto},
+		{name: "unset default", model: "gemini-2.5-flash"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err = provider.Completion(t.Context(), providers.CompletionParams{
+				Model:           tc.model,
+				Messages:        []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
+				ReasoningEffort: tc.effort,
+			})
+			require.NoError(t, err)
+
+			var request struct {
+				GenerationConfig map[string]json.RawMessage `json:"generationConfig"`
+			}
+			require.NoError(t, json.Unmarshal(<-body, &request))
+			thinkingConfig, present := request.GenerationConfig["thinkingConfig"]
+			if tc.want == "" {
+				require.False(t, present)
+				return
+			}
+			require.True(t, present)
+			require.JSONEq(t, tc.want, string(thinkingConfig))
+			require.NotContains(t, string(thinkingConfig), `"includeThoughts":false`)
+		})
+	}
 }
 
 func TestConvertImagePart(t *testing.T) {
@@ -1200,16 +1415,35 @@ func TestConvertParams(t *testing.T) {
 	provider, err := New(config.WithAPIKey("test-key"))
 	require.NoError(t, err)
 
+	for _, tokenCount := range []int64{math.MinInt32 - 1, math.MaxInt32 + 1} {
+		t.Run(fmt.Sprintf("max tokens rejects %d", tokenCount), func(t *testing.T) {
+			t.Parallel()
+
+			if tokenCount < math.MinInt || tokenCount > math.MaxInt {
+				t.Skip("overflow input cannot be represented by this platform's int")
+			}
+
+			maxTokens := int(tokenCount)
+			_, _, err := provider.convertParams(providers.CompletionParams{
+				Model:     "gemini-2.0-flash",
+				Messages:  []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
+				MaxTokens: &maxTokens,
+			})
+			require.ErrorIs(t, err, errors.ErrInvalidRequest)
+		})
+	}
+
 	t.Run("json_object sets mime type", func(t *testing.T) {
 		t.Parallel()
 
-		_, cfg := provider.convertParams(providers.CompletionParams{
+		_, cfg, err := provider.convertParams(providers.CompletionParams{
 			Model:    "gemini-2.0-flash",
 			Messages: []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
 			ResponseFormat: &providers.ResponseFormat{
 				Type: responseFormatJSON,
 			},
 		})
+		require.NoError(t, err)
 
 		require.Equal(t, responseMIMETypeJSON, cfg.ResponseMIMEType)
 		require.Nil(t, cfg.ResponseJsonSchema)
@@ -1227,7 +1461,7 @@ func TestConvertParams(t *testing.T) {
 			"required": []string{"name", "population"},
 		}
 
-		_, cfg := provider.convertParams(providers.CompletionParams{
+		_, cfg, err := provider.convertParams(providers.CompletionParams{
 			Model:    "gemini-2.0-flash",
 			Messages: []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
 			ResponseFormat: &providers.ResponseFormat{
@@ -1238,6 +1472,7 @@ func TestConvertParams(t *testing.T) {
 				},
 			},
 		})
+		require.NoError(t, err)
 
 		require.Equal(t, responseMIMETypeJSON, cfg.ResponseMIMEType)
 		require.Equal(t, schema, cfg.ResponseJsonSchema)
@@ -1246,10 +1481,11 @@ func TestConvertParams(t *testing.T) {
 	t.Run("nil response format leaves config unchanged", func(t *testing.T) {
 		t.Parallel()
 
-		_, cfg := provider.convertParams(providers.CompletionParams{
+		_, cfg, err := provider.convertParams(providers.CompletionParams{
 			Model:    "gemini-2.0-flash",
 			Messages: []providers.Message{{Role: providers.RoleUser, Content: "hi"}},
 		})
+		require.NoError(t, err)
 
 		require.Empty(t, cfg.ResponseMIMEType)
 		require.Nil(t, cfg.ResponseJsonSchema)
@@ -1458,7 +1694,7 @@ func TestIntegrationCompletion(t *testing.T) {
 	require.NotEmpty(t, resp.Choices[0].Message.Content)
 	require.Equal(t, providers.RoleAssistant, resp.Choices[0].Message.Role)
 	require.NotNil(t, resp.Usage)
-	require.Greater(t, resp.Usage.TotalTokens, 0)
+	require.Positive(t, resp.Usage.TotalTokens)
 }
 
 func TestIntegrationCompletionWithSystemMessage(t *testing.T) {
@@ -1518,7 +1754,7 @@ func TestIntegrationCompletionStream(t *testing.T) {
 	err = <-errs
 	require.NoError(t, err)
 
-	require.Greater(t, chunkCount, 0)
+	require.Positive(t, chunkCount)
 	require.NotEmpty(t, content.String())
 }
 

--- a/providers/gemini/gemini_test.go
+++ b/providers/gemini/gemini_test.go
@@ -832,6 +832,55 @@ func TestCompletionThinkingWireContract(t *testing.T) {
 	}
 }
 
+func TestCompletionStreamPreservesAsymmetricGeminiOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"reason-17\",\"thought\":true},{\"text\":\"answer-29\"}]}}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"functionCall\":{\"name\":\"lookup\",\"args\":{\"left\":17,\"right\":\"q29\"}},\"thoughtSignature\":\"AQIDBA==\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":7,\"candidatesTokenCount\":11,\"thoughtsTokenCount\":3}}\n\n")
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("GOOGLE_GEMINI_BASE_URL", server.URL)
+
+	provider, err := New(config.WithAPIKey("test-key"))
+	require.NoError(t, err)
+	chunks, errs := provider.CompletionStream(t.Context(), providers.CompletionParams{
+		Model:    "gemini-2.5-flash",
+		Messages: []providers.Message{{Role: providers.RoleUser, Content: "asymmetric-73"}},
+	})
+
+	var content, reasoning string
+	var toolCalls []providers.ToolCall
+	var finishReason string
+	var usage *providers.Usage
+	for chunk := range chunks {
+		for _, choice := range chunk.Choices {
+			content += choice.Delta.Content
+			if choice.Delta.Reasoning != nil {
+				reasoning += choice.Delta.Reasoning.Content
+			}
+			toolCalls = append(toolCalls, choice.Delta.ToolCalls...)
+			if choice.FinishReason != "" {
+				finishReason = choice.FinishReason
+			}
+		}
+		if chunk.Usage != nil {
+			usage = chunk.Usage
+		}
+	}
+	for streamErr := range errs {
+		require.NoError(t, streamErr)
+	}
+
+	require.Equal(t, "answer-29", content)
+	require.Equal(t, "reason-17", reasoning)
+	require.Len(t, toolCalls, 1)
+	require.Equal(t, "lookup", toolCalls[0].Function.Name)
+	require.JSONEq(t, `{"left":17,"right":"q29"}`, toolCalls[0].Function.Arguments)
+	require.Equal(t, "AQIDBA==", toolCalls[0].Extra[providerName][extraKeyThoughtSignature])
+	require.Equal(t, providers.FinishReasonToolCalls, finishReason)
+	require.Equal(t, &providers.Usage{PromptTokens: 7, CompletionTokens: 11, TotalTokens: 18, ReasoningTokens: 3}, usage)
+}
+
 func TestConvertImagePart(t *testing.T) {
 	t.Parallel()
 
@@ -918,7 +967,7 @@ func TestNewStreamState(t *testing.T) {
 	require.NotNil(t, state)
 	require.Equal(t, "gemini-1.5-flash", state.model)
 	require.True(t, strings.HasPrefix(state.messageID, idPrefixCompletion))
-	require.Nil(t, state.toolCalls)
+	require.False(t, state.hasToolCalls)
 	require.Nil(t, state.usage)
 }
 
@@ -1377,9 +1426,7 @@ func TestStreamStateFinalChunk(t *testing.T) {
 		state, err := newStreamState("test-model")
 		require.NoError(t, err)
 		state.finishReason = genai.FinishReasonStop
-		state.toolCalls = []providers.ToolCall{
-			{ID: "call_1", Type: "function", Function: providers.FunctionCall{Name: "get_weather"}},
-		}
+		state.hasToolCalls = true
 
 		chunk := state.finalChunk()
 		require.Equal(t, providers.FinishReasonToolCalls, chunk.Choices[0].FinishReason)

--- a/providers/gemini/thinking.go
+++ b/providers/gemini/thinking.go
@@ -1,0 +1,179 @@
+package gemini
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"google.golang.org/genai"
+
+	"github.com/mozilla-ai/any-llm-go/errors"
+	"github.com/mozilla-ai/any-llm-go/providers"
+)
+
+const (
+	// Gemini 2.5 exposes token ranges rather than named efforts. The Python
+	// binding maps minimal and low to 1024 and caps known models at their maximum.
+	thinkingBudgetHigh   int32 = 24576
+	thinkingBudgetLow    int32 = 1024
+	thinkingBudgetMax    int32 = 32768
+	thinkingBudgetMedium int32 = 8192
+)
+
+var (
+	geminiVersionPattern = regexp.MustCompile(`(?:^|/)gemini-(\d+)(?:\.(\d+))?`)
+	numericSuffixPattern = regexp.MustCompile(`^(?:-\d+)+$`)
+
+	allThinkingLevels = []genai.ThinkingLevel{
+		genai.ThinkingLevelMinimal,
+		genai.ThinkingLevelLow,
+		genai.ThinkingLevelMedium,
+		genai.ThinkingLevelHigh,
+	}
+	// Known Gemini 3 capabilities refine the permissive version routing used
+	// for custom, dated, and newly released model IDs.
+	// https://ai.google.dev/gemini-api/docs/generate-content/thinking#thinking-levels
+	thinkingLevelsByModel = map[string][]genai.ThinkingLevel{
+		"gemini-3.8-flash": {
+			genai.ThinkingLevelLow, genai.ThinkingLevelMedium, genai.ThinkingLevelHigh,
+		},
+		"gemini-3.7-flash": {
+			genai.ThinkingLevelLow, genai.ThinkingLevelMedium, genai.ThinkingLevelHigh,
+		},
+		"gemini-3.6-flash":      allThinkingLevels,
+		"gemini-3.5-flash":      allThinkingLevels,
+		"gemini-3.5-flash-lite": allThinkingLevels,
+		"gemini-3.1-flash-lite": allThinkingLevels,
+		"gemini-3.1-pro-preview": {
+			genai.ThinkingLevelLow,
+			genai.ThinkingLevelMedium,
+			genai.ThinkingLevelHigh,
+		},
+		"gemini-3.1-flash-image":      {genai.ThinkingLevelMinimal, genai.ThinkingLevelHigh},
+		"gemini-3.1-flash-lite-image": {genai.ThinkingLevelMinimal, genai.ThinkingLevelHigh},
+		"gemini-3-flash-preview":      allThinkingLevels,
+	}
+	maxThinkingBudgetByModel = map[string]int32{
+		"gemini-2.5-pro":        thinkingBudgetMax,
+		"gemini-2.5-flash":      thinkingBudgetHigh,
+		"gemini-2.5-flash-lite": thinkingBudgetHigh,
+	}
+)
+
+// applyThinking preserves SDK defaults unless the caller explicitly selects an effort.
+func applyThinking(cfg *genai.GenerateContentConfig, model string, effort providers.ReasoningEffort) error {
+	if effort == "" || effort == providers.ReasoningEffortAuto {
+		return nil
+	}
+
+	modelName := geminiModelName(model)
+	if effort == providers.ReasoningEffortNone {
+		if usesThinkingLevel(model) || matchesKnownModel(modelName, "gemini-2.5-pro") {
+			return fmt.Errorf("model %q rejects effort %q: %w", model, effort,
+				errors.NewUnsupportedParamError(providerName, "reasoning_effort"))
+		}
+		cfg.ThinkingConfig = &genai.ThinkingConfig{ThinkingBudget: new(int32)}
+		return nil
+	}
+
+	if supportedLevels := knownThinkingLevels(modelName); supportedLevels != nil || usesThinkingLevel(model) {
+		level, ok := thinkingLevel(effort)
+		// Google's OpenAI compatibility contract maps minimal to low for Gemini 3.1 Pro.
+		if matchesKnownModel(modelName, "gemini-3.1-pro-preview") && effort == providers.ReasoningEffortMinimal {
+			level, ok = genai.ThinkingLevelLow, true
+		}
+		if !ok || supportedLevels != nil && !slices.Contains(supportedLevels, level) {
+			return fmt.Errorf("model %q rejects effort %q: %w", model, effort,
+				errors.NewUnsupportedParamError(providerName, "reasoning_effort"))
+		}
+		cfg.ThinkingConfig = &genai.ThinkingConfig{IncludeThoughts: true, ThinkingLevel: level}
+		return nil
+	}
+
+	budget, ok := thinkingBudget(effort)
+	if !ok {
+		return fmt.Errorf("model %q rejects effort %q: %w", model, effort,
+			errors.NewUnsupportedParamError(providerName, "reasoning_effort"))
+	}
+	if maximum := knownMaxThinkingBudget(modelName); maximum != 0 {
+		budget = min(budget, maximum)
+	}
+	cfg.ThinkingConfig = &genai.ThinkingConfig{IncludeThoughts: true, ThinkingBudget: &budget}
+	return nil
+}
+
+func geminiModelName(model string) string {
+	if slash := strings.LastIndexByte(model, '/'); slash >= 0 {
+		model = model[slash+1:]
+	}
+	return strings.ToLower(model)
+}
+
+func knownMaxThinkingBudget(modelName string) int32 {
+	for knownModel, maximum := range maxThinkingBudgetByModel {
+		if matchesKnownModel(modelName, knownModel) {
+			return maximum
+		}
+	}
+	return 0
+}
+
+func knownThinkingLevels(modelName string) []genai.ThinkingLevel {
+	for knownModel, supported := range thinkingLevelsByModel {
+		if matchesKnownModel(modelName, knownModel) {
+			return supported
+		}
+	}
+	return nil
+}
+
+func matchesKnownModel(modelName, knownModel string) bool {
+	if modelName == knownModel {
+		return true
+	}
+	return strings.HasPrefix(modelName, knownModel) &&
+		numericSuffixPattern.MatchString(strings.TrimPrefix(modelName, knownModel))
+}
+
+func thinkingBudget(effort providers.ReasoningEffort) (int32, bool) {
+	switch effort {
+	case providers.ReasoningEffortMinimal, providers.ReasoningEffortLow:
+		return thinkingBudgetLow, true
+	case providers.ReasoningEffortMedium:
+		return thinkingBudgetMedium, true
+	case providers.ReasoningEffortHigh:
+		return thinkingBudgetHigh, true
+	case providers.ReasoningEffortXHigh, providers.ReasoningEffortMax:
+		return thinkingBudgetMax, true
+	default:
+		return 0, false
+	}
+}
+
+func thinkingLevel(effort providers.ReasoningEffort) (genai.ThinkingLevel, bool) {
+	switch effort {
+	case providers.ReasoningEffortMinimal:
+		return genai.ThinkingLevelMinimal, true
+	case providers.ReasoningEffortLow:
+		return genai.ThinkingLevelLow, true
+	case providers.ReasoningEffortMedium:
+		return genai.ThinkingLevelMedium, true
+	// Gemini's highest documented level is high, so the normalized maxima
+	// collapse to high instead of sending values the API does not accept.
+	case providers.ReasoningEffortHigh, providers.ReasoningEffortXHigh, providers.ReasoningEffortMax:
+		return genai.ThinkingLevelHigh, true
+	default:
+		return "", false
+	}
+}
+
+func usesThinkingLevel(model string) bool {
+	match := geminiVersionPattern.FindStringSubmatch(strings.ToLower(model))
+	if match == nil {
+		return false
+	}
+	major, err := strconv.Atoi(match[1])
+	return err == nil && major >= 3
+}

--- a/providers/types.go
+++ b/providers/types.go
@@ -16,11 +16,14 @@ const (
 
 // Reasoning effort levels for extended thinking.
 const (
-	ReasoningEffortAuto   ReasoningEffort = "auto"
-	ReasoningEffortHigh   ReasoningEffort = "high"
-	ReasoningEffortLow    ReasoningEffort = "low"
-	ReasoningEffortMedium ReasoningEffort = "medium"
-	ReasoningEffortNone   ReasoningEffort = "none"
+	ReasoningEffortAuto    ReasoningEffort = "auto"
+	ReasoningEffortHigh    ReasoningEffort = "high"
+	ReasoningEffortLow     ReasoningEffort = "low"
+	ReasoningEffortMax     ReasoningEffort = "max"
+	ReasoningEffortMedium  ReasoningEffort = "medium"
+	ReasoningEffortMinimal ReasoningEffort = "minimal"
+	ReasoningEffortNone    ReasoningEffort = "none"
+	ReasoningEffortXHigh   ReasoningEffort = "xhigh"
 )
 
 // Message roles.
@@ -95,7 +98,7 @@ type Capabilities struct {
 	CompletionImage     bool
 	CompletionPDF       bool
 	CompletionReasoning bool
-	CompletionStreaming  bool
+	CompletionStreaming bool
 	CompletionTools     bool
 	Embedding           bool
 	ListModels          bool


### PR DESCRIPTION
# fix(gemini): preserve thinking controls and cancellation

## Summary

Align Gemini reasoning effort with the approved model-specific policy while preserving endpoint configuration and cancellation. Unset effort and `auto` keep SDK defaults. `minimal` and `low` map to the approved 1024 budget for budget-based models; Gemini 3 uses native levels, with the documented Gemini 3.1 Pro Preview exception. Explicit `none` sends zero only where the known model supports it and otherwise returns an unsupported-parameter error.

## Review focus

- `providers/gemini/thinking.go`: review exact known-model matching, the approved 1024 mapping, caps, and Gemini 3 level handling.
- `providers/gemini/gemini.go`: confirm request errors and context cancellation propagate through both completion paths.

## Verification

- Offline request fixtures covered omitted defaults, explicit zero, budget caps, native levels, custom model IDs, and cancellation.
- Compared Google's [thinking docs](https://ai.google.dev/gemini-api/docs/generate-content/thinking), SDK [v1.66.0](https://github.com/googleapis/go-genai/blob/v1.66.0/types.go)/[v1.71.0](https://github.com/googleapis/go-genai/tree/v1.71.0), and the approved [Python policy](https://github.com/mozilla-ai/any-llm/commit/3db4175bbe34ed8d450e023c24fb85d9924ea5e1). Budget aliases are adapter policy; Google defines native budgets and levels. No new SDK minimum is introduced.
- Fresh-context reviewers checked complete aggregate diffs and tests, prioritizing baseline compatibility, official sources, then Python and Eino/Fantasy. Behavior probes and ablations preceded fixes and renewed review. No live model was called; integration tests, `TestCompletionDoesNotMutateParams` and `TestCompletionStreamDoesNotMutateParams` were excluded.

<details>
<summary>Skills and sources</summary>

- [`karpathy-guidelines`](https://github.com/forrestchang/andrej-karpathy-skills/blob/2c606141936f1eeef17fa3043a72095b4765b9c2/skills/karpathy-guidelines/SKILL.md), byte-identical to the installed skill
- [`reclaim-code-entropy`](https://github.com/Yevanchen/reclaim-code-entropy/blob/9e6482e45814076b9710b55c8dcbb064ba4b7977/skills/reclaim-code-entropy/SKILL.md)
- [`scoped-change`](https://github.com/scarletkc/agents/blob/d5a312346adcf2169eb5a31a1b88368441b32327/skills/scoped-change/SKILL.md)
- [`ux-writing`](https://github.com/scarletkc/agents/blob/d5a312346adcf2169eb5a31a1b88368441b32327/skills/ux-writing/SKILL.md)
- [`thermos`](https://github.com/cursor/plugins/blob/bdf7aa355337897f167153e05069aca505dae17c/thermos/skills/thermos/SKILL.md)
- [`use-modern-go`](https://github.com/JetBrains/go-modern-guidelines/blob/40781f167719913666fe2a7dc1c77ea6f256df0a/plugin/skills/use-modern-go/SKILL.md)
- [`modular-go`](https://github.com/PsiACE/skills/blob/2265aed05caf199426a8062461e2c9901be996d8/skills/modular-go/SKILL.md)
- [`japanese-tech-writing`](https://gist.githubusercontent.com/k16shikano/fd287c3133457c4fd8f5601d34aa817d/raw/8f2d57610a73efc97d743c9b0b0ecb1002e09fa4/SKILL.md), with its prose principles applied to English
- [`better-goal`](https://developers.openai.com/cookbook/examples/codex/using_goals_in_codex), local adaptation of the linked planning guidance, not an official skill implementation

</details>

## Checklist

- [x] Linting passes (`make lint`): equivalent configured lint was run with fixes disabled on the audited aggregate
- [x] Tests pass locally (`make test`): filtered offline race suite passed; excluded entrypoints were not exercised
- [x] Documentation updated (if needed)
- [ ] No breaking changes (or documented in summary): provider behavior is documented; maintainer API review is pending

## AI usage

IceCodeNew used Amp with GPT-6 Astra Medium for implementation and review. This PR description was prepared by the AI agent.
