### PR TITLE
fix(ollama): preserve request and stream wire semantics

### DIFF
--- a/anyllm.go
+++ b/anyllm.go
@@ -179,17 +179,17 @@ var (
 
 // Error types.
 type (
-	AuthenticationError           = errors.AuthenticationError
-	BaseError                     = errors.BaseError
-	ContentFilterError            = errors.ContentFilterError
-	ContextLengthError            = errors.ContextLengthError
-	InsufficientFundsError        = errors.InsufficientFundsError
-	InvalidRequestError           = errors.InvalidRequestError
-	MissingAPIKeyError            = errors.MissingAPIKeyError
-	ModelNotFoundError            = errors.ModelNotFoundError
-	ProviderError                 = errors.ProviderError
-	RateLimitError                = errors.RateLimitError
-	UnsupportedOperationError     = errors.UnsupportedOperationError
-	UnsupportedParamError         = errors.UnsupportedParamError
-	UnsupportedProviderError      = errors.UnsupportedProviderError
+	AuthenticationError       = errors.AuthenticationError
+	BaseError                 = errors.BaseError
+	ContentFilterError        = errors.ContentFilterError
+	ContextLengthError        = errors.ContextLengthError
+	InsufficientFundsError    = errors.InsufficientFundsError
+	InvalidRequestError       = errors.InvalidRequestError
+	MissingAPIKeyError        = errors.MissingAPIKeyError
+	ModelNotFoundError        = errors.ModelNotFoundError
+	ProviderError             = errors.ProviderError
+	RateLimitError            = errors.RateLimitError
+	UnsupportedOperationError = errors.UnsupportedOperationError
+	UnsupportedParamError     = errors.UnsupportedParamError
+	UnsupportedProviderError  = errors.UnsupportedProviderError
 )

--- a/providers/gateway/gateway.go
+++ b/providers/gateway/gateway.go
@@ -373,7 +373,7 @@ func capabilities() providers.Capabilities {
 		CompletionImage:     true,
 		CompletionPDF:       true,
 		CompletionReasoning: true,
-		CompletionStreaming:  true,
+		CompletionStreaming: true,
 		CompletionTools:     true,
 		Embedding:           true,
 		ListModels:          true,
@@ -703,7 +703,9 @@ func (p *Provider) handleRerankErrorResponse(resp *http.Response) error {
 	case http.StatusTooManyRequests:
 		return errors.NewRateLimitError(providerName, fmt.Errorf("%s", msg))
 	case http.StatusBadGateway:
-		return &UpstreamProviderError{BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider)}
+		return &UpstreamProviderError{
+			BaseError: errors.New(errCodeUpstreamProvider, providerName, fmt.Errorf("%s", msg), ErrUpstreamProvider),
+		}
 	case http.StatusGatewayTimeout:
 		return &TimeoutError{BaseError: errors.New(errCodeTimeout, providerName, fmt.Errorf("%s", msg), ErrTimeout)}
 	default:

--- a/providers/ollama/ollama.go
+++ b/providers/ollama/ollama.go
@@ -2,13 +2,18 @@
 package ollama
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
+	"maps"
+	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"time"
 
@@ -54,7 +59,6 @@ const (
 
 // Tool and response format constants.
 const (
-	emptyJSONObject      = "{}"
 	ollamaFormatJSON     = "json"
 	responseFormatJSON   = "json_object"
 	responseFormatSchema = "json_schema"
@@ -71,16 +75,10 @@ const (
 	objectModel               = "model"
 )
 
-// Thinking tag constants.
-const (
-	thinkingTagClose = "</think>"
-	thinkingTagOpen  = "<think>"
-)
-
 // Content part constants.
 const (
 	contentTypeImageURL = "image_url"
-	dataImagePrefix     = "data:image/"
+	contentTypeText     = "text"
 )
 
 // Ensure Provider implements the required interfaces.
@@ -100,11 +98,10 @@ type Provider struct {
 
 // streamState tracks accumulated state during streaming.
 type streamState struct {
-	id        string
-	model     string
-	created   int64
-	content   strings.Builder
-	reasoning strings.Builder
+	id      string
+	model   string
+	created int64
+	done    bool
 }
 
 // New creates a new Ollama provider.
@@ -154,19 +151,30 @@ func (p *Provider) Completion(
 	ctx context.Context,
 	params providers.CompletionParams,
 ) (*providers.ChatCompletion, error) {
-	req := p.convertParams(params)
+	req, err := p.convertParams(params)
+	if err != nil {
+		return nil, err
+	}
 
 	// Disable streaming for non-stream requests.
 	stream := false
 	req.Stream = &stream
 
 	var response api.ChatResponse
-	err := p.client.Chat(ctx, req, func(resp api.ChatResponse) error {
+
+	done := false
+
+	err = p.client.Chat(ctx, req, func(resp api.ChatResponse) error {
 		response = resp
+		done = resp.Done
 		return nil
 	})
 	if err != nil {
 		return nil, p.ConvertError(err)
+	}
+
+	if !done {
+		return nil, errors.NewProviderError(providerName, stderrors.New("response ended before the terminal event"))
 	}
 
 	return convertResponse(&response), nil
@@ -184,16 +192,32 @@ func (p *Provider) CompletionStream(
 		defer close(chunks)
 		defer close(errs)
 
-		req := p.convertParams(params)
+		req, err := p.convertParams(params)
+		if err != nil {
+			errs <- err
+
+			return
+		}
+
 		state := newStreamState()
 
-		err := p.client.Chat(ctx, req, func(resp api.ChatResponse) error {
+		err = p.client.Chat(ctx, req, func(resp api.ChatResponse) error {
 			chunk := state.handleChunk(&resp)
-			chunks <- chunk
-			return nil
+			select {
+			case chunks <- chunk:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		})
 		if err != nil {
 			errs <- p.ConvertError(err)
+
+			return
+		}
+
+		if !state.done {
+			errs <- errors.NewProviderError(providerName, stderrors.New("stream ended before the terminal event"))
 		}
 	}()
 
@@ -217,13 +241,13 @@ func (p *Provider) ConvertError(err error) error {
 	var statusErr api.StatusError
 	if stderrors.As(err, &statusErr) {
 		switch statusErr.StatusCode {
-		case 401:
+		case http.StatusUnauthorized:
 			return errors.NewAuthenticationError(providerName, err)
-		case 404:
+		case http.StatusNotFound:
 			return errors.NewModelNotFoundError(providerName, err)
-		case 429:
+		case http.StatusTooManyRequests:
 			return errors.NewRateLimitError(providerName, err)
-		case 400:
+		case http.StatusBadRequest:
 			if strings.Contains(statusErr.ErrorMessage, "context") {
 				return errors.NewContextLengthError(providerName, err)
 			}
@@ -273,57 +297,100 @@ func (p *Provider) Name() string {
 }
 
 // convertParams converts providers.CompletionParams to Ollama ChatRequest.
-func (p *Provider) convertParams(params providers.CompletionParams) *api.ChatRequest {
-	messages := convertMessages(params.Messages)
+func (p *Provider) convertParams(params providers.CompletionParams) (*api.ChatRequest, error) {
+	if unsupported := unsupportedCompletionParam(params); unsupported != "" {
+		return nil, errors.NewUnsupportedParamError(providerName, unsupported)
+	}
 
+	messages, err := convertMessages(params.Messages)
+	if err != nil {
+		return nil, err
+	}
+
+	tools, err := convertTools(params.Tools)
+	if err != nil {
+		return nil, err
+	}
+
+	format, err := convertResponseFormat(params.ResponseFormat)
+	if err != nil {
+		return nil, err
+	}
 	req := &api.ChatRequest{
 		Model:    params.Model,
 		Messages: messages,
-		Options:  make(map[string]any),
+		Options:  convertOptions(params),
+		Tools:    tools,
+		Format:   format,
+	}
+	if err := applyReasoningEffort(req, params.ReasoningEffort); err != nil {
+		return nil, err
 	}
 
-	// Set default context size.
-	req.Options[optionNumCtx] = defaultNumCtx
+	return req, nil
+}
 
+func convertOptions(params providers.CompletionParams) map[string]any {
+	// Keep requests independent of Ollama server and model-specific context defaults.
+	options := map[string]any{optionNumCtx: defaultNumCtx}
 	if params.Temperature != nil {
-		req.Options[optionTemperature] = *params.Temperature
+		options[optionTemperature] = *params.Temperature
 	}
 
 	if params.TopP != nil {
-		req.Options[optionTopP] = *params.TopP
+		options[optionTopP] = *params.TopP
 	}
 
 	if len(params.Stop) > 0 {
-		req.Options[optionStop] = params.Stop
+		options[optionStop] = params.Stop
 	}
 
 	if params.MaxTokens != nil {
-		req.Options[optionNumPredict] = *params.MaxTokens
+		options[optionNumPredict] = *params.MaxTokens
 	}
 
 	if params.Seed != nil {
-		req.Options[optionSeed] = *params.Seed
+		options[optionSeed] = *params.Seed
 	}
 
-	if len(params.Tools) > 0 {
-		req.Tools = convertTools(params.Tools)
+	return options
+}
+
+func applyReasoningEffort(req *api.ChatRequest, effort providers.ReasoningEffort) error {
+	// https://docs.ollama.com/api/chat defines think as a boolean or one of
+	// low, medium, high, and max. Preserve "none" as false on that wire type.
+	switch effort {
+	case "", providers.ReasoningEffortAuto:
+		return nil
+	case providers.ReasoningEffortNone:
+		req.Think = &api.ThinkValue{Value: false}
+	case providers.ReasoningEffortLow,
+		providers.ReasoningEffortMedium,
+		providers.ReasoningEffortHigh,
+		providers.ReasoningEffortMax:
+		req.Think = &api.ThinkValue{Value: string(effort)}
+	default:
+		return errors.NewUnsupportedParamError(providerName, "reasoning_effort")
 	}
 
-	if params.ResponseFormat != nil {
-		if schema := convertResponseFormat(params.ResponseFormat); schema != nil {
-			req.Format = schema
-		}
-	}
+	return nil
+}
 
-	// Handle reasoning/thinking.
-	if params.ReasoningEffort != "" &&
-		params.ReasoningEffort != providers.ReasoningEffortNone &&
-		params.ReasoningEffort != providers.ReasoningEffortAuto {
-		think := api.ThinkValue{Value: true}
-		req.Think = &think
+func unsupportedCompletionParam(params providers.CompletionParams) string {
+	switch {
+	case params.StreamOptions != nil:
+		return "stream_options"
+	case params.ToolChoice != nil:
+		return "tool_choice"
+	case params.ParallelToolCalls != nil:
+		return "parallel_tool_calls"
+	case params.User != "":
+		return "user"
+	case len(params.Extra) > 0:
+		return "extra"
+	default:
+		return ""
 	}
-
-	return req
 }
 
 // newStreamState creates a new stream state.
@@ -348,6 +415,10 @@ func (s *streamState) chunk() providers.ChatCompletionChunk {
 // handleChunk processes a streaming response and returns a chunk.
 func (s *streamState) handleChunk(resp *api.ChatResponse) providers.ChatCompletionChunk {
 	s.updateMetadata(resp)
+
+	if resp.Done {
+		s.done = true
+	}
 
 	chunk := s.chunk()
 	chunk.Choices[0].Delta = s.buildDelta(resp)
@@ -375,13 +446,11 @@ func (s *streamState) buildDelta(resp *api.ChatResponse) providers.ChunkDelta {
 
 	// Handle content.
 	if resp.Message.Content != "" {
-		s.content.WriteString(resp.Message.Content)
 		delta.Content = resp.Message.Content
 	}
 
 	// Handle thinking/reasoning.
 	if resp.Message.Thinking != "" {
-		s.reasoning.WriteString(resp.Message.Thinking)
 		delta.Reasoning = &providers.Reasoning{Content: resp.Message.Thinking}
 	}
 
@@ -408,44 +477,15 @@ func (s *streamState) handleDone(resp *api.ChatResponse, chunk *providers.ChatCo
 	}
 }
 
-// convertAssistantMessage converts an assistant message to Ollama format.
-func convertAssistantMessage(msg providers.Message) *api.Message {
-	ollamaMsg := &api.Message{
-		Role:    msg.Role,
-		Content: msg.ContentString(),
-	}
-
-	if len(msg.ToolCalls) > 0 {
-		toolCalls := make([]api.ToolCall, 0, len(msg.ToolCalls))
-		for _, tc := range msg.ToolCalls {
-			var argsMap map[string]any
-			_ = json.Unmarshal([]byte(tc.Function.Arguments), &argsMap)
-
-			args := api.NewToolCallFunctionArguments()
-			for k, v := range argsMap {
-				args.Set(k, v)
-			}
-
-			toolCalls = append(toolCalls, api.ToolCall{
-				Function: api.ToolCallFunction{
-					Name:      tc.Function.Name,
-					Arguments: args,
-				},
-			})
-		}
-		ollamaMsg.ToolCalls = toolCalls
-	}
-
-	return ollamaMsg
-}
-
 // convertDoneReason converts Ollama done reason to OpenAI finish reason.
 func convertDoneReason(reason string) string {
 	switch reason {
 	case doneReasonLength:
 		return providers.FinishReasonLength
-	default:
+	case "", doneReasonStop:
 		return providers.FinishReasonStop
+	default:
+		return reason
 	}
 }
 
@@ -478,36 +518,217 @@ func convertEmbeddingResponse(resp *api.EmbedResponse, model string) *providers.
 	}
 }
 
-// convertMessage converts a single message to Ollama format.
-func convertMessage(msg providers.Message) *api.Message {
-	switch msg.Role {
-	case providers.RoleTool:
-		return convertToolMessage(msg)
-	case providers.RoleAssistant:
-		return convertAssistantMessage(msg)
-	case providers.RoleUser:
-		return convertUserMessage(msg)
-	default:
-		// System and other roles.
-		return &api.Message{
-			Role:    msg.Role,
-			Content: msg.ContentString(),
-		}
+// convertMessage converts a single message to Ollama's documented wire model.
+func convertMessage(msg providers.Message) (*api.Message, error) {
+	if err := validateMessageMetadata(msg); err != nil {
+		return nil, err
 	}
+
+	content, images, err := convertMessageContent(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	toolCalls, err := convertRequestToolCalls(msg.ToolCalls)
+	if err != nil {
+		return nil, err
+	}
+
+	converted := &api.Message{
+		Role:      msg.Role,
+		Content:   content,
+		Images:    images,
+		ToolCalls: toolCalls,
+	}
+	if msg.Role == providers.RoleTool {
+		converted.ToolName = msg.Name
+	}
+
+	if msg.Reasoning != nil {
+		converted.Thinking = msg.Reasoning.Content
+	}
+
+	return converted, nil
+}
+
+func validateMessageMetadata(msg providers.Message) error {
+	switch msg.Role {
+	case providers.RoleSystem, providers.RoleUser, providers.RoleAssistant, providers.RoleTool:
+	default:
+		return errors.NewInvalidRequestError(providerName, fmt.Errorf("unsupported message role %q", msg.Role))
+	}
+
+	if msg.Role != providers.RoleTool && (msg.Name != "" || msg.ToolCallID != "") {
+		return errors.NewUnsupportedParamError(providerName, "messages.name/tool_call_id")
+	}
+
+	if msg.Role != providers.RoleAssistant && len(msg.ToolCalls) > 0 {
+		return errors.NewUnsupportedParamError(providerName, "messages.tool_calls")
+	}
+
+	if msg.Role != providers.RoleAssistant && msg.Reasoning != nil {
+		return errors.NewUnsupportedParamError(providerName, "messages.reasoning")
+	}
+
+	return nil
+}
+
+func convertRequestToolCalls(toolCalls []providers.ToolCall) ([]api.ToolCall, error) {
+	if len(toolCalls) == 0 {
+		return nil, nil
+	}
+
+	converted := make([]api.ToolCall, 0, len(toolCalls))
+	for _, toolCall := range toolCalls {
+		if toolCall.Type != toolTypeFunction {
+			return nil, errors.NewUnsupportedParamError(providerName, "messages.tool_calls.type")
+		}
+
+		var arguments api.ToolCallFunctionArguments
+		if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &arguments); err != nil {
+			return nil, errors.NewInvalidRequestError(
+				providerName,
+				fmt.Errorf("tool arguments must be a JSON object: %w", err),
+			)
+		}
+
+		converted = append(converted, api.ToolCall{
+			Function: api.ToolCallFunction{
+				Name:      toolCall.Function.Name,
+				Arguments: arguments,
+			},
+		})
+	}
+
+	return converted, nil
 }
 
 // convertMessages converts provider messages to Ollama format.
-func convertMessages(messages []providers.Message) []api.Message {
+func convertMessages(messages []providers.Message) ([]api.Message, error) {
 	result := make([]api.Message, 0, len(messages))
+	toolNames := make(map[string]string)
 
 	for _, msg := range messages {
-		ollamaMsg := convertMessage(msg)
-		if ollamaMsg != nil {
-			result = append(result, *ollamaMsg)
+		converted, err := convertMessage(msg)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, toolCall := range msg.ToolCalls {
+			if toolCall.ID != "" {
+				toolNames[toolCall.ID] = toolCall.Function.Name
+			}
+		}
+		// https://docs.ollama.com/capabilities/tool-calling identifies tool
+		// results by tool_name. Resolve the normalized call ID before encoding.
+		if msg.Role == providers.RoleTool && converted.ToolName == "" {
+			converted.ToolName = toolNames[msg.ToolCallID]
+			if converted.ToolName == "" {
+				return nil, errors.NewInvalidRequestError(
+					providerName,
+					stderrors.New("tool result requires a name or a matching tool call ID"),
+				)
+			}
+		}
+
+		result = append(result, *converted)
+	}
+
+	return result, nil
+}
+
+func convertMessageContent(msg providers.Message) (string, []api.ImageData, error) {
+	if content, ok := msg.Content.(string); ok {
+		return content, nil, nil
+	}
+
+	if msg.Content == nil {
+		return "", nil, nil
+	}
+
+	switch msg.Content.(type) {
+	case []providers.ContentPart, []any:
+	default:
+		return "", nil, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("unsupported message content type %T", msg.Content),
+		)
+	}
+
+	parts := msg.ContentParts()
+	if raw, ok := msg.Content.([]any); ok && len(parts) != len(raw) {
+		return "", nil, errors.NewInvalidRequestError(
+			providerName,
+			stderrors.New("message contains an invalid content part"),
+		)
+	}
+
+	var (
+		content strings.Builder
+		images  []api.ImageData
+	)
+
+	for _, part := range parts {
+		text, image, err := convertContentPart(part)
+		if err != nil {
+			return "", nil, err
+		}
+
+		content.WriteString(text)
+
+		if image != nil {
+			images = append(images, image)
 		}
 	}
 
-	return result
+	return content.String(), images, nil
+}
+
+func convertContentPart(part providers.ContentPart) (string, api.ImageData, error) {
+	switch part.Type {
+	case contentTypeText:
+		if part.ImageURL != nil {
+			return "", nil, errors.NewInvalidRequestError(
+				providerName,
+				stderrors.New("text content cannot include image_url"),
+			)
+		}
+
+		return part.Text, nil, nil
+	case contentTypeImageURL:
+		if part.Text != "" || part.ImageURL == nil {
+			return "", nil, errors.NewInvalidRequestError(
+				providerName,
+				stderrors.New("image content requires image_url only"),
+			)
+		}
+
+		decoded, err := decodeImageDataURL(part.ImageURL.URL)
+		if err != nil {
+			return "", nil, err
+		}
+
+		return "", api.ImageData(decoded), nil
+	default:
+		return "", nil, errors.NewUnsupportedParamError(providerName, "messages.content.type")
+	}
+}
+
+func decodeImageDataURL(dataURL string) ([]byte, error) {
+	metadata, encoded, ok := strings.Cut(dataURL, ",")
+	if !ok || !strings.HasPrefix(metadata, "data:") || !strings.HasSuffix(metadata, ";base64") {
+		return nil, errors.NewUnsupportedParamError(providerName, "messages.content.image_url")
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("image content must contain valid base64: %w", err),
+		)
+	}
+
+	return decoded, nil
 }
 
 // convertModelsResponse converts an Ollama list response to provider format.
@@ -531,12 +752,18 @@ func convertModelsResponse(resp *api.ListResponse) *providers.ModelsResponse {
 
 // convertResponse converts an Ollama response to provider format.
 func convertResponse(resp *api.ChatResponse) *providers.ChatCompletion {
-	content, reasoning := extractThinking(resp.Message.Content, resp.Message.Thinking)
-
 	message := providers.Message{
-		Role:      providers.RoleAssistant,
-		Content:   content,
-		Reasoning: reasoning,
+		Role:    providers.RoleAssistant,
+		Content: resp.Message.Content,
+	}
+	// Native thinking takes precedence; older models may embed reasoning in content.
+	if resp.Message.Thinking != "" {
+		message.Reasoning = &providers.Reasoning{Content: resp.Message.Thinking}
+	} else if before, tagged, found := strings.Cut(resp.Message.Content, "<think>"); found {
+		if thinking, after, closed := strings.Cut(tagged, "</think>"); closed {
+			message.Content = strings.TrimSpace(before + after)
+			message.Reasoning = &providers.Reasoning{Content: thinking}
+		}
 	}
 
 	// Handle tool calls.
@@ -568,22 +795,39 @@ func convertResponse(resp *api.ChatResponse) *providers.ChatCompletion {
 }
 
 // convertResponseFormat converts a response format to Ollama JSON schema.
-func convertResponseFormat(format *providers.ResponseFormat) json.RawMessage {
+func convertResponseFormat(format *providers.ResponseFormat) (json.RawMessage, error) {
 	if format == nil {
-		return nil
+		return nil, nil
 	}
 
 	if format.Type == responseFormatJSON {
-		return json.RawMessage(`"` + ollamaFormatJSON + `"`)
+		return json.RawMessage(`"` + ollamaFormatJSON + `"`), nil
 	}
 
-	if format.Type == responseFormatSchema && format.JSONSchema != nil {
-		if schemaBytes, err := json.Marshal(format.JSONSchema.Schema); err == nil {
-			return schemaBytes
+	if format.Type == responseFormatSchema {
+		if format.JSONSchema == nil || format.JSONSchema.Schema == nil {
+			return nil, errors.NewInvalidRequestError(
+				providerName,
+				stderrors.New("json_schema response format requires a schema"),
+			)
 		}
+
+		if format.JSONSchema.Strict != nil && *format.JSONSchema.Strict {
+			return nil, errors.NewUnsupportedParamError(providerName, "response_format.json_schema.strict")
+		}
+
+		schemaBytes, err := json.Marshal(format.JSONSchema.Schema)
+		if err != nil {
+			return nil, errors.NewInvalidRequestError(
+				providerName,
+				fmt.Errorf("response schema must be valid JSON: %w", err),
+			)
+		}
+
+		return schemaBytes, nil
 	}
 
-	return nil
+	return nil, errors.NewUnsupportedParamError(providerName, "response_format.type")
 }
 
 // convertToolCalls converts Ollama tool calls to provider format.
@@ -591,16 +835,15 @@ func convertToolCalls(toolCalls []api.ToolCall) []providers.ToolCall {
 	result := make([]providers.ToolCall, 0, len(toolCalls))
 
 	for i, tc := range toolCalls {
-		args := emptyJSONObject
-		argsMap := tc.Function.Arguments.ToMap()
-		if len(argsMap) > 0 {
-			if argsBytes, err := json.Marshal(argsMap); err == nil {
-				args = string(argsBytes)
-			}
+		args := tc.Function.Arguments.String()
+
+		toolCallID := tc.ID
+		if toolCallID == "" {
+			toolCallID = fmt.Sprintf(toolCallIDFormat, i)
 		}
 
 		result = append(result, providers.ToolCall{
-			ID:   fmt.Sprintf(toolCallIDFormat, i),
+			ID:   toolCallID,
 			Type: toolTypeFunction,
 			Function: providers.FunctionCall{
 				Name:      tc.Function.Name,
@@ -612,137 +855,132 @@ func convertToolCalls(toolCalls []api.ToolCall) []providers.ToolCall {
 	return result
 }
 
-// convertToolMessage converts a tool message to Ollama format.
-func convertToolMessage(msg providers.Message) *api.Message {
-	// Ollama uses user role for tool results.
-	return &api.Message{
-		Role:    providers.RoleUser,
-		Content: msg.ContentString(),
-	}
-}
-
 // convertTools converts provider tools to Ollama format.
-func convertTools(tools []providers.Tool) api.Tools {
+func convertTools(tools []providers.Tool) (api.Tools, error) {
+	if len(tools) == 0 {
+		return nil, nil
+	}
+
 	result := make(api.Tools, 0, len(tools))
 
 	for _, tool := range tools {
-		params := api.ToolFunctionParameters{
-			Type: schemaTypeObject,
+		if tool.Type != toolTypeFunction {
+			return nil, errors.NewUnsupportedParamError(providerName, "tools.type")
 		}
 
-		// Convert properties.
-		if props, ok := tool.Function.Parameters[schemaKeyProperties].(map[string]any); ok {
-			propsMap := api.NewToolPropertiesMap()
-			for name, prop := range props {
-				if propMap, ok := prop.(map[string]any); ok {
-					tp := api.ToolProperty{}
-					if t, ok := propMap[schemaKeyType].(string); ok {
-						tp.Type = api.PropertyType{t}
-					}
-					if d, ok := propMap[schemaKeyDescription].(string); ok {
-						tp.Description = d
-					}
-					propsMap.Set(name, tp)
-				}
-			}
-			params.Properties = propsMap
+		parameters, err := convertToolParameters(tool.Function.Parameters)
+		if err != nil {
+			return nil, err
 		}
 
-		// Convert required fields.
-		if req, ok := tool.Function.Parameters[schemaKeyRequired].([]any); ok {
-			for _, r := range req {
-				if s, ok := r.(string); ok {
-					params.Required = append(params.Required, s)
-				}
-			}
-		}
-
-		ollamaTool := api.Tool{
+		result = append(result, api.Tool{
 			Type: toolTypeFunction,
 			Function: api.ToolFunction{
 				Name:        tool.Function.Name,
 				Description: tool.Function.Description,
-				Parameters:  params,
+				Parameters:  parameters,
 			},
-		}
-
-		result = append(result, ollamaTool)
+		})
 	}
 
-	return result
+	return result, nil
 }
 
-// convertUserMessage converts a user message to Ollama format.
-func convertUserMessage(msg providers.Message) *api.Message {
-	ollamaMsg := &api.Message{
-		Role:    msg.Role,
-		Content: msg.ContentString(),
+func convertToolParameters(parameters map[string]any) (api.ToolFunctionParameters, error) {
+	normalizedParameters := map[string]any{
+		schemaKeyType:       schemaTypeObject,
+		schemaKeyProperties: nil,
+	}
+	maps.Copy(normalizedParameters, parameters)
+	parameters = normalizedParameters
+
+	encoded, err := json.Marshal(parameters)
+	if err != nil {
+		return api.ToolFunctionParameters{}, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("tool schema must be valid JSON: %w", err),
+		)
 	}
 
-	// Handle multi-modal messages with images.
-	if msg.IsMultiModal() {
-		images := extractImages(msg)
-		if len(images) > 0 {
-			ollamaMsg.Images = images
-		}
+	var converted api.ToolFunctionParameters
+	if unmarshalErr := json.Unmarshal(encoded, &converted); unmarshalErr != nil {
+		return api.ToolFunctionParameters{}, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("tool schema is invalid: %w", unmarshalErr),
+		)
 	}
 
-	return ollamaMsg
+	normalized, decodeErr := decodeJSONUseNumber(encoded)
+	if decodeErr != nil {
+		return api.ToolFunctionParameters{}, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("tool schema cannot be compared: %w", decodeErr),
+		)
+	}
+	normalizeToolSchemaSDKOmissions(normalized)
+
+	// https://docs.ollama.com/api/chat accepts JSON Schema, while the Go SDK
+	// exposes a typed subset. Reject schemas the SDK would silently weaken.
+	roundTripJSON, err := json.Marshal(converted)
+	if err != nil {
+		return api.ToolFunctionParameters{}, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("tool schema cannot be encoded: %w", err),
+		)
+	}
+
+	roundTrip, decodeErr := decodeJSONUseNumber(roundTripJSON)
+	if decodeErr != nil {
+		return api.ToolFunctionParameters{}, errors.NewInvalidRequestError(
+			providerName,
+			fmt.Errorf("tool schema cannot be compared: %w", decodeErr),
+		)
+	}
+
+	if !reflect.DeepEqual(normalized, roundTrip) {
+		return api.ToolFunctionParameters{}, errors.NewUnsupportedParamError(providerName, "tools.function.parameters")
+	}
+
+	return converted, nil
 }
 
-// extractImages extracts base64 image data from a multi-modal message.
-func extractImages(msg providers.Message) []api.ImageData {
-	var images []api.ImageData
-
-	for _, part := range msg.ContentParts() {
-		if part.Type != contentTypeImageURL || part.ImageURL == nil {
-			continue
-		}
-
-		imgURL := part.ImageURL.URL
-		if !strings.HasPrefix(imgURL, dataImagePrefix) {
-			continue
-		}
-
-		// Extract base64 data from data URL.
-		parts := strings.SplitN(imgURL, ",", 2)
-		if len(parts) != 2 {
-			continue
-		}
-
-		images = append(images, api.ImageData(parts[1]))
+func normalizeToolSchemaSDKOmissions(value any) {
+	schema, ok := value.(map[string]any)
+	if !ok {
+		return
 	}
 
-	return images
+	if required, exists := schema[schemaKeyRequired]; exists {
+		if values, isArray := required.([]any); isArray && len(values) == 0 {
+			delete(schema, schemaKeyRequired)
+		}
+	}
+
+	properties, ok := schema[schemaKeyProperties].(map[string]any)
+	if !ok {
+		return
+	}
+	for _, propertyValue := range properties {
+		property, isObject := propertyValue.(map[string]any)
+		if !isObject {
+			continue
+		}
+		if description, exists := property[schemaKeyDescription]; exists && description == "" {
+			delete(property, schemaKeyDescription)
+		}
+		normalizeToolSchemaSDKOmissions(property)
+	}
 }
 
-// extractThinking extracts thinking content from response.
-// It checks the dedicated Thinking field first, then falls back to parsing <think> tags.
-func extractThinking(content, thinking string) (string, *providers.Reasoning) {
-	// Check for dedicated thinking content first.
-	if thinking != "" {
-		return content, &providers.Reasoning{Content: thinking}
-	}
+func decodeJSONUseNumber(data []byte) (any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
 
-	// Fall back to parsing <think> tags in content.
-	if !strings.Contains(content, thinkingTagOpen) || !strings.Contains(content, thinkingTagClose) {
-		return content, nil
-	}
+	var value any
 
-	parts := strings.SplitN(content, thinkingTagOpen, 2)
-	if len(parts) != 2 {
-		return content, nil
-	}
+	err := decoder.Decode(&value)
 
-	thinkParts := strings.SplitN(parts[1], thinkingTagClose, 2)
-	if len(thinkParts) != 2 {
-		return content, nil
-	}
-
-	reasoning := &providers.Reasoning{Content: thinkParts[0]}
-	cleanContent := strings.TrimSpace(parts[0] + thinkParts[1])
-
-	return cleanContent, reasoning
+	return value, err
 }
 
 // generateID generates a unique ID for responses using crypto/rand.

--- a/providers/ollama/ollama_test.go
+++ b/providers/ollama/ollama_test.go
@@ -2,8 +2,11 @@ package ollama
 
 import (
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -17,7 +20,31 @@ import (
 	"github.com/mozilla-ai/any-llm-go/providers"
 )
 
-const testOllamaAvailabilityTimeout = 5 * time.Second
+const (
+	testOllamaAvailabilityTimeout = 5 * time.Second
+	// This fixture is independently derived from the current Chat OpenAPI and
+	// tool-calling guide, so it does not reuse the converter's assumptions.
+	documentedChatRequestJSON = `{
+		"model":"model",
+		"messages":[
+			{"role":"user","content":"look","images":["aGVsbG8="]},
+			{
+				"role":"assistant",
+				"content":"",
+				"thinking":"thought",
+				"tool_calls":[{
+					"function":{
+						"index":0,
+						"name":"weather",
+						"arguments":{"city":"Paris"}
+					}
+				}]
+			},
+			{"role":"tool","content":"sunny","tool_name":"weather"}
+		],
+		"options":{"num_ctx":32000}
+	}`
+)
 
 func TestNew(t *testing.T) {
 	// Note: Not using t.Parallel() here because child test uses t.Setenv.
@@ -66,6 +93,124 @@ func TestCapabilities(t *testing.T) {
 	require.True(t, caps.ListModels)
 }
 
+func TestCompletionSendsEstablishedContextDefault(t *testing.T) {
+	t.Parallel()
+
+	requestBody := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		requestBody <- body
+		w.Header().Set("Content-Type", "application/json")
+		_, err := fmt.Fprintln(w, `{"model":"test","message":{"role":"assistant","content":"ok"},"done":true}`)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := New(config.WithBaseURL(server.URL))
+	require.NoError(t, err)
+	_, err = provider.Completion(t.Context(), providers.CompletionParams{
+		Model:    "test",
+		Messages: []providers.Message{{Role: providers.RoleUser, Content: "hello"}},
+	})
+	require.NoError(t, err)
+
+	body := <-requestBody
+	options, ok := body["options"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, float64(32000), options["num_ctx"])
+}
+
+func TestConvertParamsPreservesDocumentedReasoningControls(t *testing.T) {
+	t.Parallel()
+
+	provider := &Provider{}
+	none, err := provider.convertParams(providers.CompletionParams{ReasoningEffort: providers.ReasoningEffortNone})
+	require.NoError(t, err)
+	require.Equal(t, false, none.Think.Value)
+
+	// These wire values match Ollama's MIT-licensed api/types_test.go fixtures.
+	for _, testCase := range []struct {
+		name   string
+		effort providers.ReasoningEffort
+		want   string
+	}{
+		{name: "low", effort: providers.ReasoningEffortLow, want: "low"},
+		{name: "medium", effort: providers.ReasoningEffortMedium, want: "medium"},
+		{name: "high", effort: providers.ReasoningEffortHigh, want: "high"},
+		{name: "max", effort: providers.ReasoningEffort("max"), want: "max"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			converted, convertErr := provider.convertParams(providers.CompletionParams{
+				ReasoningEffort: testCase.effort,
+			})
+			require.NoError(t, convertErr)
+			require.Equal(t, testCase.want, converted.Think.Value)
+		})
+	}
+
+	req, err := provider.convertParams(providers.CompletionParams{ReasoningEffort: providers.ReasoningEffortAuto})
+	require.NoError(t, err)
+	require.Nil(t, req.Think)
+
+	_, err = provider.convertParams(providers.CompletionParams{ReasoningEffort: providers.ReasoningEffort("xhigh")})
+	require.ErrorIs(t, err, errors.ErrUnsupportedParam)
+}
+
+func TestConvertParamsRejectsUnsupportedFields(t *testing.T) {
+	t.Parallel()
+
+	provider := &Provider{}
+	for _, params := range []providers.CompletionParams{
+		{StreamOptions: &providers.StreamOptions{}},
+		{ToolChoice: "auto"},
+		{ParallelToolCalls: new(false)},
+		{User: "user-1"},
+		{Extra: map[string]any{"unknown": true}},
+	} {
+		_, err := provider.convertParams(params)
+		require.ErrorIs(t, err, errors.ErrUnsupportedParam)
+	}
+}
+
+func TestConvertParamsMatchesDocumentedMessageWire(t *testing.T) {
+	t.Parallel()
+
+	provider := &Provider{}
+	req, err := provider.convertParams(providers.CompletionParams{
+		Model: "model",
+		Messages: []providers.Message{
+			{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{
+					{Type: contentTypeText, Text: "look"},
+					{Type: contentTypeImageURL, ImageURL: &providers.ImageURL{URL: "data:image/png;base64,aGVsbG8="}},
+				},
+			},
+			{
+				Role:      providers.RoleAssistant,
+				Reasoning: &providers.Reasoning{Content: "thought"},
+				ToolCalls: []providers.ToolCall{{
+					ID:   "call_1",
+					Type: toolTypeFunction,
+					Function: providers.FunctionCall{
+						Name:      "weather",
+						Arguments: `{"city":"Paris"}`,
+					},
+				}},
+			},
+			{Role: providers.RoleTool, Content: "sunny", ToolCallID: "call_1"},
+		},
+	})
+	require.NoError(t, err)
+
+	encoded, err := json.Marshal(req)
+	require.NoError(t, err)
+	require.JSONEq(t, documentedChatRequestJSON, string(encoded))
+}
+
 func TestConvertMessages(t *testing.T) {
 	t.Parallel()
 
@@ -76,7 +221,8 @@ func TestConvertMessages(t *testing.T) {
 			{Role: providers.RoleSystem, Content: "You are a helpful assistant."},
 		}
 
-		result := convertMessages(messages)
+		result, err := convertMessages(messages)
+		require.NoError(t, err)
 
 		require.Len(t, result, 1)
 		require.Equal(t, providers.RoleSystem, result[0].Role)
@@ -90,7 +236,8 @@ func TestConvertMessages(t *testing.T) {
 			{Role: providers.RoleUser, Content: "Hello"},
 		}
 
-		result := convertMessages(messages)
+		result, err := convertMessages(messages)
+		require.NoError(t, err)
 
 		require.Len(t, result, 1)
 		require.Equal(t, providers.RoleUser, result[0].Role)
@@ -104,24 +251,28 @@ func TestConvertMessages(t *testing.T) {
 			{Role: providers.RoleAssistant, Content: "Hi there!"},
 		}
 
-		result := convertMessages(messages)
+		result, err := convertMessages(messages)
+		require.NoError(t, err)
 
 		require.Len(t, result, 1)
 		require.Equal(t, providers.RoleAssistant, result[0].Role)
 		require.Equal(t, "Hi there!", result[0].Content)
 	})
 
-	t.Run("converts tool message to user message", func(t *testing.T) {
+	t.Run("converts tool message", func(t *testing.T) {
 		t.Parallel()
 
 		messages := []providers.Message{
-			{Role: providers.RoleTool, Content: "sunny, 22°C", ToolCallID: "call_123"},
+			{Role: providers.RoleTool, Content: "sunny, 22°C", Name: "get_weather", ToolCallID: "call_123"},
 		}
 
-		result := convertMessages(messages)
+		result, err := convertMessages(messages)
+		require.NoError(t, err)
 
 		require.Len(t, result, 1)
-		require.Equal(t, providers.RoleUser, result[0].Role) // Ollama uses user for tool results.
+		require.Equal(t, providers.RoleTool, result[0].Role)
+		require.Equal(t, "get_weather", result[0].ToolName)
+		require.Empty(t, result[0].ToolCallID)
 	})
 
 	t.Run("converts assistant message with tool calls", func(t *testing.T) {
@@ -144,12 +295,25 @@ func TestConvertMessages(t *testing.T) {
 			},
 		}
 
-		result := convertMessages(messages)
+		result, err := convertMessages(messages)
+		require.NoError(t, err)
 
 		require.Len(t, result, 1)
 		require.Equal(t, providers.RoleAssistant, result[0].Role)
 		require.Len(t, result[0].ToolCalls, 1)
+		require.Empty(t, result[0].ToolCalls[0].ID)
 		require.Equal(t, "get_weather", result[0].ToolCalls[0].Function.Name)
+	})
+
+	t.Run("rejects an unidentified tool result", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := convertMessages([]providers.Message{{
+			Role:       providers.RoleTool,
+			Content:    "result",
+			ToolCallID: "missing",
+		}})
+		require.ErrorIs(t, err, errors.ErrInvalidRequest)
 	})
 }
 
@@ -179,7 +343,7 @@ func TestConvertDoneReason(t *testing.T) {
 		{
 			name:     "unknown reason",
 			reason:   "unknown",
-			expected: providers.FinishReasonStop,
+			expected: "unknown",
 		},
 	}
 
@@ -193,7 +357,7 @@ func TestConvertDoneReason(t *testing.T) {
 	}
 }
 
-func TestExtractImages(t *testing.T) {
+func TestConvertMessageContent(t *testing.T) {
 	t.Parallel()
 
 	t.Run("extracts base64 image", func(t *testing.T) {
@@ -206,19 +370,21 @@ func TestExtractImages(t *testing.T) {
 				{
 					Type: "image_url",
 					ImageURL: &providers.ImageURL{
-						URL: "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+						URL: "data:image/jpeg;base64,aGVsbG8=",
 					},
 				},
 			},
 		}
 
-		images := extractImages(msg)
+		content, images, err := convertMessageContent(msg)
+		require.NoError(t, err)
 
+		require.Equal(t, "What's in this image?", content)
 		require.Len(t, images, 1)
-		require.Equal(t, "/9j/4AAQSkZJRg==", string(images[0]))
+		require.Equal(t, "hello", string(images[0]))
 	})
 
-	t.Run("ignores non-data URLs", func(t *testing.T) {
+	t.Run("rejects non-data URLs", func(t *testing.T) {
 		t.Parallel()
 
 		msg := providers.Message{
@@ -233,9 +399,10 @@ func TestExtractImages(t *testing.T) {
 			},
 		}
 
-		images := extractImages(msg)
+		_, images, err := convertMessageContent(msg)
 
 		require.Empty(t, images)
+		require.ErrorIs(t, err, errors.ErrUnsupportedParam)
 	})
 }
 
@@ -262,13 +429,85 @@ func TestConvertTools(t *testing.T) {
 		},
 	}
 
-	result := convertTools(tools)
+	result, err := convertTools(tools)
+	require.NoError(t, err)
 
 	require.Len(t, result, 1)
 	require.Equal(t, toolTypeFunction, result[0].Type)
 	require.Equal(t, "get_weather", result[0].Function.Name)
 	require.Equal(t, "Get the current weather", result[0].Function.Description)
 	require.Contains(t, result[0].Function.Parameters.Required, "location")
+	require.Equal(t, "The city name", result[0].Function.Parameters.Properties.ToMap()["location"].Description)
+
+	for _, test := range []struct {
+		parameters     map[string]any
+		wantProperties bool
+	}{
+		{parameters: nil},
+		{parameters: map[string]any{}},
+		{parameters: map[string]any{schemaKeyType: schemaTypeObject}},
+		{parameters: map[string]any{schemaKeyType: schemaTypeObject, schemaKeyProperties: map[string]any{}, schemaKeyRequired: []any{}}, wantProperties: true},
+		{parameters: map[string]any{schemaKeyType: schemaTypeObject, schemaKeyProperties: map[string]any{"city": map[string]any{
+			schemaKeyType: "string", schemaKeyDescription: "",
+		}}}, wantProperties: true},
+	} {
+		parameters := test.parameters
+		before, marshalErr := json.Marshal(parameters)
+		require.NoError(t, marshalErr)
+
+		converted, convertErr := convertToolParameters(parameters)
+		require.NoError(t, convertErr)
+		require.Equal(t, schemaTypeObject, converted.Type)
+		require.Equal(t, test.wantProperties, converted.Properties != nil)
+
+		after, marshalErr := json.Marshal(parameters)
+		require.NoError(t, marshalErr)
+		require.JSONEq(t, string(before), string(after))
+	}
+
+	_, err = convertTools([]providers.Tool{{Type: "custom"}})
+	require.ErrorIs(t, err, errors.ErrUnsupportedParam)
+
+	_, err = convertTools([]providers.Tool{{
+		Type: toolTypeFunction,
+		Function: providers.Function{
+			Parameters: map[string]any{
+				schemaKeyType:          schemaTypeObject,
+				"additionalProperties": false,
+			},
+		},
+	}})
+	require.ErrorIs(t, err, errors.ErrUnsupportedParam)
+
+	for _, minimum := range []json.Number{"7", "9007199254740993"} {
+		_, err = convertTools([]providers.Tool{{
+			Type: toolTypeFunction,
+			Function: providers.Function{
+				Parameters: map[string]any{
+					schemaKeyType: schemaTypeObject,
+					schemaKeyProperties: map[string]any{
+						"count": map[string]any{schemaKeyType: "integer", "minimum": minimum},
+					},
+				},
+			},
+		}})
+		require.ErrorIs(t, err, errors.ErrUnsupportedParam)
+	}
+
+	_, err = convertTools([]providers.Tool{{
+		Type: toolTypeFunction,
+		Function: providers.Function{
+			Name:        "",
+			Description: "",
+			Parameters: map[string]any{
+				schemaKeyType: schemaTypeObject,
+				"$defs": map[string]any{
+					"large": map[string]any{schemaKeyType: "integer", "minimum": json.Number("9007199254740993")},
+				},
+			},
+		},
+	}})
+	require.ErrorIs(t, err, errors.ErrUnsupportedParam)
 }
 
 func TestConvertToolCalls(t *testing.T) {
@@ -279,20 +518,69 @@ func TestConvertToolCalls(t *testing.T) {
 
 	toolCalls := []api.ToolCall{
 		{
+			ID: "provider-call-id",
 			Function: api.ToolCallFunction{
 				Name:      "get_weather",
 				Arguments: args,
 			},
 		},
+		{Function: api.ToolCallFunction{Name: "no_id", Arguments: args}},
 	}
 
 	result := convertToolCalls(toolCalls)
 
-	require.Len(t, result, 1)
-	require.Equal(t, "call_0", result[0].ID)
+	require.Len(t, result, 2)
+	require.Equal(t, "provider-call-id", result[0].ID)
 	require.Equal(t, toolTypeFunction, result[0].Type)
 	require.Equal(t, "get_weather", result[0].Function.Name)
 	require.Contains(t, result[0].Function.Arguments, "Paris")
+	require.Equal(t, "call_1", result[1].ID)
+}
+
+func TestConvertResponsePreservesThinking(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name      string
+		content   string
+		thinking  string
+		want      string
+		reasoning *providers.Reasoning
+	}{
+		{
+			name: "native thinking takes precedence", content: "<think>tagged</think>answer", thinking: "native",
+			want: "<think>tagged</think>answer", reasoning: &providers.Reasoning{Content: "native"},
+		},
+		{
+			name: "legacy tags", content: "<think>private chain</think>public answer",
+			want: "public answer", reasoning: &providers.Reasoning{Content: "private chain"},
+		},
+		{
+			name: "surrounding content", content: "  before<think>reason</think>after  ",
+			want: "beforeafter", reasoning: &providers.Reasoning{Content: "reason"},
+		},
+		{
+			name: "first complete block", content: "<think>first</think><think>second</think>answer",
+			want: "<think>second</think>answer", reasoning: &providers.Reasoning{Content: "first"},
+		},
+		{
+			name: "empty tagged thinking", content: "<think></think>answer",
+			want: "answer", reasoning: &providers.Reasoning{},
+		},
+		{name: "plain content", content: "  public answer  ", want: "  public answer  "},
+		{name: "unclosed tag", content: "<think>unfinished", want: "<think>unfinished"},
+		{name: "unopened tag", content: "answer</think>", want: "answer</think>"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := convertResponse(&api.ChatResponse{
+				Message: api.Message{Content: testCase.content, Thinking: testCase.thinking},
+			})
+			require.Equal(t, testCase.want, result.Choices[0].Message.Content)
+			require.Equal(t, testCase.reasoning, result.Choices[0].Message.Reasoning)
+		})
+	}
 }
 
 func TestConvertResponseFormat(t *testing.T) {
@@ -301,7 +589,8 @@ func TestConvertResponseFormat(t *testing.T) {
 	t.Run("nil format returns nil", func(t *testing.T) {
 		t.Parallel()
 
-		result := convertResponseFormat(nil)
+		result, err := convertResponseFormat(nil)
+		require.NoError(t, err)
 		require.Nil(t, result)
 	})
 
@@ -309,7 +598,8 @@ func TestConvertResponseFormat(t *testing.T) {
 		t.Parallel()
 
 		format := &providers.ResponseFormat{Type: responseFormatJSON}
-		result := convertResponseFormat(format)
+		result, err := convertResponseFormat(format)
+		require.NoError(t, err)
 
 		require.NotNil(t, result)
 		require.Equal(t, `"json"`, string(result))
@@ -330,50 +620,182 @@ func TestConvertResponseFormat(t *testing.T) {
 				},
 			},
 		}
-		result := convertResponseFormat(format)
+		result, err := convertResponseFormat(format)
+		require.NoError(t, err)
 
 		require.NotNil(t, result)
 		require.Contains(t, string(result), schemaKeyProperties)
 	})
+
+	t.Run("rejects missing json schema", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := convertResponseFormat(&providers.ResponseFormat{Type: responseFormatSchema})
+		require.ErrorIs(t, err, errors.ErrInvalidRequest)
+	})
+
+	t.Run("rejects unencodable json schema", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := convertResponseFormat(&providers.ResponseFormat{
+			Type: responseFormatSchema,
+			JSONSchema: &providers.JSONSchema{
+				Schema: map[string]any{"value": make(chan int)},
+			},
+		})
+		require.ErrorIs(t, err, errors.ErrInvalidRequest)
+	})
+
+	t.Run("accepts explicit non-strict json schema", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := convertResponseFormat(&providers.ResponseFormat{
+			Type: responseFormatSchema,
+			JSONSchema: &providers.JSONSchema{
+				Schema: map[string]any{"type": "object"},
+				Strict: new(false),
+			},
+		})
+		require.NoError(t, err)
+		require.JSONEq(t, `{"type":"object"}`, string(result))
+	})
+
+	t.Run("rejects strict json schema", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := convertResponseFormat(&providers.ResponseFormat{
+			Type:       responseFormatSchema,
+			JSONSchema: &providers.JSONSchema{Schema: map[string]any{}, Strict: new(true)},
+		})
+		require.ErrorIs(t, err, errors.ErrUnsupportedParam)
+	})
+
+	t.Run("rejects unknown format", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := convertResponseFormat(&providers.ResponseFormat{Type: "yaml"})
+		require.ErrorIs(t, err, errors.ErrUnsupportedParam)
+	})
 }
 
-func TestConvertMessage(t *testing.T) {
+func TestConvertMessageRejectsInvalidInput(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name         string
-		msg          providers.Message
-		expectedRole string
+	for _, testCase := range []struct {
+		name     string
+		message  providers.Message
+		sentinel error
 	}{
 		{
-			name:         "user message",
-			msg:          providers.Message{Role: providers.RoleUser, Content: "Hello"},
-			expectedRole: providers.RoleUser,
+			name:     "unknown role",
+			message:  providers.Message{Role: "developer", Content: "content"},
+			sentinel: errors.ErrInvalidRequest,
 		},
 		{
-			name:         "assistant message",
-			msg:          providers.Message{Role: providers.RoleAssistant, Content: "Hi"},
-			expectedRole: providers.RoleAssistant,
+			name:     "name on user message",
+			message:  providers.Message{Role: providers.RoleUser, Content: "content", Name: "name"},
+			sentinel: errors.ErrUnsupportedParam,
 		},
 		{
-			name:         "system message",
-			msg:          providers.Message{Role: providers.RoleSystem, Content: "You are helpful"},
-			expectedRole: providers.RoleSystem,
+			name: "tool call on user message",
+			message: providers.Message{
+				Role:      providers.RoleUser,
+				Content:   "content",
+				ToolCalls: []providers.ToolCall{{Type: toolTypeFunction}},
+			},
+			sentinel: errors.ErrUnsupportedParam,
 		},
 		{
-			name:         "tool message becomes user",
-			msg:          providers.Message{Role: providers.RoleTool, Content: "result", ToolCallID: "123"},
-			expectedRole: providers.RoleUser,
+			name: "reasoning on user message",
+			message: providers.Message{
+				Role:      providers.RoleUser,
+				Content:   "content",
+				Reasoning: &providers.Reasoning{Content: "thought"},
+			},
+			sentinel: errors.ErrUnsupportedParam,
 		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		{
+			name: "unsupported tool-call type",
+			message: providers.Message{
+				Role: providers.RoleAssistant,
+				ToolCalls: []providers.ToolCall{{
+					Type:     "custom",
+					Function: providers.FunctionCall{Name: "tool", Arguments: `{}`},
+				}},
+			},
+			sentinel: errors.ErrUnsupportedParam,
+		},
+		{
+			name: "invalid tool arguments",
+			message: providers.Message{
+				Role: providers.RoleAssistant,
+				ToolCalls: []providers.ToolCall{{
+					Type:     toolTypeFunction,
+					Function: providers.FunctionCall{Name: "tool", Arguments: "["},
+				}},
+			},
+			sentinel: errors.ErrInvalidRequest,
+		},
+		{
+			name: "non-object tool arguments",
+			message: providers.Message{
+				Role: providers.RoleAssistant,
+				ToolCalls: []providers.ToolCall{{
+					Type:     toolTypeFunction,
+					Function: providers.FunctionCall{Name: "tool", Arguments: `[]`},
+				}},
+			},
+			sentinel: errors.ErrInvalidRequest,
+		},
+		{
+			name:     "unparseable content part",
+			message:  providers.Message{Role: providers.RoleUser, Content: []any{"content"}},
+			sentinel: errors.ErrInvalidRequest,
+		},
+		{
+			name:     "unsupported content representation",
+			message:  providers.Message{Role: providers.RoleUser, Content: 42},
+			sentinel: errors.ErrInvalidRequest,
+		},
+		{
+			name:     "unknown content type",
+			message:  providers.Message{Role: providers.RoleUser, Content: []providers.ContentPart{{Type: "audio"}}},
+			sentinel: errors.ErrUnsupportedParam,
+		},
+		{
+			name: "text with image field",
+			message: providers.Message{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{{
+					Type:     contentTypeText,
+					Text:     "content",
+					ImageURL: &providers.ImageURL{URL: "data:image/png;base64,aGVsbG8="},
+				}},
+			},
+			sentinel: errors.ErrInvalidRequest,
+		},
+		{
+			name:     "missing image URL",
+			message:  providers.Message{Role: providers.RoleUser, Content: []providers.ContentPart{{Type: contentTypeImageURL}}},
+			sentinel: errors.ErrInvalidRequest,
+		},
+		{
+			name: "invalid image base64",
+			message: providers.Message{
+				Role: providers.RoleUser,
+				Content: []providers.ContentPart{{
+					Type:     contentTypeImageURL,
+					ImageURL: &providers.ImageURL{URL: "data:image/png;base64,%%%"},
+				}},
+			},
+			sentinel: errors.ErrInvalidRequest,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := convertMessage(tc.msg)
-			require.NotNil(t, result)
-			require.Equal(t, tc.expectedRole, result.Role)
+			_, err := convertMessage(testCase.message)
+			require.ErrorIs(t, err, testCase.sentinel)
 		})
 	}
 }
@@ -384,7 +806,7 @@ func TestNewStreamState(t *testing.T) {
 	state := newStreamState()
 	require.NotNil(t, state)
 	require.NotEmpty(t, state.id)
-	require.Greater(t, state.created, int64(0))
+	require.Positive(t, state.created)
 	require.Empty(t, state.model)
 }
 
@@ -427,7 +849,6 @@ func TestStreamStateHandleChunk(t *testing.T) {
 		require.Equal(t, "llama3.2", chunk.Model)
 		require.Len(t, chunk.Choices, 1)
 		require.Equal(t, "Hello ", chunk.Choices[0].Delta.Content)
-		require.Equal(t, "Hello ", state.content.String())
 	})
 
 	t.Run("handles thinking chunk", func(t *testing.T) {
@@ -445,7 +866,6 @@ func TestStreamStateHandleChunk(t *testing.T) {
 
 		require.NotNil(t, chunk.Choices[0].Delta.Reasoning)
 		require.Equal(t, "Let me think...", chunk.Choices[0].Delta.Reasoning.Content)
-		require.Equal(t, "Let me think...", state.reasoning.String())
 	})
 
 	t.Run("handles done chunk with usage", func(t *testing.T) {
@@ -498,39 +918,6 @@ func TestStreamStateHandleChunk(t *testing.T) {
 	})
 }
 
-func TestExtractThinking(t *testing.T) {
-	t.Parallel()
-
-	t.Run("returns dedicated thinking content", func(t *testing.T) {
-		t.Parallel()
-
-		content, reasoning := extractThinking("Hello", "I'm thinking...")
-
-		require.Equal(t, "Hello", content)
-		require.NotNil(t, reasoning)
-		require.Equal(t, "I'm thinking...", reasoning.Content)
-	})
-
-	t.Run("parses think tags from content", func(t *testing.T) {
-		t.Parallel()
-
-		content, reasoning := extractThinking("<think>Let me think</think>Hello world", "")
-
-		require.Equal(t, "Hello world", content)
-		require.NotNil(t, reasoning)
-		require.Equal(t, "Let me think", reasoning.Content)
-	})
-
-	t.Run("returns nil reasoning when no thinking", func(t *testing.T) {
-		t.Parallel()
-
-		content, reasoning := extractThinking("Hello world", "")
-
-		require.Equal(t, "Hello world", content)
-		require.Nil(t, reasoning)
-	})
-}
-
 func TestConvertError(t *testing.T) {
 	t.Parallel()
 
@@ -547,7 +934,7 @@ func TestConvertError(t *testing.T) {
 		},
 		{
 			name:         "connection refused becomes ProviderError",
-			err:          fmt.Errorf("connection refused"),
+			err:          stderrors.New("connection refused"),
 			wantSentinel: errors.ErrProvider,
 		},
 		{
@@ -582,7 +969,12 @@ func TestConvertError(t *testing.T) {
 		},
 		{
 			name:         "generic error becomes ProviderError",
-			err:          fmt.Errorf("some other error"),
+			err:          stderrors.New("some other error"),
+			wantSentinel: errors.ErrProvider,
+		},
+		{
+			name:         "StatusError 500 becomes ProviderError",
+			err:          api.StatusError{StatusCode: 500, ErrorMessage: "internal error"},
 			wantSentinel: errors.ErrProvider,
 		},
 	}
@@ -595,12 +987,13 @@ func TestConvertError(t *testing.T) {
 			result := p.ConvertError(tc.err)
 
 			if tc.wantNil {
-				require.Nil(t, result)
+				require.NoError(t, result)
 				return
 			}
 
-			require.NotNil(t, result)
-			require.True(t, stderrors.Is(result, tc.wantSentinel))
+			require.Error(t, result)
+			require.ErrorIs(t, result, tc.wantSentinel)
+			require.ErrorContains(t, result, tc.err.Error())
 		})
 	}
 }
@@ -615,6 +1008,137 @@ func TestGenerateID(t *testing.T) {
 	require.NotEmpty(t, id2)
 	require.True(t, strings.HasPrefix(id1, "chatcmpl-"))
 	require.NotEqual(t, id1, id2) // IDs should be unique.
+}
+
+func newTestProvider(t *testing.T, handler http.Handler) *Provider {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	provider, err := New(config.WithBaseURL(server.URL))
+	require.NoError(t, err)
+
+	return provider
+}
+
+func TestCompletionRequiresTerminalResponse(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintln(w, `{"model":"test","message":{"role":"assistant","content":"partial"},"done":false}`)
+	}))
+
+	_, err := provider.Completion(t.Context(), providers.CompletionParams{Model: "test"})
+	require.ErrorIs(t, err, errors.ErrProvider)
+}
+
+func TestCompletionAcceptsUnknownResponseFields(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintln(
+			w,
+			`{"model":"test","message":{"role":"assistant","content":"done","future":"value"},"done":true,"future":"value"}`,
+		)
+	}))
+
+	response, err := provider.Completion(t.Context(), providers.CompletionParams{Model: "test"})
+	require.NoError(t, err)
+	require.Equal(t, "done", response.Choices[0].Message.Content)
+}
+
+func TestCompletionPreservesCallerTimeout(t *testing.T) {
+	t.Parallel()
+
+	releaseHandler := make(chan struct{})
+	defer close(releaseHandler)
+
+	provider := newTestProvider(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		<-releaseHandler
+	}))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := provider.Completion(ctx, providers.CompletionParams{Model: "test"})
+	require.ErrorIs(t, err, errors.ErrProvider)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestCompletionStreamRequiresTerminalResponse(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintln(w, `{"model":"test","message":{"role":"assistant","content":"partial"},"done":false}`)
+	}))
+
+	chunks, errs := provider.CompletionStream(t.Context(), providers.CompletionParams{Model: "test"})
+
+	chunkCount := 0
+	for range chunks {
+		chunkCount++
+	}
+
+	require.Equal(t, 1, chunkCount)
+	require.ErrorIs(t, <-errs, errors.ErrProvider)
+}
+
+func TestCompletionStreamReturnsMidstreamError(t *testing.T) {
+	t.Parallel()
+
+	provider := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintln(w, `{"model":"test","message":{"role":"assistant","content":"partial"},"done":false}`)
+		_, _ = fmt.Fprintln(w, `{"error":"generation failed"}`)
+	}))
+
+	chunks, errs := provider.CompletionStream(t.Context(), providers.CompletionParams{Model: "test"})
+
+	count := 0
+	for range chunks {
+		count++
+	}
+
+	require.Equal(t, 1, count)
+	require.ErrorIs(t, <-errs, errors.ErrProvider)
+}
+
+func TestCompletionStreamCancellationUnblocksAnUnreadConsumer(t *testing.T) {
+	t.Parallel()
+
+	wroteChunk := make(chan struct{})
+	provider := newTestProvider(t, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = fmt.Fprintln(w, `{"model":"test","message":{"role":"assistant","content":"partial"},"done":false}`)
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+
+		flusher.Flush()
+		close(wroteChunk)
+		<-request.Context().Done()
+	}))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	chunks, errs := provider.CompletionStream(ctx, providers.CompletionParams{Model: "test"})
+
+	<-wroteChunk
+	cancel()
+
+	select {
+	case err := <-errs:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("stream did not stop after cancellation")
+	}
+
+	_, open := <-chunks
+	require.False(t, open)
 }
 
 // Integration tests - only run if Ollama is available.
@@ -706,7 +1230,7 @@ func TestIntegrationCompletionStream(t *testing.T) {
 	err = <-errs
 	require.NoError(t, err)
 
-	require.Greater(t, chunkCount, 0)
+	require.Positive(t, chunkCount)
 	require.NotEmpty(t, content.String())
 }
 

--- a/providers/types.go
+++ b/providers/types.go
@@ -16,11 +16,14 @@ const (
 
 // Reasoning effort levels for extended thinking.
 const (
-	ReasoningEffortAuto   ReasoningEffort = "auto"
-	ReasoningEffortHigh   ReasoningEffort = "high"
-	ReasoningEffortLow    ReasoningEffort = "low"
-	ReasoningEffortMedium ReasoningEffort = "medium"
-	ReasoningEffortNone   ReasoningEffort = "none"
+	ReasoningEffortAuto    ReasoningEffort = "auto"
+	ReasoningEffortHigh    ReasoningEffort = "high"
+	ReasoningEffortLow     ReasoningEffort = "low"
+	ReasoningEffortMax     ReasoningEffort = "max"
+	ReasoningEffortMedium  ReasoningEffort = "medium"
+	ReasoningEffortMinimal ReasoningEffort = "minimal"
+	ReasoningEffortNone    ReasoningEffort = "none"
+	ReasoningEffortXHigh   ReasoningEffort = "xhigh"
 )
 
 // Message roles.
@@ -95,7 +98,7 @@ type Capabilities struct {
 	CompletionImage     bool
 	CompletionPDF       bool
 	CompletionReasoning bool
-	CompletionStreaming  bool
+	CompletionStreaming bool
 	CompletionTools     bool
 	Embedding           bool
 	ListModels          bool


### PR DESCRIPTION
# fix(ollama): preserve request and stream wire semantics

## Summary

Preserve normalized messages, reasoning levels, response fields, numeric values, stream termination, and caller ownership through Ollama SDK conversion. Parameterless tools keep the established object-schema default. Other schemas must survive the SDK's typed round trip; conversion now rejects demonstrably lossy schemas instead of silently dropping constraints.

## Review focus

- `providers/ollama/ollama.go`: review the distinction between the parameterless object default and lossy typed-schema rejection.
- Completion and stream state in the same file: confirm response normalization, terminal-event handling, numeric fidelity, and request immutability.

## Verification

- Offline HTTP and stream fixtures covered messages, images, tools, reasoning values, schema defaults and rejection, numeric fidelity, cancellation, and terminal events.
- Checked request/schema conversion with Ollama SDK [v0.32.5](https://github.com/ollama/ollama/tree/v0.32.5) and [v0.34.0](https://github.com/ollama/ollama/tree/v0.34.0), against the documented [`think` field](https://docs.ollama.com/api/chat). No new SDK minimum is introduced.
- Fresh-context reviewers checked complete aggregate diffs and tests, prioritizing baseline compatibility, official sources, then Python and Eino/Fantasy. Behavior probes and ablations preceded fixes and renewed review. No live daemon was called; integration tests, `TestCompletionDoesNotMutateParams` and `TestCompletionStreamDoesNotMutateParams` were excluded.

<details>
<summary>Skills and sources</summary>

- [`karpathy-guidelines`](https://github.com/forrestchang/andrej-karpathy-skills/blob/2c606141936f1eeef17fa3043a72095b4765b9c2/skills/karpathy-guidelines/SKILL.md), byte-identical to the installed skill
- [`reclaim-code-entropy`](https://github.com/Yevanchen/reclaim-code-entropy/blob/9e6482e45814076b9710b55c8dcbb064ba4b7977/skills/reclaim-code-entropy/SKILL.md)
- [`scoped-change`](https://github.com/scarletkc/agents/blob/d5a312346adcf2169eb5a31a1b88368441b32327/skills/scoped-change/SKILL.md)
- [`ux-writing`](https://github.com/scarletkc/agents/blob/d5a312346adcf2169eb5a31a1b88368441b32327/skills/ux-writing/SKILL.md)
- [`thermos`](https://github.com/cursor/plugins/blob/bdf7aa355337897f167153e05069aca505dae17c/thermos/skills/thermos/SKILL.md)
- [`use-modern-go`](https://github.com/JetBrains/go-modern-guidelines/blob/40781f167719913666fe2a7dc1c77ea6f256df0a/plugin/skills/use-modern-go/SKILL.md)
- [`modular-go`](https://github.com/PsiACE/skills/blob/2265aed05caf199426a8062461e2c9901be996d8/skills/modular-go/SKILL.md)
- [`japanese-tech-writing`](https://gist.githubusercontent.com/k16shikano/fd287c3133457c4fd8f5601d34aa817d/raw/8f2d57610a73efc97d743c9b0b0ecb1002e09fa4/SKILL.md), with its prose principles applied to English
- [`better-goal`](https://developers.openai.com/cookbook/examples/codex/using_goals_in_codex), local adaptation of the linked planning guidance, not an official skill implementation

</details>

## Checklist

- [x] Linting passes (`make lint`): equivalent configured lint was run with fixes disabled on the audited aggregate
- [x] Tests pass locally (`make test`): filtered offline race suite passed; excluded entrypoints were not exercised
- [x] Documentation updated (if needed)
- [ ] No breaking changes (or documented in summary): final maintainer API review is pending

## AI usage

IceCodeNew used Amp with GPT-6 Astra Medium for implementation and review. This PR description was prepared by the AI agent.
